### PR TITLE
feat/SJRA-65 build and push pipeline

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -5,6 +5,11 @@
 # - (Secret) GITHUB_TOKEN: A GitHub token with permissions to push to the registry
 name: Build and Push Docker Image
 
+env:
+  IMAGE_NAME: radiant-airflow
+  NAMESPACE: radiant-network
+  REGISTRY: ghcr.io
+
 on:
   push:
     branches: [ "**" ]  # TODO : For test purpose, change to main before merging
@@ -28,7 +33,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +41,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ghcr.io/radiant-airflow
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           tags: |
             type=semver,pattern={{raw}} 
             type=semver,pattern={{version}}
@@ -58,6 +63,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ghcr.io/radiant-airflow
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,8 +1,4 @@
 # This workflow builds and pushes a Docker image to GitHub Packages
-# Required environment variables:
-# - REGISTRY: The Docker registry to push the image to.
-# - IMAGE_NAME: The name of the Docker image.
-# - (Secret) GITHUB_TOKEN: A GitHub token with permissions to push to the registry
 name: Build and Push Docker Image
 
 env:

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -12,7 +12,8 @@ env:
 
 on:
   push:
-    branches: [ "**" ]  # TODO : For test purpose, change to main before merging
+    branches:
+      - main
     tags:
       - 'v*'
 

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -1,0 +1,57 @@
+# This workflow builds and pushes a Docker image to GitHub Packages
+# Required environment variables:
+# - REGISTRY: The Docker registry to push the image to.
+# - IMAGE_NAME: The name of the Docker image.
+# - (Secret) GITHUB_TOKEN: A GitHub token with permissions to push to the registry
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [ "**" ]  # TODO : For test purpose, change to main before merging
+    tags:
+      - 'v*'
+
+jobs:
+  build_and_push:
+    name: Build and Push Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}} 
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+          flavor: |
+            latest=auto
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Log in to the Container registry
         uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -36,7 +36,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ghcr.io/radiant-airflow
           tags: |
             type=semver,pattern={{raw}} 
             type=semver,pattern={{version}}
@@ -58,6 +58,6 @@ jobs:
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-name: ghcr.io/radiant-airflow
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -55,3 +55,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
https://d3b.atlassian.net/browse/SJRA-65

# Context

To deploy the ETL pipelines to the production environment, we need to be able to build and push docker images to the registry. 

# Contribution

The PR adds the github action to build and push images to the github packages registry. 

It was adapted from the docs (https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images) with the appropriate metadata tags. 

References:
- Metadata action: https://github.com/docker/metadata-action#about
- `semver` rules: https://github.com/docker/metadata-action?tab=readme-ov-file#typesemver
- `sha` tag: https://github.com/docker/metadata-action?tab=readme-ov-file#typesha
- `latest` tag: https://github.com/docker/metadata-action?tab=readme-ov-file#latest-tag