### PR TITLE
:sparkles: feat: SJRA-178 Add analysis_type in sequencing experiments

### DIFF
--- a/radiant/dags/import_part.py
+++ b/radiant/dags/import_part.py
@@ -26,6 +26,7 @@ def cases_output_processor(results: list[Any], descriptions: list[Sequence[Seque
             case_id=case_id,
             vcf_filepath=list_rows[0]["vcf_filepath"],
             part=list_rows[0]["part"],
+            analysis_type=list_rows[0]["analysis_type"],
             experiments=[
                 Experiment(
                     seq_id=row["seq_id"],

--- a/radiant/dags/sql/radiant/init/sequencing_experiment_create_table.sql
+++ b/radiant/dags/sql/radiant/init/sequencing_experiment_create_table.sql
@@ -2,6 +2,7 @@ CREATE TABLE IF NOT EXISTS {{ params.source_sequencing_experiments }} (
     case_id INT NOT NULL,
     seq_id INT NOT NULL,
     part INT NOT NULL,
+    analysis_type VARCHAR(50),
     sample_id VARCHAR(255),
     patient_id VARCHAR(255),
     vcf_filepath VARCHAR(1024),

--- a/radiant/dags/sql/radiant/sequencing_experiment_select_delta.sql
+++ b/radiant/dags/sql/radiant/sequencing_experiment_select_delta.sql
@@ -2,6 +2,7 @@ SELECT
     case_id,
     seq_id,
     part,
+    analysis_type,
     sample_id,
     patient_id,
     vcf_filepath,

--- a/radiant/tasks/vcf/experiment.py
+++ b/radiant/tasks/vcf/experiment.py
@@ -14,4 +14,5 @@ class Case(BaseModel):
     case_id: int
     part: int
     vcf_filepath: str
+    analysis_type: str
     experiments: list[Experiment]

--- a/tests/integration/test_process_vcf.py
+++ b/tests/integration/test_process_vcf.py
@@ -13,6 +13,7 @@ def test_process_chromosomes(
     case = Case(
         case_id=1,
         part=1,
+        analysis_type="germline",
         experiments=[
             Experiment(
                 seq_id=1,

--- a/tests/unit/dags/test_import_part.py
+++ b/tests/unit/dags/test_import_part.py
@@ -9,9 +9,9 @@ from radiant.dags.import_part import cases_output_processor
 def mock_results():
     return [
         [
-            (1, "file_1.vcf", 1, 1, "patient_1", "sample_1", "role_1", "M", True),
-            (1, "file_1.vcf", 1, 2, "patient_2", "sample_2", "role_2", "F", False),
-            (2, "file_2.vcf", 2, 3, "patient_3", "sample_3", "role_3", "M", True),
+            (1, "file_1.vcf", 1, 'germline', 1, "patient_1", "sample_1", "role_1", "M", True),
+            (1, "file_1.vcf", 1, 'germline', 2, "patient_2", "sample_2", "role_2", "F", False),
+            (2, "file_2.vcf", 2, 'germline', 3, "patient_3", "sample_3", "role_3", "M", True),
         ]
     ]
 
@@ -23,6 +23,7 @@ def mock_descriptions():
             ("case_id",),
             ("vcf_filepath",),
             ("part",),
+            ("analysis_type",),
             ("seq_id",),
             ("patient_id",),
             ("sample_id",),

--- a/tests/unit/vcf/test_consequence.py
+++ b/tests/unit/vcf/test_consequence.py
@@ -6,6 +6,7 @@ from tests.unit.vcf.vcf_test_utils import variant, vcf
 case = Case(
     case_id=1,
     part=1,
+    analysis_type="germline",
     experiments=[
         Experiment(
             seq_id=1,

--- a/tests/unit/vcf/test_occurrences.py
+++ b/tests/unit/vcf/test_occurrences.py
@@ -26,6 +26,7 @@ from .vcf_test_utils import variant
 case = Case(
     case_id=1,
     part=1,
+    analysis_type="germline",
     experiments=[
         Experiment(
             seq_id=1,
@@ -146,6 +147,7 @@ def test_multi_sample():
     multi_sample_case = Case(
         case_id=1,
         part=1,
+        analysis_type="germline",
         experiments=[
             Experiment(
                 seq_id=1,


### PR DESCRIPTION
https://d3b.atlassian.net/browse/SJRA-178

### Context

After reviewing the tables produced by the end-to-end DAG, some fields that are required by the API layer are missing from the tables.

### Contribution

This PR focuses on adding a new column `analysis_type` in the `sequencing_experiments` table.