### PR TITLE
:bug: fix: SJRA-226 Update variants inserts to properly read from staging_variants

### DIFF
--- a/radiant/dags/sql/radiant/staging_variants_insert.sql
+++ b/radiant/dags/sql/radiant/staging_variants_insert.sql
@@ -1,7 +1,7 @@
 INSERT INTO {{ params.starrocks_staging_variants }}
 SELECT
     v.locus_id,
-    g.af AS gnomad_af,
+    g.af AS gnomad_v3_af,
     t.af AS topmed_af,
     tg.af AS tg_af,
     v.chromosome,

--- a/radiant/dags/sql/radiant/variants_insert.sql
+++ b/radiant/dags/sql/radiant/variants_insert.sql
@@ -2,16 +2,16 @@ INSERT OVERWRITE {{ params.starrocks_variants }}
 SELECT
     v.locus_id,
     vf.pf as pf,
-    g.af AS gnomad_af,
-    t.af AS topmed_af,
-    tg.af AS tg_af,
+    v.gnomad_v3_af,
+    v.topmed_af,
+    v.tg_af,
     vf.pc AS pc,
     vf.pn AS pn,
     v.chromosome,
     v.start,
-    cl.name AS clinvar_name,
+    v.clinvar_name,
     v.variant_class,
-    cl.interpretations AS clinvar_interpretation,
+    v.clinvar_interpretation,
     v.symbol,
     v.impact_score,
     v.consequences,
@@ -30,11 +30,6 @@ SELECT
     v.dna_change,
     v.aa_change,
     v.transcript_id,
-    om.inheritance_code AS omim_inheritance_code
+    v.omim_inheritance_code
 FROM {{ params.starrocks_staging_variants }} v
 JOIN {{ params.starrocks_variants_frequencies }} vf ON vf.locus_id = v.locus_id
-LEFT JOIN {{ params.starrocks_gnomad_genomes_v3 }} g ON g.locus_id = v.locus_id
-LEFT JOIN {{ params.starrocks_topmed_bravo }} t ON t.locus_id = v.locus_id
-LEFT JOIN {{ params.starrocks_1000_genomes }} tg ON tg.locus_id = v.locus_id
-LEFT JOIN {{ params.starrocks_clinvar }} cl  ON cl.locus_id = v.locus_id
-LEFT JOIN {{ params.starrocks_omim_gene_panel }} om  ON om.symbol = v.symbol


### PR DESCRIPTION
## Context

This is a follow-up to https://github.com/radiant-network/radiant-portal-pipeline/pull/46 in which we changed the way we insert variants. 

## Contribution

The update missed to properly target `staging_variants` for the whole new `variants` table and was still joining with open data tables. 

This PR provide the appropriate fix for the query. 