### PR TITLE
:bug: fix: SJRA-226 Remove usage of threads in cyvcf

### DIFF
--- a/radiant/dags/import_vcf.py
+++ b/radiant/dags/import_vcf.py
@@ -72,7 +72,7 @@ with DAG(
         logger.info("=" * 80)
 
         namespace = os.getenv("RADIANT_ICEBERG_DATABASE", "radiant")
-        process_chromosomes(chromosomes, case, fs, namespace=namespace, vcf_threads=4)
+        process_chromosomes(chromosomes, case, fs, namespace=namespace, vcf_threads=None)
         logger.info(
             f"✅ IMPORTED Experiment: {case.case_id}, file {case.vcf_filepath}, chromosome {','.join(chromosomes)}"
         )


### PR DESCRIPTION
## Context

Following https://github.com/radiant-network/radiant-portal-pipeline/pull/46 some tests were performed in the QA environment and it was discovered that the import-vcf DAG fails sporadically for certain chromosomes. 

That failure is silent and doesn't make the pipeline fail when it should. 

Observed errors:

```
[E::easy_errno] Libcurl reported error 16 (Error in the HTTP2 framing layer)
```

Followed by 

```
[E::hts_itr_next] Failed to seek to offset 10474767306613: Illegal seek
```

## Contribution

Removes the usage of threads when processing VCFs to avoid silencing the error. 