### PR TITLE
:sparkles: feat: Add 'end' and 'vep_impact' fields to variants and consequences tables

### DIFF
--- a/radiant/dags/sql/radiant/consequences_filter_insert.sql
+++ b/radiant/dags/sql/radiant/consequences_filter_insert.sql
@@ -22,7 +22,8 @@ SELECT
     gnomad_pli,
     gnomad_loeuf,
     phyloP17way_primate,
-    phyloP100way_vertebrate
+    phyloP100way_vertebrate,
+    vep_impact
 FROM (
     SELECT
         locus_id,
@@ -46,7 +47,8 @@ FROM (
         gnomad_pli,
         ANY_VALUE(gnomad_loeuf) AS gnomad_loeuf,
         ANY_VALUE(phyloP17way_primate) AS phyloP17way_primate,
-        ANY_VALUE(phyloP100way_vertebrate) AS phyloP100way_vertebrate
+        ANY_VALUE(phyloP100way_vertebrate) AS phyloP100way_vertebrate,
+        vep_impact
     FROM (
         SELECT
             locus_id,
@@ -70,7 +72,8 @@ FROM (
             gnomad_pli,
             gnomad_loeuf,
             phyloP17way_primate,
-            phyloP100way_vertebrate
+            phyloP100way_vertebrate,
+            vep_impact
         FROM
             {{ params.starrocks_consequences }} c,
             UNNEST(consequences) AS unnest
@@ -85,5 +88,6 @@ FROM (
         revel_score,
         spliceai_ds,
         impact_score,
-        gnomad_pli
+        gnomad_pli,
+        vep_impact
 ) t

--- a/radiant/dags/sql/radiant/init/consequences_filter_create_table.sql
+++ b/radiant/dags/sql/radiant/init/consequences_filter_create_table.sql
@@ -21,7 +21,8 @@ CREATE TABLE IF NOT EXISTS {{ params.starrocks_consequences_filter }} (
     `gnomad_pli` float NULL COMMENT "",
     `gnomad_loeuf` float NULL COMMENT "",
     `phyloP17way_primate` float NULL COMMENT "",
-    `phyloP100way_vertebrate` float NULL COMMENT ""
+    `phyloP100way_vertebrate` float NULL COMMENT "",
+    `vep_impact` VARCHAR(20) NULL COMMENT ""
 )
 ENGINE=OLAP
 DUPLICATE KEY(`locus_id`, `is_deleterious`, `impact_score`)

--- a/radiant/dags/sql/radiant/init/consequences_filter_partitioned_create_table.sql
+++ b/radiant/dags/sql/radiant/init/consequences_filter_partitioned_create_table.sql
@@ -22,7 +22,8 @@ CREATE TABLE IF NOT EXISTS {{ params.starrocks_consequences_filter_partitioned }
   `gnomad_pli` float NULL COMMENT "",
   `gnomad_loeuf` float NULL COMMENT "",
   `phyloP17way_primate` float NULL COMMENT "",
-  `phyloP100way_vertebrate` float NULL COMMENT ""
+  `phyloP100way_vertebrate` float NULL COMMENT "",
+  `vep_impact` VARCHAR(20) NULL COMMENT ""
 )
 ENGINE=OLAP
 COMMENT "OLAP"

--- a/radiant/dags/sql/radiant/init/staging_variants_create_table.sql
+++ b/radiant/dags/sql/radiant/init/staging_variants_create_table.sql
@@ -5,6 +5,7 @@ CREATE TABLE IF NOT EXISTS {{ params.starrocks_staging_variants }} (
     tg_af DOUBLE,
     chromosome CHAR(2),
     start BIGINT NULL COMMENT '',
+    end BIGINT NULL COMMENT '',
     clinvar_name VARCHAR(2000) NULL COMMENT '',
     variant_class VARCHAR(50) NULL COMMENT '',
     clinvar_interpretation ARRAY<VARCHAR(100)> NULL COMMENT '',

--- a/radiant/dags/sql/radiant/init/variants_create_table.sql
+++ b/radiant/dags/sql/radiant/init/variants_create_table.sql
@@ -8,6 +8,7 @@ CREATE TABLE IF NOT EXISTS {{ params.starrocks_variants }} (
     pn INT(11),
     chromosome CHAR(2),
     start BIGINT NULL COMMENT '',
+    end BIGINT NULL COMMENT '',
     clinvar_name VARCHAR(2000) NULL COMMENT '',
     variant_class VARCHAR(50) NULL COMMENT '',
     clinvar_interpretation ARRAY<VARCHAR(100)> NULL COMMENT '',

--- a/radiant/dags/sql/radiant/init/variants_part_create_table.sql
+++ b/radiant/dags/sql/radiant/init/variants_part_create_table.sql
@@ -9,6 +9,7 @@ CREATE TABLE IF NOT EXISTS {{ params.starrocks_variants_partitioned }} (
     pn INT(11),
     chromosome CHAR(2),
     start BIGINT NULL COMMENT '',
+    end BIGINT NULL COMMENT '',
     clinvar_name VARCHAR(2000) NULL COMMENT '',
     variant_class VARCHAR(50) NULL COMMENT '',
     clinvar_interpretation ARRAY<VARCHAR(100)> NULL COMMENT '',

--- a/radiant/dags/sql/radiant/staging_variants_insert.sql
+++ b/radiant/dags/sql/radiant/staging_variants_insert.sql
@@ -6,6 +6,7 @@ SELECT
     tg.af AS tg_af,
     v.chromosome,
     v.start,
+    v.end,
     cl.name AS clinvar_name,
     v.variant_class,
     cl.interpretations AS clinvar_interpretation,

--- a/radiant/dags/sql/radiant/variants_insert.sql
+++ b/radiant/dags/sql/radiant/variants_insert.sql
@@ -9,6 +9,7 @@ SELECT
     vf.pn AS pn,
     v.chromosome,
     v.start,
+    v.end,
     v.clinvar_name,
     v.variant_class,
     v.clinvar_interpretation,


### PR DESCRIPTION
## Context

Variants are missing `end` column and consequences filter tables are missing the `vep_impact` column. 

## Contribution

- Add `end` to the following tables:
   - `staging_variants`
   - `variants`
- Add `vep_impact` to the following tables:
   - `consequences_filter`
   - `consequences_filter_part`  