### PR TITLE
:sparkles: feat: SJRA-226 Add handling of errors when calling cyvcf

### DIFF
--- a/radiant/dags/import_vcf.py
+++ b/radiant/dags/import_vcf.py
@@ -51,17 +51,16 @@ with DAG(
     @task.external_python(pool="import_vcf", task_id="import_vcf", python=PATH_TO_PYTHON_BINARY)
     def import_vcf(case: dict, chromosomes: list[str]):
         import logging
-        import sys
-
-        logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler(sys.stdout)])
-        logger = logging.getLogger(__name__)
-
         import os
+        import sys
 
         import fsspec
 
         from radiant.tasks.vcf.experiment import Case
         from radiant.tasks.vcf.process import process_chromosomes
+
+        logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler(sys.stdout)])
+        logger = logging.getLogger(__name__)
 
         fs = fsspec.filesystem(
             "s3",

--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -1,0 +1,27 @@
+import io
+from contextlib import redirect_stderr
+from functools import wraps
+
+
+def capture_stderr_and_check_errors(error_patterns: list[str]):
+    """
+    A decorator to capture stderr output and check for specific error patterns.
+    Raises a ValueError if the error pattern is found in the stderr output.
+
+    :param error_pattern: The pattern to search for in stderr output.
+    """
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            stderr = io.StringIO()
+            with redirect_stderr(stderr):
+                result = func(*args, **kwargs)
+            errors = stderr.getvalue()
+            if any(pattern in errors for pattern in error_patterns):
+                raise ValueError(f"Detected error: {errors}")
+            return result
+
+        return wrapper
+
+    return decorator

--- a/radiant/tasks/vcf/process.py
+++ b/radiant/tasks/vcf/process.py
@@ -4,6 +4,7 @@ from cyvcf2 import VCF
 from pyiceberg.catalog import load_catalog
 
 from radiant.tasks.iceberg.table_accumulator import TableAccumulator
+from radiant.tasks.utils import capture_stderr_and_check_errors
 from radiant.tasks.vcf.common import process_common
 from radiant.tasks.vcf.consequence import parse_csq_header, process_consequence
 from radiant.tasks.vcf.experiment import Case
@@ -14,6 +15,9 @@ from radiant.tasks.vcf.variant import process_variant
 logger = logging.getLogger(__name__)
 
 
+# Required decoration because cyvcf2 doesn't fail when it encounters an error, it just prints to stderr.
+# Airflow will treat the task as successful if the error is not captured properly.
+@capture_stderr_and_check_errors(error_patterns=["[E::"])
 def process_chromosomes(
     chromosomes: list[str],
     case: Case,


### PR DESCRIPTION
## Context

When processing VCF files in the `import-vcf` DAG, we sometimes encounter error logs in the cyvcf library:

```
[E::easy_errno] Libcurl reported error 16 (Error in the HTTP2 framing layer)
[E::bgzf_read_block] Failed to read BGZF header at offset 187768775
```

However, these errors are not making the pipeline fail and are silently ignored. 
The DAG succeeds and the downstream tasks are ran. 

This is problematic because it leads to integrity problems in the data, we might miss some chromosomes and we need to be made aware so we can restart the task if required. 

## Contribution

Implemented a configurable decorator that captures the `stderr` output when running methods inside a wrapping context. 

**Why a decorator?:** To avoid having the `process_chromosome` user manage the error handling themselves (and at multiple places). It's much simpler to wrap the method from a user's perspective.  The resulting exception will be a `ValueError` containing the detected errors. 