### PR TITLE
:bug: fix: SJRA-226 Fix error capturing when importing VCF

### DIFF
--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -1,9 +1,9 @@
-import io
-from contextlib import redirect_stderr
 from functools import wraps
 
+from wurlitzer import pipes
 
-def capture_stderr_and_check_errors(error_patterns: list[str]):
+
+def capture_libc_stderr_and_check_errors(error_patterns: list[str]):
     """
     A decorator to capture stderr output and check for specific error patterns.
     Raises a ValueError if the error pattern is found in the stderr output.
@@ -14,8 +14,7 @@ def capture_stderr_and_check_errors(error_patterns: list[str]):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            stderr = io.StringIO()
-            with redirect_stderr(stderr):
+            with pipes() as (_, stderr):
                 result = func(*args, **kwargs)
             errors = stderr.getvalue()
             if any(pattern in errors for pattern in error_patterns):

--- a/radiant/tasks/vcf/process.py
+++ b/radiant/tasks/vcf/process.py
@@ -4,7 +4,7 @@ from cyvcf2 import VCF
 from pyiceberg.catalog import load_catalog
 
 from radiant.tasks.iceberg.table_accumulator import TableAccumulator
-from radiant.tasks.utils import capture_stderr_and_check_errors
+from radiant.tasks.utils import capture_libc_stderr_and_check_errors
 from radiant.tasks.vcf.common import process_common
 from radiant.tasks.vcf.consequence import parse_csq_header, process_consequence
 from radiant.tasks.vcf.experiment import Case
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 
 # Required decoration because cyvcf2 doesn't fail when it encounters an error, it just prints to stderr.
 # Airflow will treat the task as successful if the error is not captured properly.
-@capture_stderr_and_check_errors(error_patterns=["[E::"])
+@capture_libc_stderr_and_check_errors(error_patterns=["[E::"])
 def process_chromosomes(
     chromosomes: list[str],
     case: Case,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ pyiceberg[s3fs]==0.9.0
 # Needed for filesystem abstraction
 fs>=2.4.16
 pyarrow==19.0.1
+
+# Needed for error capture
+wurlitzer==3.1.1

--- a/tests/docker/test_docker.py
+++ b/tests/docker/test_docker.py
@@ -14,3 +14,4 @@ def test_docker_image_contains_cyvcf(docker_container):
     exit_code, output = docker_container.exec('/bin/bash -c "/home/airflow/.venv/radiant/bin/pip freeze"')
     assert exit_code == 0
     assert b"cyvcf2" in output
+    assert b"wurlitzer" in output

--- a/tests/integration/test_process_vcf.py
+++ b/tests/integration/test_process_vcf.py
@@ -66,7 +66,16 @@ def test_process_chromosomes(
 
 
 def fake_error_logging(*args, **kwargs):
-    print("[E:: Fake error message", file=sys.stderr)
+    import ctypes
+
+    libc = ctypes.CDLL(None)
+    if sys.platform == "darwin":
+        # macOS uses __stderrp
+        c_stderr = ctypes.c_void_p.in_dll(libc, "__stderrp")
+    else:
+        # Linux and most other Unix-like OSes use stderr
+        c_stderr = ctypes.c_void_p.in_dll(libc, "stderr")
+    libc.fprintf(c_stderr, b"[E:: Fake error message\n")
 
 
 def test_process_chromosomes_error(


### PR DESCRIPTION
## Context

This is a follow-up to https://github.com/radiant-network/radiant-portal-pipeline/pull/50 which, after more investigation, didn't properly capture the stderr at the C-level, which is what we actually want. 

## Contribution

**How was this tested locally?:** The `fake_error_logging` was updated to target c-level stderr. Without the new fix added in this PR, the previous validation doesn't capture the c-level errors. 

We introduce a new dependency named `wurlitzer` that can capture c-level output and redirect them to the Python level. 

This will required a new docker image tagging and an update to the infrastructure configuration. 