### PR TITLE
:sparkles: feat: SJRA-239 Add namespacing for germline snv starrocks tables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ x-airflow-common:
   # In order to add custom dependencies or upgrade provider packages you can use your extended image.
   # Comment the image line, place your Dockerfile in the directory where you placed the docker-compose.yaml
   # and uncomment the "build" line below, Then run `docker-compose build` to build the images.
-  image: ${AIRFLOW_IMAGE_NAME:-ghcr.io/radiant-network/radiant-airflow:1.0.1}
+  image: ${AIRFLOW_IMAGE_NAME:-ghcr.io/radiant-network/radiant-airflow:1.0.2}
   # build: .
   environment:
     &airflow-common-env

--- a/radiant/dags/sql/radiant/init/sequencing_experiment_create_table.sql
+++ b/radiant/dags/sql/radiant/init/sequencing_experiment_create_table.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS {{ params.source_sequencing_experiments }} (
+CREATE TABLE IF NOT EXISTS {{ params.starrocks_sequencing_experiments }} (
     case_id INT NOT NULL,
     seq_id INT NOT NULL,
     part INT NOT NULL,

--- a/radiant/dags/sql/radiant/sequencing_experiment_select_delta.sql
+++ b/radiant/dags/sql/radiant/sequencing_experiment_select_delta.sql
@@ -12,7 +12,7 @@ SELECT
     created_at,
     updated_at,
     ingested_at
-FROM {{ params.source_sequencing_experiments }}
+FROM {{ params.starrocks_sequencing_experiments }}
 WHERE
     part=%(part)s and
     updated_at >= COALESCE(ingested_at, '1970-01-01 00:00:00')

--- a/radiant/dags/sql/radiant/staging_variants_freq_insert.sql
+++ b/radiant/dags/sql/radiant/staging_variants_freq_insert.sql
@@ -2,7 +2,7 @@ INSERT /*+set_var(dynamic_overwrite = true)*/ OVERWRITE {{ params.starrocks_stag
 WITH patients_total_count AS (
     SELECT
         COUNT(DISTINCT s.patient_id) AS cnt
-    FROM {{ params.source_sequencing_experiments }} s where s.seq_id in (select seq_id from {{ params.starrocks_occurrences }} where part=%(part)s)
+    FROM {{ params.starrocks_sequencing_experiments }} s where s.seq_id in (select seq_id from {{ params.starrocks_occurrences }} where part=%(part)s)
 ),
 freqs as (
     SELECT o.part,
@@ -10,7 +10,7 @@ freqs as (
         COUNT(DISTINCT patient_id) AS pc,
         (SELECT cnt FROM patients_total_count) AS pn
     FROM {{ params.starrocks_occurrences }} o
-    JOIN {{ params.source_sequencing_experiments }} s ON s.seq_id = o.seq_id
+    JOIN {{ params.starrocks_sequencing_experiments }} s ON s.seq_id = o.seq_id
     WHERE o.part = %(part)s
     GROUP BY locus_id, o.part
 )

--- a/radiant/tasks/data/radiant_tables.py
+++ b/radiant/tasks/data/radiant_tables.py
@@ -8,17 +8,16 @@ ICEBERG_DATABASE_ENV_KEY = "RADIANT_ICEBERG_DATABASE"
 
 STARROCKS_COLOCATE_GROUP_MAPPING = {"colocate_query_group": f"{NAMESPACE}.query_group"}
 
+GERMLINE_SNV_NAMESPACE_STARROCKS_PREFIX = "germline__snv__"
 
-SOURCE_SEQUENCING_EXPERIMENT_MAPPING = {
-    "source_sequencing_experiments": "sequencing_experiments",
-}
+
+# --- Iceberg tables
 
 ICEBERG_GERMLINE_SNV_MAPPING = {
     "iceberg_consequences": "germline_snv_consequences",
     "iceberg_occurrences": "germline_snv_occurrences",
     "iceberg_variants": "germline_snv_variants",
 }
-
 
 ICEBERG_OPEN_DATA_MAPPING = {
     "iceberg_1000_genomes": "1000_genomes",
@@ -33,6 +32,18 @@ ICEBERG_OPEN_DATA_MAPPING = {
     "iceberg_orphanet_gene_set": "orphanet_gene_set",
     "iceberg_cosmic_gene_set": "cosmic_gene_set",
     "iceberg_ddd_gene_set": "ddd_gene_set",
+}
+
+ICEBERG_CATALOG_DATABASE = {
+    "iceberg_catalog": os.getenv("RADIANT_ICEBERG_CATALOG", "radiant_iceberg_catalog"),
+    "iceberg_database": os.getenv("RADIANT_ICEBERG_DATABASE", "radiant"),
+}
+
+
+# --- StarRocks tables
+
+STARROCKS_SEQUENCING_EXPERIMENT_MAPPING = {
+    "starrocks_sequencing_experiments": "sequencing_experiments",
 }
 
 STARROCKS_GERMLINE_SNV_MAPPING = {
@@ -64,11 +75,6 @@ STARROCKS_OPEN_DATA_MAPPING = {
     "starrocks_ddd_gene_panel": "ddd_gene_panel",
 }
 
-ICEBERG_CATALOG_DATABASE = {
-    "iceberg_catalog": os.getenv("RADIANT_ICEBERG_CATALOG", "radiant_iceberg_catalog"),
-    "iceberg_database": os.getenv("RADIANT_ICEBERG_DATABASE", "radiant"),
-}
-
 
 def get_iceberg_germline_snv_mapping() -> dict:
     return {
@@ -93,17 +99,35 @@ def get_iceberg_tables() -> dict:
     }
 
 
-def get_radiant_mapping() -> dict:
+def get_starrocks_germline_snv_mapping() -> dict:
+    namespace = os.environ.get(RADIANT_TABLES_PREFIX_ENV_KEY)
+    namespace = f"{namespace}_" if namespace else GERMLINE_SNV_NAMESPACE_STARROCKS_PREFIX
+    return {key: f"{namespace}{value}" for key, value in STARROCKS_GERMLINE_SNV_MAPPING.items()}
+
+
+def get_starrocks_open_data_mapping() -> dict:
     namespace = os.environ.get(RADIANT_TABLES_PREFIX_ENV_KEY)
     namespace = f"{namespace}_" if namespace else ""
+    return {key: f"{namespace}{value}" for key, value in STARROCKS_OPEN_DATA_MAPPING.items()}
+
+
+def get_starrocks_sequencing_experiment_mapping() -> dict:
+    namespace = os.environ.get(RADIANT_TABLES_PREFIX_ENV_KEY)
+    namespace = f"{namespace}_" if namespace else ""
+    return {key: f"{namespace}{value}" for key, value in STARROCKS_SEQUENCING_EXPERIMENT_MAPPING.items()}
+
+
+def get_radiant_mapping() -> dict:
+    namespace = os.environ.get(RADIANT_TABLES_PREFIX_ENV_KEY)
+    namespace = f"{namespace}_" if namespace else GERMLINE_SNV_NAMESPACE_STARROCKS_PREFIX
     mapping = {
         key: f"{namespace}{value}"
         for key, value in {
-            **SOURCE_SEQUENCING_EXPERIMENT_MAPPING,
-            **STARROCKS_GERMLINE_SNV_MAPPING,
-            **STARROCKS_OPEN_DATA_MAPPING,
             **STARROCKS_COLOCATE_GROUP_MAPPING,
         }.items()
     }
+    mapping.update(get_starrocks_sequencing_experiment_mapping())
+    mapping.update(get_starrocks_germline_snv_mapping())
+    mapping.update(get_starrocks_open_data_mapping())
     mapping.update(get_iceberg_tables())
     return mapping

--- a/radiant/tasks/data/radiant_tables.py
+++ b/radiant/tasks/data/radiant_tables.py
@@ -42,8 +42,9 @@ ICEBERG_CATALOG_DATABASE = {
 
 # --- StarRocks tables
 
-STARROCKS_SEQUENCING_EXPERIMENT_MAPPING = {
+STARROCKS_COMMON_MAPPING = {
     "starrocks_sequencing_experiments": "sequencing_experiments",
+    "starrocks_variants_lookup": "variants_lookup",
 }
 
 STARROCKS_GERMLINE_SNV_MAPPING = {
@@ -55,7 +56,6 @@ STARROCKS_GERMLINE_SNV_MAPPING = {
     "starrocks_variants": "variants",
     "starrocks_variants_frequencies": "variants_frequencies",
     "starrocks_variants_partitioned": "variants_partitioned",
-    "starrocks_variants_lookup": "variants_lookup",
     "starrocks_staging_variants": "staging_variants",
     "starrocks_staging_variants_frequencies": "staging_variants_frequencies_part",
 }
@@ -111,10 +111,10 @@ def get_starrocks_open_data_mapping() -> dict:
     return {key: f"{namespace}{value}" for key, value in STARROCKS_OPEN_DATA_MAPPING.items()}
 
 
-def get_starrocks_sequencing_experiment_mapping() -> dict:
+def get_starrocks_common_mapping() -> dict:
     namespace = os.environ.get(RADIANT_TABLES_PREFIX_ENV_KEY)
     namespace = f"{namespace}_" if namespace else ""
-    return {key: f"{namespace}{value}" for key, value in STARROCKS_SEQUENCING_EXPERIMENT_MAPPING.items()}
+    return {key: f"{namespace}{value}" for key, value in STARROCKS_COMMON_MAPPING.items()}
 
 
 def get_radiant_mapping() -> dict:
@@ -126,7 +126,7 @@ def get_radiant_mapping() -> dict:
             **STARROCKS_COLOCATE_GROUP_MAPPING,
         }.items()
     }
-    mapping.update(get_starrocks_sequencing_experiment_mapping())
+    mapping.update(get_starrocks_common_mapping())
     mapping.update(get_starrocks_germline_snv_mapping())
     mapping.update(get_starrocks_open_data_mapping())
     mapping.update(get_iceberg_tables())

--- a/tests/integration/dags/sql/test_queries.py
+++ b/tests/integration/dags/sql/test_queries.py
@@ -68,17 +68,17 @@ def test_queries_are_valid(
     monkeypatch.setenv("RADIANT_ICEBERG_DATABASE", setup_namespace)
 
     from radiant.tasks.data.radiant_tables import (
-        SOURCE_SEQUENCING_EXPERIMENT_MAPPING,
-        STARROCKS_GERMLINE_SNV_MAPPING,
-        STARROCKS_OPEN_DATA_MAPPING,
+        get_starrocks_germline_snv_mapping,
+        get_starrocks_open_data_mapping,
+        get_starrocks_sequencing_experiment_mapping,
     )
 
     # Validate table creation for Open Data & Radiant
-    _validate_init(starrocks_session, sql_dir=_OPEN_DATA_INIT_DIR, tables=STARROCKS_OPEN_DATA_MAPPING.values())
+    _validate_init(starrocks_session, sql_dir=_OPEN_DATA_INIT_DIR, tables=get_starrocks_open_data_mapping().values())
     _validate_init(
         starrocks_session,
         sql_dir=_RADIANT_INIT_DIR,
-        tables={**STARROCKS_GERMLINE_SNV_MAPPING, **SOURCE_SEQUENCING_EXPERIMENT_MAPPING}.values(),
+        tables={**get_starrocks_germline_snv_mapping(), **get_starrocks_sequencing_experiment_mapping()}.values(),
     )
 
     # Validate table insertion using SQL `EXPLAIN` for Open Data & Radiant (Requires existing tables)

--- a/tests/integration/dags/sql/test_queries.py
+++ b/tests/integration/dags/sql/test_queries.py
@@ -68,9 +68,9 @@ def test_queries_are_valid(
     monkeypatch.setenv("RADIANT_ICEBERG_DATABASE", setup_namespace)
 
     from radiant.tasks.data.radiant_tables import (
+        get_starrocks_common_mapping,
         get_starrocks_germline_snv_mapping,
         get_starrocks_open_data_mapping,
-        get_starrocks_sequencing_experiment_mapping,
     )
 
     # Validate table creation for Open Data & Radiant
@@ -78,7 +78,7 @@ def test_queries_are_valid(
     _validate_init(
         starrocks_session,
         sql_dir=_RADIANT_INIT_DIR,
-        tables={**get_starrocks_germline_snv_mapping(), **get_starrocks_sequencing_experiment_mapping()}.values(),
+        tables={**get_starrocks_germline_snv_mapping(), **get_starrocks_common_mapping()}.values(),
     )
 
     # Validate table insertion using SQL `EXPLAIN` for Open Data & Radiant (Requires existing tables)


### PR DESCRIPTION
## Context

Currently in the StarRocks table, tables are not namespaced. 

E.g.:

- variants
- consequences
- occurrences
- ...

However, we need to prepare the environment to receive different types of sequencing, namely:

```
germline_snv
germline_cnv
somatic_snv
somatic_cnv
```

Tables need to be namespaced appropriately in the database. 

## Contribution

Namespace nomenclature: 

Use double underscore `__` to separate domain and underscores `_` for word separation. 
Example

```
germline__snv__variants_lookup
```

Where `germline` and `snv` are different domain sections and where `variants_lookup` is the table name. 

Projected namespaces to be added eventually are:
- `germline__cnv__`
- `somatic__snv__` 
- `somatic__cnv__`

### Table list

Following this contribution, expect the following tables in the database (e.g. `radiant`):

```
Tables_in_radiant                               |
------------------------------------------------+
1000_genomes                                    |
clinvar                                         |
cosmic_gene_panel                               |
dbnsfp                                          |
ddd_gene_panel                                  |
germline__snv__consequences                     |
germline__snv__consequences_filter              |
germline__snv__consequences_filter_partitioned  |
germline__snv__occurrences                      |
germline__snv__staging_variants                 |
germline__snv__staging_variants_frequencies_part|
germline__snv__tmp_variants                     |
germline__snv__variants                         |
germline__snv__variants_frequencies             |
germline__snv__variants_partitioned             |
gnomad_constraints                              |
gnomad_genomes_v3                               |
hpo_gene_panel                                  |
omim_gene_panel                                 |
orphanet_gene_panel                             |
sequencing_experiments                          |
spliceai                                        |
topmed_bravo                                    |
variants_lookup                                 |
```