### PR TITLE
:construction_worker: fix: Pin libcurl to a specific version in the docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,18 @@ FROM --platform=$BUILDPLATFORM apache/airflow:2.10.5-python3.12
 USER root
 
 # Install dependencies for htslib
-#build-essential zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev
-RUN apt-get update && apt-get install -y bzip2  build-essential zlib1g-dev libbz2-dev liblzma-dev libcurl4-openssl-dev libssl-dev && apt-get clean
+RUN apt-get update && apt-get install -y bzip2 git build-essential zlib1g-dev libbz2-dev liblzma-dev libssl-dev libpsl-dev && apt-get clean
+
+ARG LIBCURL_VERSION=8.13.0
+RUN curl -L -O https://curl.se/download/curl-${LIBCURL_VERSION}.tar.gz && \
+    tar -xzf curl-${LIBCURL_VERSION}.tar.gz && \
+    cd curl-${LIBCURL_VERSION} && \
+    ./configure --with-ssl --prefix=/usr/local && \
+    make -j$(nproc) && \
+    make install && \
+    ldconfig && \
+    cd .. && \
+    rm -rf curl-${LIBCURL_VERSION} curl-${LIBCURL_VERSION}.tar.gz
 
 # Install htslib with flag enable-s3
 RUN curl -L -O https://github.com/samtools/htslib/releases/download/1.21/htslib-1.21.tar.bz2 && \


### PR DESCRIPTION
## Context

Currently in the ETL, we have a bug where for some of the VCFs, we encounter `libcurl` errors: 

```
INFO - ValueError: Detected error: [E::easy_errno] Libcurl reported error 16 (Error in the HTTP2 framing layer)
INFO - [E::bgzf_read_block] Failed to read BGZF header at offset 187767754
INFO - [E::hts_itr_next] Failed to seek to offset 10474711404396: Illegal seek
```

However, this error is not encounter when running the VCF parsing DAG with the same file. 

## Contribution

This PR pins the version of `libcurl` to `8.13.0` (the latest at the moment of opening the PR) and manually installs it in the Docker image. 