### PR TITLE
🐛 fix: SJRA-240 Ensure decorator outputs logs correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 
 .idea
 logs
+
+# VCF
+*.gz.tbi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
 
-docker-build:
+build-docker:
 	docker build -t radiant-airflow:latest .
 
 install:
@@ -12,7 +12,7 @@ install-dev: install
 	# Required for standalone unit tests
 	airflow db init
 
-test-docker: docker-build
+test-docker: build-docker
 	pytest tests/docker/
 
 test-unit:

--- a/radiant/dags/import_vcf.py
+++ b/radiant/dags/import_vcf.py
@@ -71,7 +71,7 @@ with DAG(
         logger.info("=" * 80)
 
         namespace = os.getenv("RADIANT_ICEBERG_DATABASE", "radiant")
-        process_chromosomes(chromosomes, case, fs, namespace=namespace, vcf_threads=None)
+        process_chromosomes(chromosomes, case, fs, namespace=namespace, vcf_threads=4)
         logger.info(
             f"✅ IMPORTED Experiment: {case.case_id}, file {case.vcf_filepath}, chromosome {','.join(chromosomes)}"
         )

--- a/radiant/tasks/iceberg/table_accumulator.py
+++ b/radiant/tasks/iceberg/table_accumulator.py
@@ -9,7 +9,7 @@ from pyiceberg.catalog import Table
 from pyiceberg.exceptions import CommitFailedException
 from pyiceberg.expressions import And, EqualTo
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("airflow.task")
 
 PARQUET_FILE_SIZE_MB = 256
 MAX_BUFFERED_ROWS = 10000

--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -1,3 +1,4 @@
+import sys
 from functools import wraps
 
 from wurlitzer import pipes
@@ -14,9 +15,14 @@ def capture_libc_stderr_and_check_errors(error_patterns: list[str]):
     def decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
-            with pipes() as (_, stderr):
+            with pipes() as (stdout, stderr):
                 result = func(*args, **kwargs)
             errors = stderr.getvalue()
+            output = stdout.getvalue()
+            if output:
+                print(output, file=sys.stdout)
+            if errors:
+                print(errors, file=sys.stderr)
             if any(pattern in errors for pattern in error_patterns):
                 raise ValueError(f"Detected error: {errors}")
             return result

--- a/radiant/tasks/vcf/process.py
+++ b/radiant/tasks/vcf/process.py
@@ -12,7 +12,7 @@ from radiant.tasks.vcf.occurrence import process_occurrence
 from radiant.tasks.vcf.pedigree import Pedigree
 from radiant.tasks.vcf.variant import process_variant
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("airflow.task")
 
 
 # Required decoration because cyvcf2 doesn't fail when it encounters an error, it just prints to stderr.


### PR DESCRIPTION
## Context

In https://github.com/radiant-network/radiant-portal-pipeline/pull/50 we added a decorator to capture C-level errors when running VCF parsing. 

This had the side effect of silencing the logs in the method. 

The culprit was the capturing of the `sys.stdout` and `sys.stderr` without properly handling them in the decorator:

```
with pipes() as (stdout, stderr):   # <--- We have to do something with this `stdout` and `stderr` 
   ...
```

## Contribution

- Adds passthrough of captured logs to `stdout` and `stderr` 

## Scope Creep

- Sets back threading in VCF processing to `4` 
- Renames `docker-build` into `build-docker` for makefile conformity (action keyword first)


### Tested locally

**Before the fix:**

```
[2025-05-23, 12:27:45 UTC] {process_utils.py:186} INFO - Executing cmd: /home/***/.venv/radiant/bin/python /tmp/venv-callt6_nhz7p/script.py /tmp/venv-callt6_nhz7p/script.in /tmp/venv-callt6_nhz7p/script.out /tmp/venv-callt6_nhz7p/string_args.txt /tmp/venv-callt6_nhz7p/termination.log
[2025-05-23, 12:27:45 UTC] {process_utils.py:190} INFO - Output:
[2025-05-23, 12:27:47 UTC] {process_utils.py:194} INFO - INFO:__main__:🔁 STARTING IMPORT for Case: 1, chromosome chrM,chr18,chr1
[2025-05-23, 12:27:47 UTC] {process_utils.py:194} INFO - INFO:__main__:================================================================================
[2025-05-23, 12:27:47 UTC] {process_utils.py:194} INFO - INFO:__main__:One more log...
[2025-05-23, 12:27:48 UTC] {process_utils.py:194} INFO - INFO:__main__:✅ IMPORTED Experiment: 1, file s3+http://vcf/test.vcf.gz, chromosome chrM,chr18,chr1
[2025-05-23, 12:27:48 UTC] {python.py:240} INFO - Done. Returned value was: None
```

**After the fix:** 

```
[2025-05-23, 12:31:46 UTC] {process_utils.py:190} INFO - Output:
[2025-05-23, 12:31:48 UTC] {process_utils.py:194} INFO - INFO:__main__:🔁 STARTING IMPORT for Case: 1, chromosome chrM,chr18,chr1
[2025-05-23, 12:31:48 UTC] {process_utils.py:194} INFO - INFO:__main__:================================================================================
[2025-05-23, 12:31:48 UTC] {process_utils.py:194} INFO - INFO:__main__:One more log...
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - /opt/***/dags/radiant/tasks/vcf/process.py:76: UserWarning: no intervals found for b's3+http://vcf/test.vcf.gz' at chrM
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO -   for record in vcf(chromosome):
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - /opt/***/dags/radiant/tasks/vcf/process.py:76: UserWarning: no intervals found for b's3+http://vcf/test.vcf.gz' at chr18
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO -   for record in vcf(chromosome):
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - 
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Starting processing chromosome: chrM
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_occurrences'), partition {'part': 1, 'case_id': 1, 'seq_id': 1, 'chromosome': 'M'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_variants'), partition {'case_id': 1, 'chromosome': 'M'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_consequences'), partition {'case_id': 1, 'chromosome': 'M'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:✅ IMPORTED Experiment: 1, file s3+http://vcf/test.vcf.gz, chromosome chrM
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Starting processing chromosome: chr18
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_occurrences'), partition {'part': 1, 'case_id': 1, 'seq_id': 1, 'chromosome': '18'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_variants'), partition {'case_id': 1, 'chromosome': '18'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_consequences'), partition {'case_id': 1, 'chromosome': '18'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:✅ IMPORTED Experiment: 1, file s3+http://vcf/test.vcf.gz, chromosome chr18
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Starting processing chromosome: chr1
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Writing to parquet path: s3://warehouse/radiant/germline_snv_occurrences/part=1/case_id=1/seq_id=1/chromosome=1/64ff7091-25ff-4a3d-83fc-7afe210abc8f.parquet
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:aiobotocore.credentials:Found credentials in environment variables.
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Try to commit tx for table ('radiant', 'germline_snv_occurrences') with filter {'part': 1, 'case_id': 1, 'seq_id': 1, 'chromosome': '1'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Successfully overwrite partition {'part': 1, 'case_id': 1, 'seq_id': 1, 'chromosome': '1'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Writing to parquet path: s3://warehouse/radiant/germline_snv_variants/case_id=1/chromosome=1/fd4a2067-3c2e-47a9-bb3e-2da62f4c0b56.parquet
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Try to commit tx for table ('radiant', 'germline_snv_variants') with filter {'case_id': 1, 'chromosome': '1'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:Successfully overwrite partition {'case_id': 1, 'chromosome': '1'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:No data to write for table ('radiant', 'germline_snv_consequences'), partition {'case_id': 1, 'chromosome': '1'}
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:***.task:✅ IMPORTED Experiment: 1, file s3+http://vcf/test.vcf.gz, chromosome chr1
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - 
[2025-05-23, 12:31:49 UTC] {process_utils.py:194} INFO - INFO:__main__:✅ IMPORTED Experiment: 1, file s3+http://vcf/test.vcf.gz, chromosome chrM,chr18,chr1
```