### PR TITLE
:bug: fix: SJRA-278 Fix log capture to display logs on exceptions

### DIFF
--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -1,4 +1,3 @@
-import logging
 import sys
 from functools import wraps
 

--- a/radiant/tasks/vcf/process.py
+++ b/radiant/tasks/vcf/process.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 
 from cyvcf2 import VCF
 from pyiceberg.catalog import load_catalog

--- a/radiant/tasks/vcf/process.py
+++ b/radiant/tasks/vcf/process.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 
 from cyvcf2 import VCF
 from pyiceberg.catalog import load_catalog


### PR DESCRIPTION
## Context

Follow-up on https://github.com/radiant-network/radiant-portal-pipeline/pull/61, the fix wasn't complete.

## Contribution

Because the way `wurlitzer` works: 

> when using `PIPE` (default), the type of captured output
        is `io.StringIO/BytesIO` instead of an OS pipe.
        This eliminates max buffer size issues (and hang when output exceeds 65536 bytes),
        but also means the buffer cannot be read with `.read()` methods
        until after the context exits.

Moving the handling of the generated exception outside the context fixed the missing logs. 
