### PR TITLE
Fix/sjra 281 single commit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,8 @@ x-airflow-common:
     AWS_REGION: us-east-1
     AWS_ACCESS_KEY_ID: admin
     AWS_SECRET_ACCESS_KEY: password
+    AWS_ENDPOINT_URL: http://radiant-minio:9000
+    AWS_ALLOW_HTTP: true
     HTS_S3_HOST: radiant-minio:9000
     HTS_S3_ADDRESS_STYLE: path
     PYICEBERG_CATALOG__DEFAULT__URI: http://radiant-iceberg-rest:8181

--- a/radiant/dags/init_iceberg_tables.py
+++ b/radiant/dags/init_iceberg_tables.py
@@ -43,7 +43,6 @@ with DAG(
         part_field = OCCURRENCE_SCHEMA.find_field("part")
         case_id_field = OCCURRENCE_SCHEMA.find_field("case_id")
         seq_id_field = OCCURRENCE_SCHEMA.find_field("seq_id")
-        chromosome_field = OCCURRENCE_SCHEMA.find_field("chromosome")
 
         partition_spec = PartitionSpec(
             fields=[
@@ -65,12 +64,6 @@ with DAG(
                     name=seq_id_field.name,
                     transform=IdentityTransform(),
                 ),
-                PartitionField(
-                    field_id=1003,
-                    source_id=chromosome_field.field_id,
-                    name=chromosome_field.name,
-                    transform=IdentityTransform(),
-                ),
             ]
         )
         catalog.create_table_if_not_exists(table_name, schema=OCCURRENCE_SCHEMA, partition_spec=partition_spec)
@@ -89,7 +82,6 @@ with DAG(
             catalog.drop_table(table_name)
 
         case_id_field = VARIANT_SCHEMA.find_field("case_id")
-        chromosome_field = VARIANT_SCHEMA.find_field("chromosome")
 
         partition_spec = PartitionSpec(
             fields=[
@@ -98,13 +90,7 @@ with DAG(
                     source_id=case_id_field.field_id,
                     name="case_id",
                     transform=IdentityTransform(),
-                ),
-                PartitionField(
-                    field_id=1003,
-                    source_id=chromosome_field.field_id,
-                    name="chromosome",
-                    transform=IdentityTransform(),
-                ),
+                )
             ]
         )
         catalog.create_table_if_not_exists(table_name, schema=VARIANT_SCHEMA, partition_spec=partition_spec)
@@ -123,7 +109,6 @@ with DAG(
             catalog.drop_table(table_name)
 
         case_id_field = CONSEQUENCE_SCHEMA.find_field("case_id")
-        chromosome_field = CONSEQUENCE_SCHEMA.find_field("chromosome")
 
         partition_spec = PartitionSpec(
             fields=[
@@ -132,13 +117,7 @@ with DAG(
                     source_id=case_id_field.field_id,
                     name="case_id",
                     transform=IdentityTransform(),
-                ),
-                PartitionField(
-                    field_id=1003,
-                    source_id=chromosome_field.field_id,
-                    name="chromosome",
-                    transform=IdentityTransform(),
-                ),
+                )
             ]
         )
         catalog.create_table_if_not_exists(table_name, schema=CONSEQUENCE_SCHEMA, partition_spec=partition_spec)

--- a/radiant/tasks/iceberg/partition_commit.py
+++ b/radiant/tasks/iceberg/partition_commit.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class PartitionCommit(BaseModel):
+    parquet_files: list[str]
+    partition_filter: dict[str, Any]

--- a/radiant/tasks/iceberg/table_accumulator.py
+++ b/radiant/tasks/iceberg/table_accumulator.py
@@ -1,17 +1,18 @@
+import itertools
 import logging
-import os
-import time
 import uuid
 
 import pyarrow as pa
-import pyarrow.parquet as pq
 from pyiceberg.catalog import Table
-from pyiceberg.exceptions import CommitFailedException
-from pyiceberg.expressions import And, EqualTo
+from pyiceberg.io.pyarrow import (
+    PyArrowFileIO,
+)
+
+from radiant.tasks.iceberg.utils import dataframe_to_data_files
 
 logger = logging.getLogger("airflow.task")
 
-PARQUET_FILE_SIZE_MB = 256
+PARQUET_FILE_SIZE_MB = 1024
 MAX_BUFFERED_ROWS = 10000
 
 
@@ -35,7 +36,6 @@ class TableAccumulator:
     def __init__(
         self,
         table: Table,
-        fs=None,
         partition_filter: dict = None,
         max_buffered_rows: int = MAX_BUFFERED_ROWS,
         parquet_file_size_mb: int = PARQUET_FILE_SIZE_MB,
@@ -45,7 +45,6 @@ class TableAccumulator:
 
         Args:
             table (Table): The target Iceberg table instance.
-            fs: Optional PyArrow filesystem object for writing Parquet files.
             partition_filter (dict, optional): Partition key-value pairs to overwrite.
             max_buffered_rows (int): Maximum number of rows to buffer before merging.
             parquet_file_size_mb (int): Parquet file size threshold in MB for writing.
@@ -53,7 +52,6 @@ class TableAccumulator:
         self.table = table
         self.schema = self.remove_field_ids(table.schema().as_arrow())
         self.partition_filter = partition_filter or {}
-        self.fs = fs
         self.parquet_paths = []
         self.rows = []
         self.accumulated_pa_table = None
@@ -61,21 +59,44 @@ class TableAccumulator:
         self.parquet_file_size_mb = parquet_file_size_mb
 
     @staticmethod
-    def remove_field_ids(schema: pa.Schema):
+    def remove_field_ids(schema: pa.Schema) -> pa.Schema:
         """
-        Return a new Arrow schema with field IDs removed.
+        Recursively remove Iceberg field IDs from an Arrow schema.
 
         Args:
             schema (pa.Schema): An Arrow schema that may include Iceberg field IDs.
 
         Returns:
-            pa.Schema: A clean schema without field IDs.
+            pa.Schema: A schema without any field IDs.
         """
-        fields = []
-        for field in schema:
-            pa_field = pa.field(field.name, field.type, nullable=field.nullable)
-            fields.append(pa_field)
-        return pa.schema(fields)
+
+        def strip_field_ids(field: pa.Field) -> pa.Field:
+            field_type = field.type
+            if pa.types.is_struct(field_type):
+                # Recursively clean struct fields
+                new_fields = [strip_field_ids(f) for f in field_type]
+                new_type = pa.struct(new_fields)
+            elif pa.types.is_list(field_type):
+                # List has a single value field
+                value_field = strip_field_ids(field_type.value_field)
+                new_type = pa.list_(value_field)
+            elif pa.types.is_large_list(field_type):
+                value_field = strip_field_ids(field_type.value_field)
+                new_type = pa.large_list(value_field)
+            elif pa.types.is_map(field_type):
+                # Map has key and item fields
+                new_type = pa.map_(
+                    strip_field_ids(field_type.key_field),
+                    strip_field_ids(field_type.item_field),
+                    keys_sorted=field_type.keys_sorted,
+                )
+            else:
+                new_type = field_type  # Primitive type
+
+            return pa.field(field.name, new_type, nullable=field.nullable)
+
+        new_fields = [strip_field_ids(f) for f in schema]
+        return pa.schema(new_fields)
 
     def append(self, row: dict):
         """
@@ -130,79 +151,28 @@ class TableAccumulator:
             self.clear_rows()
 
             if self.accumulated_pa_table.get_total_buffer_size() >= self.parquet_file_size_mb * 1024 * 1024:
-                self.write_files(commit=False, merge=False)
+                self.write_files(merge=False)
 
-    def write_files(self, commit: bool = True, merge=True) -> str | None:
+    def write_files(self, merge: bool = True):
         """
-        Write the accumulated Arrow table to a Parquet file, and optionally
-        commit the file to the Iceberg table.
+        Write the accumulated Arrow table to a Parquet file
 
         Args:
-            commit (bool): Whether to commit the written file to Iceberg.
             merge (bool): Whether to force a merge before writing.
 
-        Returns:
-            str | None: The Parquet file path if written, otherwise None.
         """
+        logger.info("Write arrow to parquet")
         if merge:
             self.merge_table(force=True)
-        if not self.accumulated_pa_table:
-            logger.info(f"No data to write for table {self.table.name()}, partition {self.partition_filter}")
-            return None
 
-        file_uuid = str(uuid.uuid4())
-        parts = [f"{k}={v}" for k, v in self.partition_filter.items()]
-        table_location = self.table.location().replace("s3a://", "s3://")
-        parquet_path = os.path.join(table_location, *parts, f"{file_uuid}.parquet")
-        self.parquet_paths.append(parquet_path)
-
-        logger.info(f"Writing to parquet path: {parquet_path}")
-
-        with self.fs.open(parquet_path, "wb") as fos, pq.ParquetWriter(fos, schema=self.schema) as writer:
-            writer.write_table(self.accumulated_pa_table)
-
-        self.accumulated_pa_table = None
-        if commit:
-            self.commit_files()
-        return parquet_path
-
-    def commit_files(self):
-        """
-        Commit all written Parquet files to the Iceberg table using overwrite mode.
-
-        Raises:
-            ValueError: If the partition filter is empty.
-            CommitFailedException: If commit retries are exhausted.
-        """
-        if not self.parquet_paths:
-            logger.info(
-                f"No parquet files to commit for table {self.table.name()} partition filter {self.partition_filter}"
+        if self.accumulated_pa_table:
+            file_io = PyArrowFileIO(self.table.catalog.properties)
+            counter = itertools.count()
+            uuid_ = uuid.uuid4()
+            files = list(
+                dataframe_to_data_files(self.table.metadata, self.accumulated_pa_table, file_io, uuid_, counter)
             )
-            return
-        # Create filter expression for multi-column partition
-        filter_expr = None
-        for col, val in self.partition_filter.items():
-            expr = EqualTo(col, val)
-            filter_expr = expr if filter_expr is None else And(filter_expr, expr)
-        if filter_expr is None:
-            raise ValueError(f"Partition filter {self.partition_filter} must contain at least one key-value pair.")
-        max_retries = 200
-        while max_retries > 0:
-            try:
-                logger.info(f"Try to commit tx for table {self.table.name()} with filter {self.partition_filter}")
-                self.table.refresh()
-                tx = self.table.transaction()
-                tx.delete(filter_expr)
-                tx.add_files(self.parquet_paths)
-                tx.commit_transaction()
-
-                logger.info(f"Successfully overwrite partition {self.partition_filter}")
-                break
-
-            except CommitFailedException as e:
-                max_retries -= 1
-                logger.info(f"Commit failed: {e}. Retries left: {max_retries}")
-                time.sleep(1)
-                if max_retries <= 0:
-                    logger.error("Failed after 200 retries. Giving up.")
-                    raise e
+            logger.info(f"Writing {len(files)} files to parquet")
+            logger.info(f"files {files}")
+            self.parquet_paths.extend([f.file_path.replace("s3a", "s3") for f in files])
+            self.accumulated_pa_table = None

--- a/radiant/tasks/iceberg/utils.py
+++ b/radiant/tasks/iceberg/utils.py
@@ -1,8 +1,37 @@
+import itertools
 import logging
+import time
+import uuid
+from collections.abc import Iterable, Iterator
 
-from pyiceberg.schema import Schema
+import pyarrow as pa
+import pyarrow.parquet as pq
+from pyiceberg.catalog import Table
+from pyiceberg.exceptions import CommitFailedException
+from pyiceberg.expressions import And, EqualTo
+from pyiceberg.io import FileIO
+from pyiceberg.io.pyarrow import (
+    _determine_partitions,
+    _get_parquet_writer_kwargs,
+    _to_requested_schema,
+    bin_pack_arrow_table,
+    compute_statistics_plan,
+    data_file_statistics_from_parquet_metadata,
+    parquet_path_to_id_mapping,
+    pyarrow_to_schema,
+)
+from pyiceberg.manifest import DataFile, DataFileContent, FileFormat
+from pyiceberg.schema import Schema, sanitize_column_names
+from pyiceberg.table import WriteTask, load_location_provider
+from pyiceberg.table.metadata import TableMetadata
+from pyiceberg.typedef import Record
+from pyiceberg.utils.concurrent import ExecutorFactory
+from pyiceberg.utils.config import Config
+from pyiceberg.utils.properties import property_as_int
 
-logger = logging.getLogger(__name__)
+from radiant.tasks.iceberg.partition_commit import PartitionCommit
+
+logger = logging.getLogger("airflow.task")
 
 
 def merge_schemas(schema1: Schema, schema2: Schema):
@@ -11,3 +40,196 @@ def merge_schemas(schema1: Schema, schema2: Schema):
     """
     appended_fields = list(schema1.fields) + list(schema2.fields)
     return Schema(*appended_fields)
+
+
+def commit_files(table: Table, partition_to_commit: list[PartitionCommit]):
+    """
+    Commit all written Parquet files to the Iceberg table using overwrite mode.
+
+    Raises:
+        ValueError: If the partition filter is empty.
+        CommitFailedException: If commit retries are exhausted.
+    """
+    if not partition_to_commit:
+        logger.info(f"No partitions to commit for table {table.name()} partition filter")
+        return
+
+    # Create filter expression for multi-column partition
+    table.refresh()
+    tx = table.transaction()
+    for partition in partition_to_commit:
+        filter_expr = None
+        for col, val in partition.partition_filter.items():
+            expr = EqualTo(col, val)
+            filter_expr = expr if filter_expr is None else And(filter_expr, expr)
+        if filter_expr is None:
+            raise ValueError(
+                f"Partition filter {partition.partition_filter} must contain at least one key-value pair."
+            )
+        tx.delete(filter_expr)
+        if partition.parquet_files:
+            tx.add_files(partition.parquet_files)
+
+    max_retries = 20
+    while max_retries > 0:
+        try:
+            tx.commit_transaction()
+            logger.info("Successfully overwrite partitions")
+            break
+        except CommitFailedException as e:
+            max_retries -= 1
+            logger.info(f"Commit failed: {e}. Retries left: {max_retries}")
+            time.sleep(1)
+            if max_retries <= 0:
+                logger.error("Failed after 10 retries. Giving up.")
+                raise e
+
+
+def dataframe_to_data_files(
+    table_metadata: TableMetadata,
+    df: pa.Table,
+    io: FileIO,
+    write_uuid: uuid.UUID | None = None,
+    counter: Iterator[int] | None = None,
+) -> Iterable[DataFile]:
+    """Convert a PyArrow table into a DataFile.
+    This function is a copy of pyiceberg.io.pyarrow._dataframe_to_data_files.
+    These functions are copied to generate parquet files that can be read by any other engine.
+    Unfortunately, pyiceberg does not expose these functions as public API.
+    We also modified these functions to not include field ids in targeted schema. Otherwise,
+    add_files during commit phase fails.
+
+    Returns:
+        An iterable that supplies datafiles that represent the table.
+    """
+    from pyiceberg.table import DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE, TableProperties, WriteTask
+
+    counter = counter or itertools.count(0)
+    write_uuid = write_uuid or uuid.uuid4()
+    target_file_size: int = property_as_int(  # type: ignore  # The property is set with non-None value.
+        properties=table_metadata.properties,
+        property_name=TableProperties.WRITE_TARGET_FILE_SIZE_BYTES,
+        default=TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
+    )
+    name_mapping = table_metadata.schema().name_mapping
+    from pyiceberg.utils.config import Config
+
+    downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
+    task_schema = pyarrow_to_schema(
+        df.schema, name_mapping=name_mapping, downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us
+    )
+
+    if table_metadata.spec().is_unpartitioned():
+        yield from _write_file(
+            io=io,
+            table_metadata=table_metadata,
+            tasks=iter(
+                [
+                    WriteTask(write_uuid=write_uuid, task_id=next(counter), record_batches=batches, schema=task_schema)
+                    for batches in bin_pack_arrow_table(df, target_file_size)
+                ]
+            ),
+        )
+    else:
+        partitions = _determine_partitions(spec=table_metadata.spec(), schema=table_metadata.schema(), arrow_table=df)
+        yield from _write_file(
+            io=io,
+            table_metadata=table_metadata,
+            tasks=iter(
+                [
+                    WriteTask(
+                        write_uuid=write_uuid,
+                        task_id=next(counter),
+                        record_batches=batches,
+                        partition_key=partition.partition_key,
+                        schema=task_schema,
+                    )
+                    for partition in partitions
+                    for batches in bin_pack_arrow_table(partition.arrow_table_partition, target_file_size)
+                ]
+            ),
+        )
+
+
+def _write_file(io: FileIO, table_metadata: TableMetadata, tasks: Iterator[WriteTask]) -> Iterator[DataFile]:
+    """
+    Write Parquet files for the given tasks and return an iterator of DataFile objects.
+    This function is a copy of pyiceberg.io.pyarrow.write_file. The modified version does not include field ids in
+    targeted schema. Otherwise, function add_files during commit phase fails.
+    :param io:
+    :param table_metadata:
+    :param tasks:
+    :return:
+    """
+    from pyiceberg.table import DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE, TableProperties
+
+    parquet_writer_kwargs = _get_parquet_writer_kwargs(table_metadata.properties)
+    row_group_size = property_as_int(
+        properties=table_metadata.properties,
+        property_name=TableProperties.PARQUET_ROW_GROUP_LIMIT,
+        default=TableProperties.PARQUET_ROW_GROUP_LIMIT_DEFAULT,
+    )
+    location_provider = load_location_provider(
+        table_location=table_metadata.location, table_properties=table_metadata.properties
+    )
+
+    def write_parquet(task: WriteTask) -> DataFile:
+        table_schema = table_metadata.schema()
+        # if schema needs to be transformed, use the transformed schema and adjust the arrow table accordingly
+        # otherwise use the original schema
+        if (sanitized_schema := sanitize_column_names(table_schema)) != table_schema:
+            file_schema = sanitized_schema
+        else:
+            file_schema = table_schema
+
+        downcast_ns_timestamp_to_us = Config().get_bool(DOWNCAST_NS_TIMESTAMP_TO_US_ON_WRITE) or False
+        batches = [
+            _to_requested_schema(
+                requested_schema=file_schema,
+                file_schema=task.schema,
+                batch=batch,
+                downcast_ns_timestamp_to_us=downcast_ns_timestamp_to_us,
+                include_field_ids=False,  # !!!Do not include field ids in targeted schema,
+                # this is needed to avoid issues with add_files during commit phase.
+            )
+            for batch in task.record_batches
+        ]
+        arrow_table = pa.Table.from_batches(batches)
+        file_path = location_provider.new_data_location(
+            data_file_name=task.generate_data_file_filename("parquet"),
+            partition_key=task.partition_key,
+        )
+        fo = io.new_output(file_path)
+        with (
+            fo.create(overwrite=True) as fos,
+            pq.ParquetWriter(fos, schema=arrow_table.schema, **parquet_writer_kwargs) as writer,
+        ):
+            writer.write(arrow_table, row_group_size=row_group_size)
+        statistics = data_file_statistics_from_parquet_metadata(
+            parquet_metadata=writer.writer.metadata,
+            stats_columns=compute_statistics_plan(file_schema, table_metadata.properties),
+            parquet_column_mapping=parquet_path_to_id_mapping(file_schema),
+        )
+        data_file = DataFile(
+            content=DataFileContent.DATA,
+            file_path=file_path,
+            file_format=FileFormat.PARQUET,
+            partition=task.partition_key.partition if task.partition_key else Record(),
+            file_size_in_bytes=len(fo),
+            # After this has been fixed:
+            # https://github.com/apache/iceberg-python/issues/271
+            # sort_order_id=task.sort_order_id,
+            sort_order_id=None,
+            # Just copy these from the table for now
+            spec_id=table_metadata.default_spec_id,
+            equality_ids=None,
+            key_metadata=None,
+            **statistics.to_serialized_dict(),
+        )
+
+        return data_file
+
+    executor = ExecutorFactory.get_or_create()
+    data_files = executor.map(write_parquet, tasks)
+
+    return iter(data_files)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,5 @@ psycopg2-binary==2.9.10
 ruff==0.11.4
 pymysql
 cyvcf2
+# Needed for filesystem abstraction in tests
+fs>=2.4.16

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 # Core iceberg dependency with S3 support
 pyiceberg[s3fs]==0.9.0
 
-# Needed for filesystem abstraction
-fs>=2.4.16
 pyarrow==19.0.1
 
 # Needed for error capture

--- a/tests/unit/dags/test_import_vcf.py
+++ b/tests/unit/dags/test_import_vcf.py
@@ -9,19 +9,25 @@ def test_dag_is_importable(dag_bag):
 
 def test_dag_has_correct_number_of_tasks(dag_bag):
     dag = dag_bag.get_dag(f"{NAMESPACE}-import-vcf")
-    assert len(dag.tasks) == 2  # get_cases and import_vcf
+    assert len(dag.tasks) == 4  # get_cases and import_vcf
 
 
 def test_dag_has_correct_tasks(dag_bag):
     dag = dag_bag.get_dag(f"{NAMESPACE}-import-vcf")
     task_ids = [task.task_id for task in dag.tasks]
     assert task_ids[0] == "get_cases"
-    assert task_ids[1] == "import_vcf"
+    assert task_ids[1] == "create_parquet_files"
+    assert task_ids[2] == "merge_commits"
+    assert task_ids[3] == "commit_partitions"
 
 
 def test_dag_task_dependencies_are_correct(dag_bag):
     dag = dag_bag.get_dag(f"{NAMESPACE}-import-vcf")
     get_cases_task = dag.get_task("get_cases")
-    import_vcf_task = dag.get_task("import_vcf")
+    import_vcf_task = dag.get_task("create_parquet_files")
+    merge_commits_task = dag.get_task("merge_commits")
+    commit_partitions = dag.get_task("commit_partitions")
 
     assert import_vcf_task in get_cases_task.downstream_list
+    assert merge_commits_task in import_vcf_task.downstream_list
+    assert commit_partitions in merge_commits_task.downstream_list


### PR DESCRIPTION
This PR change the way trancation are commited in iceberg catalog. 

**Before**
- Tables was partitioned by case + chromosome, leading to many small files
- Each time a chromosome was processed, a transaction was commited. It was causing conflicts during commit. After a conflict, we need to refresh and re-try the commit. Which can casue pressure on object store during metadata refresh.

**After**
- Tables are now partitioned by case. Each case took 20 minutes. Which is slower than partition by case + chromosome because there is less parallelization, but as a result there is les parquet files. 
- Commit occurs after parquet files for ALL the case has been written. This is done in an additional step. 