### PR TITLE
🐛 fix: SJRA-321 Fix dependencies for Airflow container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L -O https://curl.se/download/curl-${LIBCURL_VERSION}.tar.gz && \
 RUN curl -L -O https://github.com/samtools/htslib/releases/download/1.21/htslib-1.21.tar.bz2 && \
     tar -xvf htslib-1.21.tar.bz2 && \
     cd htslib-1.21 && \
-    ./configure --enable-libcurl --enable-s3 && \
+    ./configure --enable-libcurl && \
     make && \
     make install && \
     cd .. && \

--- a/Dockerfile-mwaa
+++ b/Dockerfile-mwaa
@@ -35,7 +35,7 @@ RUN curl -L -O https://curl.se/download/curl-${LIBCURL_VERSION}.tar.gz && \
 RUN curl -L -O https://github.com/samtools/htslib/releases/download/1.21/htslib-1.21.tar.bz2 && \
     tar -xvf htslib-1.21.tar.bz2 && \
     cd htslib-1.21 && \
-    ./configure --enable-libcurl --enable-s3 && \
+    ./configure --enable-libcurl && \
     make && \
     make install && \
     cd .. && \

--- a/radiant/dags/import_vcf.py
+++ b/radiant/dags/import_vcf.py
@@ -59,6 +59,7 @@ with DAG(
     def create_parquet_files(case: dict):
         import json
         import logging
+        import os
         import sys
         from urllib import parse
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
+boto3<1.36
+
 # Core iceberg dependency with S3 support
+s3fs<=2024.10.0
 pyiceberg[s3fs]==0.9.0
 
 pyarrow==19.0.1

--- a/tests/integration/dags/conftest.py
+++ b/tests/integration/dags/conftest.py
@@ -12,11 +12,7 @@ def create_and_append_table(iceberg_client, namespace, table_name, file_path, js
 
 @pytest.fixture(scope="session")
 def open_data_iceberg_tables(
-    starrocks_iceberg_catalog,
-    setup_namespace,
-    iceberg_client,
-    resources_dir,
-    random_test_id,
+    starrocks_iceberg_catalog, iceberg_client, setup_namespace, resources_dir, random_test_id
 ):
     # Json fields are required for certain .tsv files to properly handle types
     tables = {
@@ -50,7 +46,7 @@ def open_data_iceberg_tables(
     }
 
     # This is hackish to avoid referencing the airflow container that might not be available in some
-    # runtime environments (i.e. GHA)
+    # runtime environments (i.e. GHA) when running either integration tests or slow tests
     for namespace in ["radiant_iceberg_namespace", setup_namespace]:
         for table, json_fields in tables.items():
             create_and_append_table(

--- a/tests/integration/dags/conftest.py
+++ b/tests/integration/dags/conftest.py
@@ -12,7 +12,11 @@ def create_and_append_table(iceberg_client, namespace, table_name, file_path, js
 
 @pytest.fixture(scope="session")
 def open_data_iceberg_tables(
-    starrocks_iceberg_catalog, iceberg_client, setup_namespace, resources_dir, random_test_id
+    starrocks_iceberg_catalog,
+    setup_namespace,
+    iceberg_client,
+    resources_dir,
+    random_test_id,
 ):
     # Json fields are required for certain .tsv files to properly handle types
     tables = {
@@ -44,15 +48,19 @@ def open_data_iceberg_tables(
         "hpo_gene_set": None,
         "orphanet_gene_set": None,
     }
-    for table, json_fields in tables.items():
-        create_and_append_table(
-            iceberg_client,
-            setup_namespace,
-            f"{table}",
-            resources_dir / "open_data" / f"{table}.tsv",
-            json_fields=json_fields,
-            is_clinvar=(table == "clinvar"),
-        )
+
+    # This is hackish to avoid referencing the airflow container that might not be available in some
+    # runtime environments (i.e. GHA)
+    for namespace in ["radiant_iceberg_namespace", setup_namespace]:
+        for table, json_fields in tables.items():
+            create_and_append_table(
+                iceberg_client,
+                namespace,
+                f"{table}",
+                resources_dir / "open_data" / f"{table}.tsv",
+                json_fields=json_fields,
+                is_clinvar=(table == "clinvar"),
+            )
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/dags/conftest.py
+++ b/tests/integration/dags/conftest.py
@@ -6,8 +6,9 @@ from tests.utils.dags import get_pyarrow_table_from_csv, poll_dag_until_success,
 
 def create_and_append_table(iceberg_client, namespace, table_name, file_path, json_fields=None, is_clinvar=False):
     content = get_pyarrow_table_from_csv(csv_path=file_path, sep="\t", json_fields=json_fields, is_clinvar=is_clinvar)
-    iceberg_client.create_table_if_not_exists(f"{namespace}.{table_name}", schema=content.schema)
-    iceberg_client.load_table(f"{namespace}.{table_name}").append(df=content)
+    if iceberg_client.namespace_exists(namespace):
+        iceberg_client.create_table_if_not_exists(f"{namespace}.{table_name}", schema=content.schema)
+        iceberg_client.load_table(f"{namespace}.{table_name}").append(df=content)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Context

With https://github.com/radiant-network/radiant-portal-pipeline/pull/69 closed, we replaced the mechanism by which HTSLIB fetches the data from external files. It now uses S3 presigned URLs instead of the S3 protocol. 

Those changes were not properly propagated to the original Airflow image, in which some dependencies were missing to pre-sign URLs.

## Contribution

This PR adds the missing dependencies. (This required pinning `s3fs` and `boto3` versions to avoid a dependency conflict between them)

It also removes the `enable-s3` option with which `htslib` is compiled. It should now only rely on `libcurl` to fetch the VCF files. 