### PR TITLE
:bug: fix: SJRA-154 Create a script for loading data from csv

### DIFF
--- a/scripts/load_clinical_data.md
+++ b/scripts/load_clinical_data.md
@@ -1,0 +1,87 @@
+# 📄 `load_data.sh` – PostgreSQL CSV Loader
+
+This script automates the process of:
+
+1. **Truncating** a set of interrelated PostgreSQL tables (with `CASCADE`)
+2. **Importing CSV files** into those tables using the `psql \copy` command
+
+---
+
+## ✅ Requirements
+
+- Bash shell (Linux/macOS)
+- `psql` installed and accessible in your `PATH`
+- PostgreSQL database with the expected schema already created
+- A directory containing the CSV files (with headers)
+
+---
+
+## 🧩 Tables Affected
+
+The following tables are truncated in the specified order (to respect foreign keys):
+
+```
+organization
+patient
+project
+request
+case_analysis
+cases
+family
+observation_coding
+sample
+experiment
+sequencing_experiment
+pipeline
+task
+task_has_sequencing_experiment
+document
+task_has_document
+```
+
+Each table will be loaded from its corresponding `.csv` file.
+
+---
+
+## 📥 Usage
+
+```bash
+./load_data.sh <PGUSER> <PGHOST> <PGPORT> <PGDATABASE> <CSV_DIR>
+```
+
+### Arguments
+
+| Argument      | Description                                |
+|---------------|--------------------------------------------|
+| `PGUSER`      | Database user                              |
+| `PGHOST`      | PostgreSQL hostname (e.g., `localhost`)    |
+| `PGPORT`      | PostgreSQL port (usually `5432`)           |
+| `PGDATABASE`  | Target database name                       |
+| `CSV_DIR`     | Path to directory containing the CSV files |
+
+### Password
+
+- If the `PGPASSWORD` environment variable is **already set**, it will be used to authenticate.
+- If not, the script will **prompt you securely** to enter the password at runtime.
+
+---
+
+
+## 🛠 Customization
+
+You can adapt the script to:
+
+- Add logging of errors or rows inserted
+- Run specific validation after loading
+- Use transactions around insertions (if not using `\copy` directly)
+- Skip loading certain tables (by commenting out the relevant lines)
+
+---
+
+## 🧪 Testing Tip
+
+To dry-run the file loading commands without executing:
+
+```bash
+bash -x ./load_data.sh ...
+```

--- a/scripts/load_clinical_data.sh
+++ b/scripts/load_clinical_data.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Usage: ./load_data.sh <PGUSER> <PGHOST> <PGPORT> <PGDATABASE> <CSV_DIR>
+
+set -e  # Exit immediately if a command exits with a non-zero status
+
+PGUSER=$1
+PGHOST=$2
+PGPORT=$3
+PGDATABASE=$4
+CSV_DIR=$5
+
+# Prompt for password if not already set in env
+if [ -z "$PGPASSWORD" ]; then
+  read -s -p "Enter PostgreSQL password: " PGPASSWORD
+  echo
+fi
+
+export PGPASSWORD
+
+echo "Truncating tables..."
+psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -p "$PGPORT" <<SQL
+TRUNCATE organization CASCADE;
+TRUNCATE patient CASCADE;
+TRUNCATE project CASCADE;
+TRUNCATE request CASCADE;
+TRUNCATE case_analysis CASCADE;
+TRUNCATE cases CASCADE;
+TRUNCATE family CASCADE;
+TRUNCATE observation_coding CASCADE;
+TRUNCATE sample CASCADE;
+TRUNCATE experiment CASCADE;
+TRUNCATE sequencing_experiment CASCADE;
+TRUNCATE pipeline CASCADE;
+TRUNCATE task CASCADE;
+TRUNCATE task_has_sequencing_experiment CASCADE;
+TRUNCATE document CASCADE;
+TRUNCATE task_has_document CASCADE;
+SQL
+
+echo "Loading data..."
+
+copy_cmd() {
+  echo "Importing $2..."
+  psql -h "$PGHOST" -U "$PGUSER" -d "$PGDATABASE" -p "$PGPORT" -c "\\copy $1 FROM '$CSV_DIR/$2' DELIMITER ',' CSV HEADER;"
+}
+
+copy_cmd organization organization.csv
+copy_cmd patient patient.csv
+copy_cmd project project.csv
+copy_cmd case_analysis case_analysis.csv
+copy_cmd "cases(id,proband_id,project_id,case_analysis_id,status_code,request_id,performer_lab_id,primary_condition,note,created_on,updated_on)" cases.csv
+copy_cmd family family.csv
+copy_cmd observation_coding observation_coding.csv
+copy_cmd sample sample.csv
+copy_cmd experiment experiment.csv
+copy_cmd "sequencing_experiment(id,case_id,patient_id,sample_id,experiment_id,status_code,aliquot,request_id,performer_lab_id,run_name,run_alias,run_date,capture_kit,is_paired_end,read_length,created_on,updated_on)" sequencing_experiment.csv
+copy_cmd pipeline pipeline.csv
+copy_cmd task task.csv
+copy_cmd task_has_sequencing_experiment task_has_sequencing_experiments.csv
+copy_cmd document document.csv
+copy_cmd task_has_document task_has_documents.csv
+
+echo "✅ All data imported successfully."


### PR DESCRIPTION
This PR add a script and its documentation for laoding initial data into clinical tables. We cannot use airflow because we are using `\copy`statement in postgres. This statement allow us to import files from a local device, without copying these on database server. 

An alternative could be use `aws_s3.table_import_from_s3` for loading files from S3. Example : 
```
CREATE EXTENSION IF NOT EXISTS aws_s3 CASCADE;
SELECT aws_s3.table_import_from_s3(
    'project',                             -- target table
    '',                                    -- all columns
    '(FORMAT CSV, HEADER true)',          -- CSV options
    'your-bucket-name',
    'path/to/project.csv',
    'us-east-1'
);
```
But it requires to add permission on postgres cluster to S3. This script is temporary and will be replaced by an API for creating case, patients, ....