### PR TITLE
:zap: fix: SJRA-406 Reduce memory usage

### DIFF
--- a/radiant/dags/import_part.py
+++ b/radiant/dags/import_part.py
@@ -196,15 +196,15 @@ def import_part():
             if os.getenv("STARROCKS_BROKER_USE_INSTANCE_PROFILE", "false").lower() == "true":
                 broker_configuration = f"""
                     'aws.s3.use_instance_profile' = 'true',
-                    'aws.s3.region' = '{os.getenv('AWS_REGION', 'us-east-1')}'
+                    'aws.s3.region' = '{os.getenv("AWS_REGION", "us-east-1")}'
                 """
             else:
                 broker_configuration = f"""
-                    'aws.s3.region' = '{os.getenv('AWS_REGION', 'us-east-1')}',
-                    'aws.s3.endpoint' = '{os.getenv('AWS_ENDPOINT_URL', 's3.amazonaws.com')}',
+                    'aws.s3.region' = '{os.getenv("AWS_REGION", "us-east-1")}',
+                    'aws.s3.endpoint' = '{os.getenv("AWS_ENDPOINT_URL", "s3.amazonaws.com")}',
                     'aws.s3.enable_path_style_access' = 'true',
-                    'aws.s3.access_key' = '{os.getenv('AWS_ACCESS_KEY_ID', 'access_key')}',
-                    'aws.s3.secret_key' = '{os.getenv('AWS_SECRET_ACCESS_KEY', 'secret_key')}'
+                    'aws.s3.access_key' = '{os.getenv("AWS_ACCESS_KEY_ID", "access_key")}',
+                    'aws.s3.secret_key' = '{os.getenv("AWS_SECRET_ACCESS_KEY", "secret_key")}'
                 """
 
             for _params in _parameters:

--- a/radiant/dags/init_iceberg_tables.py
+++ b/radiant/dags/init_iceberg_tables.py
@@ -48,7 +48,6 @@ with DAG(
 
         part_field = OCCURRENCE_SCHEMA.find_field("part")
         case_id_field = OCCURRENCE_SCHEMA.find_field("case_id")
-        seq_id_field = OCCURRENCE_SCHEMA.find_field("seq_id")
 
         partition_spec = PartitionSpec(
             fields=[
@@ -62,12 +61,6 @@ with DAG(
                     field_id=1001,
                     source_id=case_id_field.field_id,
                     name=case_id_field.name,
-                    transform=IdentityTransform(),
-                ),
-                PartitionField(
-                    field_id=1002,
-                    source_id=seq_id_field.field_id,
-                    name=seq_id_field.name,
                     transform=IdentityTransform(),
                 ),
             ]

--- a/radiant/tasks/iceberg/table_accumulator.py
+++ b/radiant/tasks/iceberg/table_accumulator.py
@@ -12,7 +12,9 @@ from radiant.tasks.iceberg.utils import dataframe_to_data_files
 
 logger = logging.getLogger("airflow.task")
 
-PARQUET_FILE_SIZE_MB = 1024
+PARQUET_FILE_SIZE_MB = 500  # Keep this value slightly lower than size of
+# TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
+# otherwise there is a risk to write small parquet files.
 MAX_BUFFERED_ROWS = 10000
 
 
@@ -132,6 +134,7 @@ class TableAccumulator:
         Clear the in-memory row buffer.
         """
         self.rows.clear()
+        # gc.collect()
 
     def merge_table(self, force: bool = False):
         """


### PR DESCRIPTION

Our task consumes a lot of memory  

### Arrow table accumulator is too big 
We set this accummulator size to 1024MB. As a result it writes 2 parquet files for each chunk of this table. Furthermore, sometimes it generates a tiny parquet files because size of this table does not align with Pyarrow estimation for parquet file size.

Solution : Set this number to 500MB. As a result the memory usage should be divided by 2 and the parquet files should have the same size than before. The tiny parquet files should disappear

### Change occurrence table partitioning
In case of a family, we manage one table accumulator by family member. In that way, we can manage partitions by sequencing experiment. But it’s not really useful in our process, because even if there is a new sequencing for a case, it will produce a combined vcf for families. So we need to re-import the whole case. By removing this partition, we can keep our memory usage as low as a solo case.

### Results 
Process takes 3-4Gb of memory per case, even for a family.