### PR TITLE
:wrench: fix: SJRA-594 Add document-patient entry for exomiser file 

### DIFF
--- a/radiant/dags/sql/clinical/seeds.sql
+++ b/radiant/dags/sql/clinical/seeds.sql
@@ -1793,4 +1793,5 @@ INSERT INTO {{ params.clinical_document_has_patient }} (document_id, patient_id)
     (136, 1),
     (136, 3),
     (235, 22),
-    (236, 22);
+    (236, 22),
+    (245, 3);


### PR DESCRIPTION
In seed, an entry is missing for document_has_patient table. It causes case 1 not having exomiser data in QA