### PR TITLE
feat: SJRA-1317 change load exomiser to stop losing exomiser data on partial loads

### DIFF
--- a/radiant/dags/import_part.py
+++ b/radiant/dags/import_part.py
@@ -247,13 +247,18 @@ def import_part():
         parameters=task_ids,
     )
 
-    insert_exomiser = RadiantStarRocksOperator(
+    insert_exomiser = RadiantStarRocksPartitionSwapOperator(
         task_id="insert_exomiser",
-        sql="./sql/radiant/exomiser_insert.sql",
-        task_display_name="[StarRocks] Insert Exomiser",
+        table="{{ mapping.starrocks_exomiser }}",
+        task_display_name="[StarRocks] Insert Exomiser Part",
+        swap_partition=SwapPartition(
+            partition="{{ params.part }}",
+            copy_partition_sql="./sql/radiant/exomiser_copy_partition.sql",
+        ),
         submit_task_options=std_submit_task_opts,
-        parameters={"part": "{{ params.part }}"},
-        trigger_rule=TriggerRule.NONE_FAILED,
+        parameters=sequencing_ids,
+        insert_partition_sql="./sql/radiant/exomiser_insert_partition_delta.sql",
+        trigger_rule=TriggerRule.ALL_SUCCESS,
     )
 
     with TaskGroup(group_id="germline_snv_occurrence") as tg_germline_snv_occurrence:

--- a/radiant/dags/sql/radiant/exomiser_copy_partition.sql
+++ b/radiant/dags/sql/radiant/exomiser_copy_partition.sql
@@ -1,0 +1,3 @@
+SELECT *
+FROM {{ table }} PARTITION ( p{{ partition }})
+WHERE seq_id NOT IN %(seq_ids)s AND seq_id NOT IN %(deleted_seq_ids)s;

--- a/radiant/dags/sql/radiant/exomiser_insert_partition_delta.sql
+++ b/radiant/dags/sql/radiant/exomiser_insert_partition_delta.sql
@@ -13,4 +13,4 @@ select e.part,
        acmg_evidence
 FROM {{ mapping.starrocks_staging_exomiser }} e
 JOIN {{ mapping.starrocks_snv_tmp_variant }} v ON e.locus_hash = v.locus_hash
-WHERE part = {{ partition }};
+WHERE part = {{ partition }} AND seq_id IN %(seq_ids)s AND seq_id NOT IN %(deleted_seq_ids)s;

--- a/radiant/dags/sql/radiant/exomiser_insert_partition_delta.sql
+++ b/radiant/dags/sql/radiant/exomiser_insert_partition_delta.sql
@@ -1,4 +1,3 @@
-INSERT /*+set_var(dynamic_overwrite = true)*/ OVERWRITE {{ mapping.starrocks_exomiser }}
 select e.part,
        seq_id,
        locus_id,
@@ -14,4 +13,4 @@ select e.part,
        acmg_evidence
 FROM {{ mapping.starrocks_staging_exomiser }} e
 JOIN {{ mapping.starrocks_snv_tmp_variant }} v ON e.locus_hash = v.locus_hash
-WHERE part = %(part)s;
+WHERE part = {{ partition }};

--- a/tests/integration/dags/sql/test_queries.py
+++ b/tests/integration/dags/sql/test_queries.py
@@ -90,6 +90,8 @@ def _explain_insert(starrocks_session, sql_dir):
                 or "cnv_occurrence_copy_partition" in sql_file.lower()
                 or "snv_occurrence_insert_partition_delta" in sql_file.lower()
                 or "snv_occurrence_copy_partition" in sql_file.lower()
+                or "exomiser_copy_partition" in sql_file.lower()
+                or "exomiser_insert_partition_delta" in sql_file.lower()
             ):
                 # "EXPLAIN" not supported with "LOAD"
                 continue


### PR DESCRIPTION
## 📌 Context

The `exomiser_insert.sql` used `INSERT OVERWRITE` on the full partition combined with a JOIN on `starrocks_snv_tmp_variant` (scoped to the current task's variants only). This caused data loss: each task run would overwrite the entire partition with only its own subset of exomiser rows, deleting previously loaded data from other tasks in the same partition.

## 📝 Changes

- Replace `INSERT OVERWRITE` in `exomiser_insert.sql` with the partition swap pattern already used by CNV/SNV occurrence tables
- Rename `exomiser_insert.sql` → `exomiser_insert_partition_delta.sql` to match naming conventions
- Add `exomiser_copy_partition.sql`: copies existing exomiser rows for the partition, excluding seq_ids being replaced (same pattern as `germline_cnv_occurrence_copy_partition.sql`)
- Change `insert_exomiser` in `import_part.py` from `RadiantStarRocksOperator` to `RadiantStarRocksPartitionSwapOperator` with `sequencing_ids` as parameters and `TriggerRule.ALL_SUCCESS`
- Exclude the two new SQL files from the `EXPLAIN` validation test in `test_queries.py` (same rationale as other copy/delta files: they rely on operator-provided Jinja variables not available in the test render context)

## ☑️ TO-DOs

- [ ] Test to do when deployed in QA: Validate on a partition that has been loaded by multiple tasks to confirm no data loss

## 🧪 Tests

- `test_dag_contains_all_tasks` — unchanged, task_id `insert_exomiser` is preserved
- `test_queries.py` — updated skip list to exclude `exomiser_copy_partition` and `exomiser_insert_partition_delta`
- `test_exomiser_insert.py` — no changes needed (covers staging broker load only)

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The root cause was that the JOIN on `starrocks_snv_tmp_variant` served a dual purpose: fetching `locus_id` (needed, since it's not in staging_exomiser) and implicitly filtering to the current task's variants (too narrow for an OVERWRITE). The partition swap pattern resolves this cleanly — the copy step preserves rows for other seq_ids, and the insert step adds only the current task's rows.
- `sequencing_ids` (containing `seq_ids` / `deleted_seq_ids`) replaces `{"part": "{{ params.part }}"}` as the parameters for `insert_exomiser`; `part` is now provided via the Jinja `{{ partition }}` context injected by the operator.
