### PR TITLE
SJRA-1419: make dags compatible with airflow 2 and airflow 3

### DIFF
--- a/radiant/dags/diagnostics.py
+++ b/radiant/dags/diagnostics.py
@@ -5,7 +5,7 @@ from radiant.dags import DEFAULT_ARGS, NAMESPACE
 
 with DAG(
     dag_id=f"{NAMESPACE}-diagnostic",
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
     default_args=DEFAULT_ARGS,
     tags=["radiant", "starrocks", "manual", "dns"],

--- a/radiant/dags/import_germline_snv_vcf.py
+++ b/radiant/dags/import_germline_snv_vcf.py
@@ -1,10 +1,10 @@
 import logging
 import os
 
+import pendulum
 from airflow import DAG
 from airflow.decorators import task
 from airflow.models import Param
-from airflow.utils.dates import days_ago
 
 from radiant.dags import IS_AWS, NAMESPACE, ECSEnv, get_namespace
 from radiant.dags.operators.utils import s3_store_content
@@ -35,8 +35,8 @@ dag_params = {
 with DAG(
     dag_id=f"{NAMESPACE}-import-germline-snv-vcf",
     default_args=default_args,
-    start_date=days_ago(1),
-    schedule_interval=None,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
     tags=["radiant", "iceberg"],
     dag_display_name="Radiant - Import Germline SNV VCF",
     catchup=False,

--- a/radiant/dags/import_open_data.py
+++ b/radiant/dags/import_open_data.py
@@ -2,8 +2,8 @@ import logging
 
 from airflow import DAG
 from airflow.models import Param
+from airflow.models.baseoperator import chain
 from airflow.operators.empty import EmptyOperator
-from airflow.utils.helpers import chain
 
 from radiant.dags import NAMESPACE
 from radiant.tasks.starrocks.operator import RadiantStarrocksLoadOperator, RadiantStarRocksOperator, SubmitTaskOptions
@@ -42,7 +42,7 @@ dag_params = {
 with DAG(
     dag_id=f"{NAMESPACE}-import-open-data",
     dag_display_name="Radiant - Import Open Data",
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
     default_args=default_args,
     params=dag_params,

--- a/radiant/dags/init-qa-clinical-data.py
+++ b/radiant/dags/init-qa-clinical-data.py
@@ -14,12 +14,12 @@ dag_params = {
 
 with DAG(
     dag_id=f"{NAMESPACE}-init-simulated-clinical-data",
-    schedule_interval=None,
     catchup=False,
     default_args=DEFAULT_ARGS,
     tags=["radiant", "postgres", "manual", "qa"],
     dag_display_name="[QA] Radiant - Init Simulated Clinical Data",
     params=dag_params,
+    schedule=None,
 ) as dag:
     _mapping = get_radiant_mapping()
     _mapping = {key: value.replace("radiant_jdbc", "radiant").replace("`", "") for key, value in _mapping.items()}

--- a/radiant/dags/init_iceberg_tables.py
+++ b/radiant/dags/init_iceberg_tables.py
@@ -1,8 +1,8 @@
 import logging
 import os
 
+import pendulum
 from airflow import DAG
-from airflow.utils.dates import days_ago
 
 from radiant.dags import IS_AWS, NAMESPACE, ECSEnv, get_namespace
 
@@ -17,8 +17,8 @@ LOGGER = logging.getLogger(__name__)
 with DAG(
     dag_id=f"{NAMESPACE}-init-iceberg-tables",
     default_args=default_args,
-    start_date=days_ago(1),
-    schedule_interval=None,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
     tags=["radiant", "iceberg", "manual"],
     dag_display_name="Radiant - Init Iceberg Tables",
     catchup=False,

--- a/radiant/dags/init_starrocks_tables.py
+++ b/radiant/dags/init_starrocks_tables.py
@@ -1,6 +1,6 @@
 from airflow import DAG
 from airflow.models import Param
-from airflow.utils.helpers import chain
+from airflow.models.baseoperator import chain
 
 from radiant.dags import DEFAULT_ARGS, NAMESPACE, SQL_DIR
 from radiant.tasks.starrocks.operator import RadiantStarRocksOperator
@@ -20,7 +20,7 @@ dag_params = {
 
 with DAG(
     dag_id=f"{NAMESPACE}-init-starrocks-tables",
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
     default_args=DEFAULT_ARGS,
     params=dag_params,


### PR DESCRIPTION
## 📌 Context

We are preparing to migrate Radiant to Airflow 3. However, since Airflow is shared with other teams in CQDG, we will need to support both Airflow 2 and Airflow 3 for some time.

As a first step, this PR introduces minimal changes to the DAGs to ensure they compile and run correctly on both Airflow 2 and Airflow 3.06. All workflows should continue to function as expected in Airflow 2.


## 📝 Changes

<!-- List the main changes in this PR. -->

- Updated imports for Airflow 3 compatibility.
- Replaced schedule_interval=None with schedule=None.
- Replaced days_ago with static start dates.

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

- [ ] Make sure to run dags one last time on both airflow 2 and airflow 3 (with sandbox poc branch)

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

-  Ensure all unit tests pass locally.
- Validate that the DAGs run successfully in the sandbox environment with both Airflow 2 and Airflow 3: https://github.com/radiant-network/radiant-portal-sandbox/pull/10

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

-  Using dynamic start dates is considered an anti-pattern in Airflow. This is because Airflow periodically re-parses DAG files to detect changes, and a dynamic start date will change on each parse, potentially breaking time-based scheduling and causing unexpected behavior.
- In Airflow 3, if the schedule parameter is not set, its default value is None (the DAG is not scheduled). However, in Airflow 2, the default schedule is daily (the DAG runs once per day) if no schedule is specified, as documented here:
https://www.astronomer.io/docs/learn/2.x/scheduling-in-airflow#parameters