### PR TITLE
fix: SJRA-1171 return 0 instead of NULL for nb_snv with no overlap

### DIFF
--- a/radiant/dags/sql/radiant/germline_cnv_occurrence_insert_partition_delta.sql
+++ b/radiant/dags/sql/radiant/germline_cnv_occurrence_insert_partition_delta.sql
@@ -9,11 +9,12 @@ WITH cytoband AS (SELECT o.name, o.seq_id, array_agg(c.cytoband) AS cytoband
                     AND g.end >= o.start
                WHERE o.seq_id IN %(seq_ids)s
                GROUP BY o.name, o.seq_id),
-     snv AS (SELECT o.name, o.seq_id, COUNT(1) AS nb_snv
+     snv AS (SELECT o.name,
+                    o.seq_id,
+                    SUM(CASE WHEN s.has_alt = true AND s.chromosome = o.chromosome AND s.start <= o.end AND s.start >= o.start THEN 1 ELSE 0 END) AS nb_snv
              FROM {{ mapping.iceberg_germline_cnv_occurrence }} o
-             JOIN {{ mapping.iceberg_germline_snv_occurrence }} s ON s.chromosome = o.chromosome AND s.start <= o.end
-                    AND s.start >= o.start AND o.seq_id = s.seq_id
-             WHERE s.has_alt = true AND s.seq_id IN %(seq_ids)s AND o.seq_id IN %(seq_ids)s AND s.part={{ partition }}
+             JOIN {{ mapping.iceberg_germline_snv_occurrence }} s ON o.seq_id = s.seq_id
+             WHERE s.seq_id IN %(seq_ids)s AND o.seq_id IN %(seq_ids)s AND s.part={{ partition }}
              GROUP BY o.name, o.seq_id),
     gnomad_overlaps AS (
         SELECT


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
  In the germline CNV occurrences insertion SQL, the `nb_snv` calculation
  (number of SNVs overlapping a CNV) was returning NULL when no SNV
  overlapped the CNV, whereas the expected value is 0.  

This PR fixes thecalculation to correctly distinguish the two cases:
  - `nb_snv = 0`: SNVs exist for this sequencing, but none (with `has_alt = true`) overlap this CNV.
  - `nb_snv = NULL`: no SNV data available for this sequencing (the CNV row finds no match in the JOIN).

## 📝 Changes

<!-- List the main changes in this PR. -->
-  Modified the snv subquery (CTE) in cnv insertion script.  The JOIN no longer filters directly on overlap conditions. These are evaluated inside a SUM statement instead.

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->
- [ ] 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->
- Base on my investigation, there would be no test to update.
- I tested manually in the sandbox and inspected the content of the germline__cnv__occurrence table before / after fix. I could see that, for the nb_snv column, the only change is that NULL values are replaced by 0. The other values remained unchanged.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- I considered adding a unit test for this change. I decided not to do it for now, because the setup effort would be significant (it involves open data tables as well), and, also,  whether we want this kind of test in this repo feels like a question that deserves a team discussion to me.  If you'd like to include this effort in this PR or that we create a dedicated ticket for this, please let me know.
- I worry a bit about the performance impact of the query modification, as the JOIN will return more matches than before. I think it should still be reasonable since we keep the filters on seq_id and partition, but if you disagree, please let me know.