### PR TITLE
feat: SJRA-1530 add env var for service account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ logs
 
 # ECS related files
 *plugins.zip
+
+*.DS_STORE

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -12,6 +12,7 @@ class BaseK8SOperator:
         return dict(
             namespace=os.getenv("RADIANT_TASK_OPERATOR_KUBERNETES_NAMESPACE"),
             image=os.getenv("RADIANT_TASK_OPERATOR_IMAGE"),
+            service_account_name=os.getenv("RADIANT_TASK_OPERATOR_SERVICE_ACCOUNT_NAME"),
             image_pull_policy="IfNotPresent",
             get_logs=True,
             is_delete_operator_pod=True,


### PR DESCRIPTION
## 📌 Context

We need to congigure serivce account from an environment variable. On EKS, the iam permissions comes from a module named pod identity. This module associate a kubernetes service account to a IAM role. So we cannot use default service.account

## 📝 Changes

- Fetch service account from env var. KubernetesPodOperator fallback to default if nil.


## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

