### PR TITLE
feat: SJRA-1553 Add data QA on snv__variant table

### DIFF
--- a/data-qa/.gitignore
+++ b/data-qa/.gitignore
@@ -1,5 +1,6 @@
 .venv/
 .env
+.user.yml
 target/
 logs/
 dbt_packages/

--- a/data-qa/README.md
+++ b/data-qa/README.md
@@ -13,19 +13,69 @@ invariants on tables.
 | Should Not Contain Only Null   | `should_not_contain_only_null` (dynamic, custom)              |
 | Should Not Contain Same Value  | `should_not_contain_same_value` (dynamic, custom)             |
 | Should Be Unique               | `tests: [unique]` (built-in, displayed via custom `name:`)    |
-| Values Contained In Dictionary | `tests: [accepted_values: {values: [...]}]`                   |
+| Values Contained In Dictionary | scalar: `accepted_values` (built-in); array: `accepted_values_in_array` (custom) |
+| Should Be Within Range         | `should_be_within_range` (dynamic, custom)                    |
 | Cross-Field / Custom Invariant | Singular tests in `tests/*.sql`                               |
 
-The two **dynamic** tests (`should_not_contain_only_null`,
-`should_not_contain_same_value`) introspect the target table's columns at
-compile time and emit one check per column, minus an explicit `except` list.
-New columns are picked up on the next run automatically; dropped columns
-disappear from the check. Only the `except` list needs maintenance.
+Three **dynamic** tests introspect the table's columns at compile time and
+emit one check per column: `should_not_contain_only_null` and
+`should_not_contain_same_value` sweep all columns minus an `except` list;
+`should_be_within_range` sweeps only columns matching a `like` substring
+(default `_pf_`). New matching columns are picked up automatically; only the
+`except` / `like` config needs maintenance.
 
 For the built-in dbt tests (`not_null`, `unique`), the YAML keeps standard
 dbt syntax — only the displayed name is overridden via `name:` so that
 TestQuality / JUnit reports show consistent vocabulary
 (`should_not_contain_null_<col>`, `should_be_unique_<col>`).
+
+### Purpose of `Values Contained In Dictionary` tests
+
+These tests exist to **detect new upstream values that the portal does not
+yet handle**. "The portal" hardcodes behaviour in two places:
+
+1. **Backend Go facets** — `backend/internal/repository/facets.go`
+   (`NewFacetsRepository`). The closed list of values the API surfaces
+   for a column when the frontend calls it with `withDictionary: true`.
+   A value not in this list **cannot be selected as a filter** even if
+   it appears in result rows.
+2. **Frontend i18n** — `frontend/translations/common/*.json`. The closed
+   list of values that have hardcoded translations, badge colours,
+   abbreviations, icons, sort order, etc. A value not in this list
+   **renders as raw text in the UI**.
+
+A new upstream value not present in **either** source is fully unhandled.
+A value present in only one is a portal-internal inconsistency (out of
+scope for data-qa, but worth flagging).
+
+Each test's accepted-values list mirrors the relevant source(s) — the
+**union** of backend facets and frontend i18n for scalar columns. Keep a
+`mirrors facets.go + i18n — keep in sync` comment next to the list so
+future maintainers know what to update.
+
+Rule of thumb:
+
+- **Keep the test** if the column drives portal behaviour through a
+  closed set of values in either backend facets or frontend i18n (e.g.
+  `consequences`, `vep_impact`, `variant_class`, `clinvar_interpretation`,
+  `chromosome` — all hardcoded somewhere).
+- **Drop the test** if the column is free-form / informational only and
+  the portal renders the raw value as-is everywhere (no backend facet,
+  no frontend i18n). Maintaining a dictionary the portal doesn't depend
+  on is busywork that will rot.
+
+Scalar columns use dbt's built-in `accepted_values`. Array columns use the
+custom `accepted_values_in_array` generic test (`macros/`), which unnests
+the array and flags any element not in `values`. Both are declared in the
+source YAML with a `name:` (append the Jira id when a ticket tracks a known
+gap, e.g. `..._SJRA1552`) and a `values:` list.
+
+Values are tested **raw / case-sensitive** — no normalization. For array
+columns the dictionary therefore mirrors backend `facets.go` in its data
+case (e.g. `mature_miRNA_variant`, `TFBS_ablation`); frontend i18n short
+forms are sanitized lookup keys that never appear in raw data, so they're
+out of scope. Singular tests under `tests/` are now reserved for cross-field
+invariants that don't fit a generic test (e.g. `no_star_alternate`).
 
 ## Prerequisites
 
@@ -46,7 +96,13 @@ dbt deps                     # installs dbt_utils
 ## Configuration
 
 Connection params come from env vars (no secrets in the repo). Copy
-`.env.example` to `.env` and fill in the values, or export them in your shell:
+`.env.example` to `.env` and fill in the values, then load it into your shell:
+
+```bash
+set -a && source .env && set +a   # export every var from .env
+```
+
+Or export them directly in your shell:
 
 ```bash
 export SR_HOST=localhost

--- a/data-qa/macros/test_accepted_values_in_array.sql
+++ b/data-qa/macros/test_accepted_values_in_array.sql
@@ -1,0 +1,21 @@
+{#
+  Generic test — Accepted Values for an ARRAY column. The built-in
+  `accepted_values` only handles scalars; this unnests the array and
+  flags any element not in `values` (raw, case-sensitive). Returns one
+  row per distinct unknown value.
+#}
+
+{% test accepted_values_in_array(model, column_name, values) %}
+
+select distinct
+    val as invalid_value
+from {{ model }} s,
+     unnest(s.{{ column_name }}) as t(val)
+where val is not null
+  and val not in (
+    {%- for v in values %}
+    '{{ v }}'{{ "," if not loop.last }}
+    {%- endfor %}
+  )
+
+{% endtest %}

--- a/data-qa/macros/test_should_be_within_range.sql
+++ b/data-qa/macros/test_should_be_within_range.sql
@@ -1,0 +1,36 @@
+{#
+  Generic test — Should Be Within Range, dynamic over columns. Every value
+  of the targeted columns must fall in [min_value, max_value]. Columns are
+  picked dynamically by `like` substring match (default `_pf_`: the
+  frequency/ratio columns), so new matching columns are covered on the next
+  run automatically. Returns one row per column that has an out-of-range
+  value. NULLs are not flagged (a null ratio is not out of range).
+#}
+
+{% test should_be_within_range(model, like='_pf_', min_value=0, max_value=1) %}
+
+    {%- set columns = adapter.get_columns_in_relation(model) -%}
+    {%- set checked = [] -%}
+    {%- for col in columns if like in col.name -%}
+        {%- do checked.append(col.name) -%}
+    {%- endfor -%}
+
+    {%- if checked | length == 0 -%}
+        select 1 as dummy where 1 = 0
+    {%- else -%}
+        select column_name, n_out_of_range
+        from (
+            {%- for col in checked %}
+            select
+                '{{ col }}' as column_name,
+                count(*) as n_out_of_range
+            from {{ model }}
+            where {{ adapter.quote(col) }} < {{ min_value }}
+               or {{ adapter.quote(col) }} > {{ max_value }}
+            {%- if not loop.last %} union all {% endif %}
+            {%- endfor %}
+        ) checks
+        where n_out_of_range > 0
+    {%- endif -%}
+
+{% endtest %}

--- a/data-qa/sources/snv.yml
+++ b/data-qa/sources/snv.yml
@@ -3,48 +3,31 @@ version: 2
 sources:
   - name: radiant
     schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
-    description: "Radiant StarRocks analytical schema."
     tables:
       - name: snv__variant
-        description: |
-          Aggregated SNV variants (one row per locus). StarRocks primary key is
-          locus_id. Columns marked NULL in the Data Definition Language (DDL)
-          are tested here for the stricter invariants that the loading pipeline
-          is expected to honor.
         tests:
-          # Should Not Contain Only Null — dynamic sweep over all columns.
-          # Schema evolution is handled automatically: new columns are picked
-          # up on the next run, dropped columns disappear from the check.
-          # Only `except` needs maintenance (legitimate exclusions).
+          # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
-              name: snv_variant__should_not_contain_only_null
+              # SJRA-1550 mane_select
+              name: snv_variant__should_not_contain_only_null_SJRA-1550
               except:
-                # Already covered by stricter `not_null` tests below — no
-                # value in re-checking them via the dynamic sweep.
+                # Already covered by snv_variant__should_not_contain_null__*
                 - locus_id
                 - chromosome
                 - start
                 - reference
                 - alternate
                 - locus
-                # FIXME: MANE annotation is entirely absent in QA — mane_select
-                # is all-NULL (and is_mane_select / is_mane_plus are all-FALSE,
-                # see not_constant below). Investigate whether MANE is meant to
-                # be loaded in QA.
-                - mane_select
 
-          # Should Not Contain Same Value — dynamic sweep over all columns.
-          # Same evolution semantics as above.
+          # --- Should Not Contain Same Value ---------------------------------
           - should_not_contain_same_value:
-              name: snv_variant__should_not_contain_same_value
+              # SJRA-1550 is_mane_select is_mane_plus
+              name: snv_variant__should_not_contain_same_value_SJRA-1550
               except:
-                # Unique columns: count(distinct) == row_count, the test
-                # passes trivially but it's expensive on a 16M-row table.
+                # Already covered by snv_variant__should_be_unique__* 
                 - locus_id
                 - locus
-                # WGS-only QA dataset: every whole-exome (WXS) frequency /
-                # count column is constant (all 0). Legitimate environment
-                # limitation — re-check once QA carries WXS data.
+                # WGS-only QA dataset
                 - germline_pc_wxs
                 - germline_pn_wxs
                 - germline_pc_wxs_affected
@@ -57,61 +40,119 @@ sources:
                 - somatic_pc_tn_wxs
                 - somatic_pn_tn_wxs
                 - somatic_pf_tn_wxs
-                # FIXME: same MANE gap as above — these flags are FALSE for all
-                # 16M variants. Suspected missing MANE annotation in QA, not a
-                # benign constant. Investigate.
-                - is_mane_select
-                - is_mane_plus
+
+          # --- Should Be Within Range ----------------------------------------
+          # pf frequency ratios must be in [0,1] (defaults: like '_pf_', 0..1)
+          - should_be_within_range:
+              name: snv_variant__should_be_within_range_pf
         columns:
-          # --- Should Not Contain Null ---------------------------------------
           - name: locus_id
-            description: "Primary key. Must be present and unique."
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__locus_id
+              # --- Should Be Unique ------------------------------------------
               - unique:
                   name: snv_variant__should_be_unique__locus_id
           - name: chromosome
-            description: "CHAR(2). One of 1..22, X, Y, M (no 'chr' prefix)."
+            description: "CHAR(2)."
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__chromosome
+              # --- Accepted Values -------------------------------------------
+              # mirrors facets.go + i18n — keep in sync
               - accepted_values:
-                  name: snv_variant__accepted_values_chromosome
+                  # SJRA-1551: M
+                  name: snv_variant__accepted_values_chromosome_SJRA-1551
                   values:
                     ['1','2','3','4','5','6','7','8','9','10','11','12',
                      '13','14','15','16','17','18','19','20','21','22',
-                     'X','Y','M']
+                     'X','Y']
           - name: start
-            description: "1-based start position. Nullable in DDL but always populated in practice."
+            description: "1-based start position."
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__start
           - name: reference
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__reference
           - name: alternate
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__alternate
           - name: locus
-            description: "Canonical locus string. Must be unique per variant."
             tests:
+              # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_variant__should_not_contain_null__locus
+              # --- Should Be Unique ------------------------------------------
               - unique:
                   name: snv_variant__should_be_unique__locus
-
-          # --- Values Contained In Dictionary --------------------------------
           - name: vep_impact
             tests:
+              # --- Accepted Values -------------------------------------------
+              # mirrors impact-indicator.tsx + facets.go — keep in sync
               - accepted_values:
                   name: snv_variant__accepted_values_vep_impact
                   values: ['HIGH', 'MODERATE', 'LOW', 'MODIFIER']
                   config:
                     where: "vep_impact is not null"
-
-          # Note: per-column `at_least_one` and `not_constant` tests were
-          # replaced by the dynamic `should_not_contain_only_null` and
-          # `should_not_contain_same_value` table-level tests declared above.
+          - name: variant_class
+            description: "Sequence Ontology variant class."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # mirrors facets.go + i18n — keep in sync
+              - accepted_values:
+                  name: snv_variant__accepted_values_variant_class
+                  values:
+                    ['insertion', 'deletion', 'SNV', 'indel',
+                     'substitution', 'sequence_alteration']
+                  config:
+                    where: "variant_class is not null"
+          - name: clinvar_interpretation
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # mirrors facets.go + i18n — keep in sync
+              - accepted_values_in_array:
+                  # SJRA-1552: established_risk_allele -> Established_risk_allele,
+                  #            low_penetrance -> _low_penetrance
+                  name: snv_variant__accepted_values_clinvar_interpretation_SJRA-1552
+                  values:
+                    ['Affects', 'association_not_found', 'association', 'Benign',
+                     'confers_sensitivity', 'Conflicting_classifications_of_pathogenicity',
+                     'conflicting_data_from_submitters',
+                     'Conflicting_interpretations_of_pathogenicity', 'drug_response',
+                     'established_risk_allele', 'Likely_benign',
+                     'likely_pathogenic_low_penetrance', 'Likely_pathogenic',
+                     'Likely_risk_allele', 'low_penetrance',
+                     'no_classification_for_the_single_variant', 'not_provided', 'other',
+                     'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
+                     'Uncertain_risk_allele', 'Uncertain_significance']
+          - name: consequences
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # mirrors facets.go + i18n — keep in sync
+              - accepted_values_in_array:
+                  name: snv_variant__accepted_values_consequences
+                  values:
+                    ['3_prime_UTR_variant', '5_prime_UTR_variant',
+                     'coding_sequence_variant', 'downstream_gene_variant',
+                     'feature_elongation', 'feature_truncation', 'frameshift_variant',
+                     'incomplete_terminal_codon_variant', 'inframe_deletion',
+                     'inframe_insertion', 'intergenic_variant', 'intron_variant',
+                     'mature_miRNA_variant', 'missense_variant', 'NMD_transcript_variant',
+                     'non_coding_transcript_exon_variant', 'non_coding_transcript_variant',
+                     'protein_altering_variant', 'regulatory_region_ablation',
+                     'regulatory_region_amplification', 'regulatory_region_variant',
+                     'splice_acceptor_variant', 'splice_donor_5th_base_variant',
+                     'splice_donor_region_variant', 'splice_donor_variant',
+                     'splice_polypyrimidine_tract_variant', 'splice_region_variant',
+                     'start_lost', 'start_retained_variant', 'stop_gained', 'stop_lost',
+                     'stop_retained_variant', 'synonymous_variant', 'TF_binding_site_variant',
+                     'TFBS_ablation', 'TFBS_amplification', 'transcript_ablation',
+                     'transcript_amplification', 'upstream_gene_variant']

--- a/data-qa/tests/snv_variant__validate_no_star_alternate.sql
+++ b/data-qa/tests/snv_variant__validate_no_star_alternate.sql
@@ -1,8 +1,6 @@
 {#
-  Singular test — Should Be Empty: the aggregated variant table must not
-  contain the spanning-deletion placeholder allele ('*'). Such rows are a
-  VCF artifact and are expected to be filtered out upstream. A singular
-  test passes when this query returns zero rows.
+  `*` in `alternate` is the spanning-deletion placeholder (VCF artifact),
+  expected to be filtered out upstream — this table should contain none.
 #}
 
 select


### PR DESCRIPTION
# feat: SJRA-1553 Add data QA on snv__variant table

## 📌 Context

Enrichissement de la suite de tests data-qa (dbt) sur la table `snv__variant`. L'objectif principal est de couvrir la table par des tests de **dictionnaire de valeurs** (« Values Contained In Dictionary ») afin de détecter les nouvelles valeurs en amont que le portail ne gère pas encore — soit via les facets backend (`backend/internal/repository/facets.go`), soit via l'i18n frontend (`frontend/translations/common/*.json`). Une valeur absente des deux sources est entièrement non gérée.

On ajoute aussi un nouveau test de plage de valeurs pour les colonnes de fréquence, et on uniformise le nommage des tests existants.

## 📝 Changes

- **Nouveau test générique `accepted_values_in_array`** (`macros/test_accepted_values_in_array.sql`) : équivalent de `accepted_values` pour les colonnes de type tableau. Désimbrique le tableau et signale toute valeur absente de la liste (brute, sensible à la casse).
- **Nouveau test générique dynamique `should_be_within_range`** (`macros/test_should_be_within_range.sql`) : vérifie que les valeurs des colonnes ciblées sont dans `[min_value, max_value]`. Sélection dynamique des colonnes par sous-chaîne `like` (défaut `_pf_`, les ratios de fréquence, plage `[0,1]`) — les nouvelles colonnes correspondantes sont couvertes automatiquement. Les NULL ne sont pas signalés.
- **`sources/snv.yml`** :
  - Ajout des tests de dictionnaire : `vep_impact`, `variant_class`, `chromosome` (scalaires) et `clinvar_interpretation`, `consequences` (tableaux). Chaque liste reflète l'union des facets backend + i18n frontend, avec un commentaire `mirrors facets.go + i18n — keep in sync`.
  - Ajout du test de plage `snv_variant__should_be_within_range_pf` sur les ratios de fréquence.
  - Retrait de la valeur `M` de la liste acceptée de `chromosome` (gap tracké **SJRA-1551**).
  - Nettoyage des FIXME MANE remplacés par des tags Jira dans les noms de tests : `should_not_contain_only_null` et `should_not_contain_same_value` taggés **SJRA-1550** (mane_select tout NULL, is_mane_select / is_mane_plus constants en QA).
  - `clinvar_interpretation` taggé **SJRA-1552** (écarts de casse connus : `established_risk_allele`, `low_penetrance`).
  - Uniformisation des `except` (commentaires renvoyant aux tests `not_null`/`unique` plutôt qu'aux descriptions verbeuses) ; allègement des descriptions de colonnes.
- **`README.md`** : documentation des trois tests dynamiques, de la distinction scalaire/tableau pour les dictionnaires, et d'une nouvelle section « Purpose of Values Contained In Dictionary tests » expliquant la règle keep/drop (garder si la colonne pilote un comportement du portail via un ensemble fermé de valeurs ; retirer si la valeur est libre/informative). Ajout de l'astuce de chargement du `.env` (`set -a && source .env && set +a`).
- **`.gitignore`** : ajout de `.user.yml`.
- **`tests/snv_variant__validate_no_star_alternate.sql`** : commentaire condensé (aucun changement logique).

> Les tags Jira encore présents dans le code (**SJRA-1550**, **SJRA-1551**, **SJRA-1552**) correspondent à des écarts amont connus, partiellement résolus, qui restent à investiguer/corriger côté pipeline ou portail.

## 🧪 Tests

Les tests dbt impactés ont été exécutés localement et passent avec succès.

```bash
cd data-qa
dbt test --select source:radiant.snv__variant
```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1553 (principal)
- SJRA-1550, SJRA-1551, SJRA-1552 (gaps amont connus, suivis)

<!-- End JIRA Issues -->
