### PR TITLE
feat: SJRA-1560 Add data QA on germline__snv__occurrence table

### DIFF
--- a/data-qa/README.md
+++ b/data-qa/README.md
@@ -65,8 +65,9 @@ Rule of thumb:
   on is busywork that will rot.
 
 Scalar columns use dbt's built-in `accepted_values`. Array columns use the
-custom `accepted_values_in_array` generic test (`macros/`), which unnests
-the array and flags any element not in `values`. Both are declared in the
+custom `accepted_values_in_array` generic test (`macros/`), which `array_filter`s
+each array down to the offending elements *before* unnesting (so valid rows
+emit nothing instead of exploding) and flags any element not in `values`. Both are declared in the
 source YAML with a `name:` (append the Jira id when a ticket tracks a known
 gap, e.g. `..._SJRA1552`) and a `values:` list.
 
@@ -123,8 +124,9 @@ dbt debug
 # Run all data tests
 dbt test
 
-# Just the snv__variant tests
-dbt test --select source:radiant.snv__variant
+# Scope to one table (list available tables with the command below)
+dbt test --select source:radiant.<table>
+dbt list --resource-type source     # shows every source:radiant.<table>
 ```
 
 dbt writes detailed results to `target/run_results.json`. Each failing test
@@ -135,27 +137,22 @@ investigate.
 
 ```
 data-qa/
-├── dbt_project.yml      # minimal — no models, just tests
-├── profiles.yml         # env-var driven, single target
-├── packages.yml         # dbt_utils
-├── requirements.txt
-├── macros/
-│   ├── test_should_not_contain_only_null.sql  # dynamic null-coverage sweep
-│   └── test_should_not_contain_same_value.sql # dynamic constant-value sweep
-├── sources/
-│   └── snv.yml          # snv__variant generic tests
-├── tests/
-│   └── snv_variant__validate_no_star_alternate.sql  # singular test example
-├── scripts/
-│   ├── run_results_to_junit.py  # run_results.json -> JUnit XML (stdlib)
-│   └── run_qa.sh                # reusable core: dbt test + convert (CI-ready)
-├── reports/             # generated JUnit XML (gitignored) for TestQuality
-└── models/              # empty by design
+├── macros/    # custom generic tests (dynamic sweeps, array accepted-values)
+├── sources/   # source + generic-test declarations, one YAML per table
+├── tests/     # singular tests (cross-field invariants), one SQL per check
+├── scripts/   # dbt test runner + JUnit conversion (CI-ready)
+├── reports/   # generated JUnit XML (gitignored) for TestQuality
+└── models/    # empty by design
 ```
+
+Root also holds the usual dbt config (`dbt_project.yml`, `profiles.yml`,
+`packages.yml`, `requirements.txt`).
 
 ## Adding tests for another table
 
-1. Add a `sources/<name>.yml` entry under `sources[0].tables`.
+1. Add a `sources/<table_name>.yml` file (one per table, named after it).
+   Each declares the shared `radiant` source with a single table — dbt merges
+   tables across files as long as no `(source, table)` pair is duplicated.
 2. List its columns with the relevant generic tests, and/or attach
    `should_not_contain_only_null` / `should_not_contain_same_value` at the
    table level with an appropriate `except` list.

--- a/data-qa/macros/test_accepted_values_in_array.sql
+++ b/data-qa/macros/test_accepted_values_in_array.sql
@@ -1,8 +1,8 @@
 {#
   Generic test — Accepted Values for an ARRAY column. The built-in
-  `accepted_values` only handles scalars; this unnests the array and
-  flags any element not in `values` (raw, case-sensitive). Returns one
-  row per distinct unknown value.
+  `accepted_values` only handles scalars; this flags any element not in
+  `values` (raw, case-sensitive). Returns one row per distinct unknown
+  value.
 #}
 
 {% test accepted_values_in_array(model, column_name, values) %}
@@ -10,12 +10,11 @@
 select distinct
     val as invalid_value
 from {{ model }} s,
-     unnest(s.{{ column_name }}) as t(val)
-where val is not null
-  and val not in (
-    {%- for v in values %}
-    '{{ v }}'{{ "," if not loop.last }}
-    {%- endfor %}
-  )
+     unnest(array_filter(
+       s.{{ column_name }},
+       x -> x is not null and not array_contains([
+         {%- for v in values %}'{{ v }}'{{ "," if not loop.last }}{%- endfor %}
+       ], x)
+     )) as t(val)
 
 {% endtest %}

--- a/data-qa/sources/germline_snv_occurrence.yml
+++ b/data-qa/sources/germline_snv_occurrence.yml
@@ -1,0 +1,119 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: germline__snv__occurrence
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              # SJRA-1559: info_culprit info_haplotype_score info_vqslod info_ds info_r2_5p_bias info_inbreed_coeff
+              name: germline_snv_occurrence__should_not_contain_only_null_SJRA-1559
+              except:
+                # Already covered by germline_snv_occurrence__should_not_contain_null__*
+                - part
+                - seq_id
+                - task_id
+                - locus_id
+                - phased
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: germline_snv_occurrence__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - part
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele-depth ratios must be in [0,1] (defaults: like 'ad_ratio', 0..1)
+          - should_be_within_range:
+              name: germline_snv_occurrence__should_be_within_range_ad_ratio
+              like: ad_ratio
+        columns:
+          - name: part
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_snv_occurrence__should_not_contain_null__part
+          - name: seq_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_snv_occurrence__should_not_contain_null__seq_id
+          - name: task_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_snv_occurrence__should_not_contain_null__task_id
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_snv_occurrence__should_not_contain_null__locus_id
+          - name: phased
+            description: "BOOLEAN."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_snv_occurrence__should_not_contain_null__phased
+          - name: zygosity
+            description: "CHAR(3)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
+              # mirrors i18n — keep in sync
+              - accepted_values:
+                  name: germline_snv_occurrence__accepted_values_zygosity
+                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  config:
+                    where: "zygosity is not null"
+          - name: father_zygosity
+            description: "CHAR(3)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
+              # mirrors i18n — keep in sync
+              - accepted_values:
+                  name: germline_snv_occurrence__accepted_values_father_zygosity
+                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  config:
+                    where: "father_zygosity is not null"
+          - name: mother_zygosity
+            description: "CHAR(3)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
+              # mirrors i18n — keep in sync
+              - accepted_values:
+                  name: germline_snv_occurrence__accepted_values_mother_zygosity
+                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  config:
+                    where: "mother_zygosity is not null"
+          - name: transmission_mode
+            description: "VARCHAR(50)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/2ef5a320b986493694e8a820d467d017?v=2808ef9b129c443e853d939a5524805d
+              # mirrors facets.go + transmission-mode-badge.tsx — keep in sync
+              - accepted_values:
+                  name: germline_snv_occurrence__accepted_values_transmission_mode
+                  values:
+                    ['autosomal_dominant_de_novo', 'autosomal_dominant', 'autosomal_recessive',
+                     'x_linked_dominant_de_novo', 'x_linked_recessive_de_novo', 'x_linked_dominant',
+                     'x_linked_recessive', 'non_carrier_proband', 'unknown_parents_genotype',
+                     'unknown_father_genotype', 'unknown_mother_genotype', 'unknown_proband_genotype']
+                  config:
+                    where: "transmission_mode is not null"
+          - name: exomiser_acmg_classification
+            description: "VARCHAR(300)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/1135448b7a5543e19c968fea72ea82e7?v=50ac6d7244744fc1a6b3c30347acd5e4
+              # mirrors classification-badge.tsx + i18n — keep in sync
+              - accepted_values:
+                  name: germline_snv_occurrence__accepted_values_exomiser_acmg_classification
+                  values:
+                    ['pathogenic', 'likely_pathogenic', 'uncertain_significance',
+                     'likely_benign', 'benign']
+                  config:
+                    where: "exomiser_acmg_classification is not null"

--- a/data-qa/sources/snv_variant.yml
+++ b/data-qa/sources/snv_variant.yml
@@ -24,7 +24,7 @@ sources:
               # SJRA-1550 is_mane_select is_mane_plus
               name: snv_variant__should_not_contain_same_value_SJRA-1550
               except:
-                # Already covered by snv_variant__should_be_unique__* 
+                # Already covered by snv_variant__should_be_unique__*
                 - locus_id
                 - locus
                 # WGS-only QA dataset
@@ -61,14 +61,14 @@ sources:
               - not_null:
                   name: snv_variant__should_not_contain_null__chromosome
               # --- Accepted Values -------------------------------------------
-              # mirrors facets.go + i18n — keep in sync
+              # Notion: https://app.notion.com/p/ferlab/550fc21aed7a4de7a3636e80c6b3978a?v=2490f606225d4f60afe5088cdc77049c
+              # mirrors facets.go — keep in sync
               - accepted_values:
-                  # SJRA-1551: M
-                  name: snv_variant__accepted_values_chromosome_SJRA-1551
+                  name: snv_variant__accepted_values_chromosome
                   values:
                     ['1','2','3','4','5','6','7','8','9','10','11','12',
                      '13','14','15','16','17','18','19','20','21','22',
-                     'X','Y']
+                     'X','Y','M']
           - name: start
             description: "1-based start position."
             tests:
@@ -96,6 +96,7 @@ sources:
           - name: vep_impact
             tests:
               # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/08b7fcfc5a25414badffb256709d6521?v=59e0ecb4229d4bc08ddc538f76ae870f
               # mirrors impact-indicator.tsx + facets.go — keep in sync
               - accepted_values:
                   name: snv_variant__accepted_values_vep_impact
@@ -106,6 +107,7 @@ sources:
             description: "Sequence Ontology variant class."
             tests:
               # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/8baeb6e84ee24f0788a8154f8bfecdd9?v=6a806497b9d246d1b98def1df974e7c2
               # mirrors facets.go + i18n — keep in sync
               - accepted_values:
                   name: snv_variant__accepted_values_variant_class
@@ -117,25 +119,25 @@ sources:
           - name: clinvar_interpretation
             tests:
               # --- Accepted Values (array) -----------------------------------
+              # Notion: https://app.notion.com/p/ferlab/79b61815da5c4fbb898d65a6e88b5256?v=af0f09733b8345d3a68ee75dafabecfb
               # mirrors facets.go + i18n — keep in sync
               - accepted_values_in_array:
-                  # SJRA-1552: established_risk_allele -> Established_risk_allele,
-                  #            low_penetrance -> _low_penetrance
-                  name: snv_variant__accepted_values_clinvar_interpretation_SJRA-1552
+                  name: snv_variant__accepted_values_clinvar_interpretation
                   values:
                     ['Affects', 'association_not_found', 'association', 'Benign',
                      'confers_sensitivity', 'Conflicting_classifications_of_pathogenicity',
                      'conflicting_data_from_submitters',
                      'Conflicting_interpretations_of_pathogenicity', 'drug_response',
-                     'established_risk_allele', 'Likely_benign',
+                     'Established_risk_allele', 'Likely_benign',
                      'likely_pathogenic_low_penetrance', 'Likely_pathogenic',
                      'Likely_risk_allele', 'low_penetrance',
                      'no_classification_for_the_single_variant', 'not_provided', 'other',
                      'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
-                     'Uncertain_risk_allele', 'Uncertain_significance']
+                     'Uncertain_risk_allele', 'Uncertain_significance', '_low_penetrance']
           - name: consequences
             tests:
               # --- Accepted Values (array) -----------------------------------
+              # Notion: https://app.notion.com/p/ferlab/faa862446e4d4498a7238bd55e468b4f?v=2de0eadfa7d34ed49aa171c57e6e6c7e
               # mirrors facets.go + i18n — keep in sync
               - accepted_values_in_array:
                   name: snv_variant__accepted_values_consequences

--- a/data-qa/tests/germline_snv_occurrence__validate_no_wt_zygosity.sql
+++ b/data-qa/tests/germline_snv_occurrence__validate_no_wt_zygosity.sql
@@ -1,0 +1,18 @@
+{#
+  Occurrences are inserted only when the sample carries the alternate allele
+  (`has_alt = 1 in calls`, see germline_snv_occurrence_insert_partition_delta.sql:
+  `WHERE ... AND has_alt`). A WT (0/0) genotype carries no alt, so `zygosity`
+  should never be 'WT' in this table — these rows should have been filtered out
+  upstream. ('WT' is still in the accepted-values dictionary because it is a
+  valid, portal-handled zygosity in general — this asserts the stronger
+  table-specific invariant.)
+#}
+
+select
+    part,
+    seq_id,
+    task_id,
+    locus_id,
+    zygosity
+from {{ source('radiant', 'germline__snv__occurrence') }}
+where zygosity = 'WT'


### PR DESCRIPTION
# feat: SJRA-1560 Add data QA on germline__snv__occurrence table

## 📌 Context

Ce PR étend la suite de tests data QA (dbt) du dossier `data-qa/` à une nouvelle table : `germline__snv__occurrence`. Il en profite pour uniformiser la convention « un fichier YAML par table », améliorer le macro de test sur les colonnes de type tableau, et clore quelques écarts de dictionnaire identifiés précédemment.

## 📝 Changes

- **Nouvelle table couverte** : ajout de `sources/germline_snv_occurrence.yml` déclarant la source `radiant.germline__snv__occurrence` avec ses tests génériques :
  - `not_null` sur les colonnes clés (`part`, `seq_id`, `task_id`, `locus_id`, `phased`) ;
  - `should_not_contain_only_null` (avec `except`) et `should_not_contain_same_value` ;
  - `should_be_within_range` sur les ratios `ad_ratio` (intervalle `[0,1]`) ;
  - `accepted_values` sur `zygosity`, `father_zygosity`, `mother_zygosity`, `transmission_mode` et `exomiser_acmg_classification`, chaque liste reflétant le dictionnaire du portail (références Notion + sources `facets.go` / badges / i18n notées en commentaire).
- **Nouveau test singulier** : `tests/germline_snv_occurrence__validate_no_wt_zygosity.sql` valide l'invariant propre à la table — aucune occurrence ne devrait avoir une zygosité `WT`, puisque les occurrences ne sont insérées que lorsque l'échantillon porte l'allèle alternatif (`has_alt`). `WT` reste dans le dictionnaire car c'est une valeur valide en général.
- **Amélioration du macro** `test_accepted_values_in_array.sql` : le test applique désormais `array_filter` pour réduire chaque tableau aux seuls éléments fautifs *avant* le `unnest` ; les lignes valides n'émettent plus rien au lieu de « exploser » inutilement.
- **Renommage** `sources/snv.yml` → `sources/snv_variant.yml` pour respecter la convention « un YAML nommé d'après sa table ».
- **Écarts de dictionnaire résolus** dans `snv_variant.yml` (tags Jira retirés → bugs corrigés) :
  - `SJRA-1551` : ajout de `M` aux valeurs acceptées de `chromosome` ;
  - `SJRA-1552` : ajout de `Established_risk_allele` et `_low_penetrance` aux valeurs acceptées de `clinvar_interpretation`.
  - Les tags `SJRA-1550` et `SJRA-1559` demeurent : écarts encore ouverts (résolution partielle du dictionnaire).
- Ajout de liens Notion en commentaire sur plusieurs tests `accepted_values` pour documenter la source de vérité du dictionnaire.
- **README** mis à jour : nouvelle convention « un fichier YAML par table », description du comportement du test sur tableaux, et commandes dbt génériques (`dbt test --select source:radiant.<table>`, `dbt list --resource-type source`).

## 🧪 Tests

- Tests dbt exécutés localement sur les tables `germline__snv__occurrence` et `snv__variant` — passent avec succès.
- Lancer la suite ciblée :
  ```bash
  dbt test --select source:radiant.germline__snv__occurrence
  ```

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- SJRA-1560
- SJRA-1551 (résolu)
- SJRA-1552 (résolu)
<!-- End JIRA Issues -->
