### PR TITLE
upkeep: SJRA-1524 fix dag upload command to clean up stale files

### DIFF
--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -91,8 +91,12 @@ serves Airflow 2 and Airflow 3. Run this from the repo root. MWAA picks up DAGs
 from this path automatically; no restart needed.
 
 ```sh
-aws s3 cp --recursive radiant s3://radiant-tst-airflow-qa/dags/radiant --exclude="__pycache__/*" --exclude="*.pyc"
+aws s3 sync radiant s3://radiant-tst-airflow-qa/dags/radiant --delete --exclude="*__pycache__*" --exclude="*.pyc"
 ```
+
+> `sync --delete` removes from the bucket any file that no longer exists locally —
+> without it, DAGs deleted from the repo would linger in S3 and keep being parsed
+> by MWAA.
 
 ## Step 4 — Build and push the Radiant operator image
 


### PR DESCRIPTION
## 📌 Context

The MWAA deployment doc instructed using `aws s3 cp --recursive` to upload DAGs.  This never removes files from the bucket, so DAGs deleted from the repo would linger in S3 and keep being parsed by MWAA.

We adjust the command to avoid this.

## 📝 Changes

<!-- List the main changes in this PR. -->

-  Replace `aws s3 cp --recursive` with `aws s3 sync --delete` in `mwaa/README.md` so stale files are cleaned up from the
  S3 DAGs folder

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

- Test that the command work in chop qa environment 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->


## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->
