### PR TITLE
feat: SJRA-1562 Add data QA on somatic__snv__occurrence table

### DIFF
--- a/data-qa/sources/somatic_snv_occurrence.yml
+++ b/data-qa/sources/somatic_snv_occurrence.yml
@@ -1,0 +1,109 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: somatic__snv__occurrence
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: somatic_snv_occurrence__should_not_contain_only_null
+              except:
+                # Already covered by somatic_snv_occurrence__should_not_contain_null__*
+                - locus_id
+                - part
+                - task_id
+                - tumor_seq_id
+                # Constant by construction
+                - quality
+                # Not yet implemented
+                - normal_gt_status
+                - tumor_gt_status
+                # Probably same as SJRA-1559 (waiting for investigation)
+                - info_baseq_rank_sum
+                - info_culprit
+                - info_ds
+                - info_excess_het
+                - info_fraction_informative_reads
+                - info_fs
+                - info_haplotype_score
+                - info_hotspotallele
+                - info_inbreed_coeff
+                - info_old_record
+                - info_mapq
+                - info_mleac
+                - info_mleaf
+                - info_mq
+                - info_m_qrank_sum
+                - info_mq0
+                - info_qd
+                - info_read_pos_rank_sum
+                - info_r2_5p_bias
+                - info_sor
+                - info_vqslod
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: somatic_snv_occurrence__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - normal_calls
+                - normal_has_alt
+                - normal_zygosity
+                - part
+                - tumor_has_alt
+                # Single tumor-normal task QA dataset
+                - normal_seq_id
+                - task_id
+                - tumor_seq_id
+                - tumor_zygosity
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele-depth ratios must be in [0,1] (defaults: like 'ad_ratio', 0..1)
+          - should_be_within_range:
+              name: somatic_snv_occurrence__should_be_within_range_ad_ratio
+              like: ad_ratio
+        columns:
+          - name: part
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_snv_occurrence__should_not_contain_null__part
+          - name: task_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_snv_occurrence__should_not_contain_null__task_id
+          - name: tumor_seq_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_snv_occurrence__should_not_contain_null__tumor_seq_id
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_snv_occurrence__should_not_contain_null__locus_id
+          - name: tumor_zygosity
+            description: "CHAR(3)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
+              # mirrors i18n — keep in sync
+              - accepted_values:
+                  name: somatic_snv_occurrence__accepted_values_tumor_zygosity
+                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  config:
+                    where: "tumor_zygosity is not null"
+          - name: normal_zygosity
+            description: "CHAR(3)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
+              # mirrors i18n — keep in sync
+              - accepted_values:
+                  name: somatic_snv_occurrence__accepted_values_normal_zygosity
+                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  config:
+                    where: "normal_zygosity is not null"

--- a/data-qa/tests/somatic_snv_occurrence__validate_no_wt_tumor_zygosity.sql
+++ b/data-qa/tests/somatic_snv_occurrence__validate_no_wt_tumor_zygosity.sql
@@ -1,0 +1,18 @@
+{#
+  Occurrences are inserted only when the tumor sample carries the alternate
+  allele (`tumor_has_alt`, see somatic_snv_occurrence_insert_partition_delta.sql:
+  `WHERE ... AND COALESCE(o.tumor_has_alt, FALSE)`). A WT (0/0) genotype carries
+  no alt, so `tumor_zygosity` should never be 'WT' in this table — these rows
+  should have been filtered out upstream. ('WT' is still in the accepted-values
+  dictionary because it is a valid, portal-handled zygosity in general — this
+  asserts the stronger table-specific invariant.)
+#}
+
+select
+    part,
+    task_id,
+    tumor_seq_id,
+    locus_id,
+    tumor_zygosity
+from {{ source('radiant', 'somatic__snv__occurrence') }}
+where tumor_zygosity = 'WT'


### PR DESCRIPTION
# feat: SJRA-1562 Add data QA on somatic__snv__occurrence table

## 📌 Context

Ajout d'une couverture de data QA (dbt) sur la table `somatic__snv__occurrence`. L'objectif est de valider l'intégrité des données d'occurrences SNV somatiques et de faire ressortir les écarts attendus du jeu de données QA (paire tumeur-normal unique).

## 📝 Changes

- **Nouvelle source dbt** [`data-qa/sources/somatic_snv_occurrence.yml`](data-qa/sources/somatic_snv_occurrence.yml) déclarant la table `radiant.somatic__snv__occurrence` avec les tests suivants :
  - `should_not_contain_only_null` : vérifie qu'aucune colonne n'est entièrement nulle, avec une liste `except` documentée (colonnes déjà couvertes par les tests `not_null`, colonnes constantes par construction, colonnes non encore implémentées, et colonnes en attente d'investigation — probablement liées à SJRA-1559).
  - `should_not_contain_same_value` : détecte les colonnes à valeur unique, avec `except` pour les colonnes constantes par construction et celles propres au jeu QA à paire tumeur-normal unique.
  - `should_be_within_range` (`like: ad_ratio`) : valide que les ratios de profondeur allélique restent dans l'intervalle [0,1].
  - Tests `not_null` par colonne sur `part`, `task_id`, `tumor_seq_id` et `locus_id`.
  - Tests `accepted_values` sur `tumor_zygosity` et `normal_zygosity` (valeurs `HET`, `HOM`, `HEM`, `WT`, `UNK`), conditionnés sur la non-nullité. Ces dictionnaires reflètent l'i18n du portail et doivent rester synchronisés (référence Notion en commentaire).

- **Nouveau test singulier** [`data-qa/tests/somatic_snv_occurrence__validate_no_wt_tumor_zygosity.sql`](data-qa/tests/somatic_snv_occurrence__validate_no_wt_tumor_zygosity.sql) : assure que `tumor_zygosity` n'est jamais `'WT'` dans cette table. Un génotype WT (0/0) ne porte pas l'allèle alternatif, alors que les occurrences ne sont insérées que lorsque `tumor_has_alt` est vrai — ces lignes devraient donc être filtrées en amont. C'est un invariant propre à la table, plus fort que le dictionnaire `accepted_values` (où `WT` reste une valeur valide en général).

## 🧪 Tests

Les tests dbt de data QA ont été exécutés localement sur la table `somatic__snv__occurrence` et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- [SJRA-1562](https://ferlab.atlassian.net/browse/SJRA-1562)

<!-- End JIRA Issues -->


[SJRA-1562]: https://d3b.atlassian.net/browse/SJRA-1562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ