### PR TITLE
feat: SJRA-1565 Add data QA on germline__cnv__occurrence table

### DIFF
--- a/data-qa/sources/germline_cnv_occurrence.yml
+++ b/data-qa/sources/germline_cnv_occurrence.yml
@@ -1,0 +1,68 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: germline__cnv__occurrence
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: germline_cnv_occurrence__should_not_contain_only_null
+              except:
+                # Already covered by germline_cnv_occurrence__should_not_contain_null__*
+                - part
+                - task_id
+                - cnv_id
+                # Constant by construction
+                - svlen
+                - cipos
+                - ciend
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: germline_cnv_occurrence__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - part
+                - phased
+                - svtype
+
+          # --- Should Be Within Range ----------------------------------------
+          # gnomAD frequencies must be in [0,1] (defaults: 0..1)
+          - should_be_within_range:
+              name: germline_cnv_occurrence__should_be_within_range_gnomad_af
+              like: gnomad_af
+          - should_be_within_range:
+              name: germline_cnv_occurrence__should_be_within_range_gnomad_sf
+              like: gnomad_sf
+        columns:
+          - name: part
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_cnv_occurrence__should_not_contain_null__part
+          - name: task_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_cnv_occurrence__should_not_contain_null__task_id
+          - name: cnv_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: germline_cnv_occurrence__should_not_contain_null__cnv_id
+          - name: chromosome
+            description: "VARCHAR(20)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # Notion: https://app.notion.com/p/ferlab/550fc21aed7a4de7a3636e80c6b3978a?v=2490f606225d4f60afe5088cdc77049c
+              # mirrors facets.go — keep in sync
+              - accepted_values:
+                  name: germline_cnv_occurrence__accepted_values_chromosome
+                  values:
+                    ['1','2','3','4','5','6','7','8','9','10','11','12',
+                     '13','14','15','16','17','18','19','20','21','22',
+                     'X','Y','M']
+                  config:
+                    where: "chromosome is not null"

--- a/data-qa/sources/snv_variant.yml
+++ b/data-qa/sources/snv_variant.yml
@@ -120,7 +120,7 @@ sources:
             tests:
               # --- Accepted Values (array) -----------------------------------
               # Notion: https://app.notion.com/p/ferlab/79b61815da5c4fbb898d65a6e88b5256?v=af0f09733b8345d3a68ee75dafabecfb
-              # mirrors facets.go + i18n — keep in sync
+              # mirrors facets.go + classification-badge.tsx + i18n — keep in sync
               - accepted_values_in_array:
                   name: snv_variant__accepted_values_clinvar_interpretation
                   values:
@@ -130,7 +130,7 @@ sources:
                      'Conflicting_interpretations_of_pathogenicity', 'drug_response',
                      'Established_risk_allele', 'Likely_benign',
                      'likely_pathogenic_low_penetrance', 'Likely_pathogenic',
-                     'Likely_risk_allele', 'low_penetrance',
+                     'Likely_risk_allele',
                      'no_classification_for_the_single_variant', 'not_provided', 'other',
                      'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
                      'Uncertain_risk_allele', 'Uncertain_significance', '_low_penetrance']


### PR DESCRIPTION
# feat: SJRA-1565 Add data QA on germline__cnv__occurrence table

## 📌 Context

Ajout de tests d'assurance qualité des données (data-qa) sur la table `germline__cnv__occurrence`, qui n'était pas encore couverte. En complément, mise à jour de la liste des valeurs acceptées pour l'interprétation ClinVar des SNV afin de la garder synchronisée avec les sources de référence.

## 📝 Changes

- **Nouveau fichier** `data-qa/sources/germline_cnv_occurrence.yml` couvrant la table `germline__cnv__occurrence` :
  - `should_not_contain_only_null` sur l'ensemble des colonnes, avec exceptions justifiées (`part`, `task_id`, `cnv_id` déjà couvertes par les tests `not_null` ; `svlen`, `cipos`, `ciend` constantes par construction).
  - `should_not_contain_same_value`, avec exceptions pour les colonnes constantes par construction (`part`, `phased`, `svtype`).
  - `should_be_within_range` sur les fréquences gnomAD (`gnomad_af`, `gnomad_sf`) qui doivent être dans l'intervalle [0,1] (valeurs par défaut).
  - `not_null` sur les colonnes clés `part`, `task_id`, `cnv_id`.
  - `accepted_values` sur `chromosome` (1–22, X, Y, M), alignée sur `facets.go`.
- **`data-qa/sources/snv_variant.yml`** :
  - Retrait de la valeur `low_penetrance` de la liste acceptée pour `clinvar_interpretation` (doublon de `_low_penetrance`).
  - Mise à jour du commentaire de référence : la liste reflète désormais `facets.go` + `classification-badge.tsx` + i18n.

## 🧪 Tests

Tests data-qa exécutés localement et passants.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1565

<!-- End JIRA Issues -->
