### PR TITLE
feat: SJRA-1574 Add data QA on snv__consequence table and refactor dictionaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,4 @@ logs
 *plugins.zip
 
 *.DS_STORE
+.testquality

--- a/data-qa/README.md
+++ b/data-qa/README.md
@@ -49,9 +49,15 @@ A value present in only one is a portal-internal inconsistency (out of
 scope for data-qa, but worth flagging).
 
 Each test's accepted-values list mirrors the relevant source(s) — the
-**union** of backend facets and frontend i18n for scalar columns. Keep a
-`mirrors facets.go + i18n — keep in sync` comment next to the list so
-future maintainers know what to update.
+**union** of backend facets and frontend i18n for scalar columns. The lists
+themselves live in a single place — `macros/dictionaries.sql` — one
+`dict_<name>()` macro per dictionary, so a value shared across tables (e.g.
+`consequences`, `vep_impact`, `chromosome`, `zygosity`) is declared once. A
+source YAML references it with `values: "{{ dict_<name>() }}"` (quoted for
+YAML validity; dbt renders the macro to the list at compile time — do **not**
+add `| tojson`, which breaks the `return()`-based macros). The
+`mirrors facets.go + i18n — keep in sync` comment lives next to each macro, so
+that file is the one place to update when an upstream value changes.
 
 Rule of thumb:
 
@@ -137,7 +143,7 @@ investigate.
 
 ```
 data-qa/
-├── macros/    # custom generic tests (dynamic sweeps, array accepted-values)
+├── macros/    # custom generic tests + dictionaries.sql
 ├── sources/   # source + generic-test declarations, one YAML per table
 ├── tests/     # singular tests (cross-field invariants), one SQL per check
 ├── scripts/   # dbt test runner + JUnit conversion (CI-ready)
@@ -155,7 +161,10 @@ Root also holds the usual dbt config (`dbt_project.yml`, `profiles.yml`,
    tables across files as long as no `(source, table)` pair is duplicated.
 2. List its columns with the relevant generic tests, and/or attach
    `should_not_contain_only_null` / `should_not_contain_same_value` at the
-   table level with an appropriate `except` list.
+   table level with an appropriate `except` list. For an `accepted_values` /
+   `accepted_values_in_array` test, reference the shared list via
+   `values: "{{ dict_<name>() }}"`; add a new macro to
+   `macros/dictionaries.sql` if the dictionary doesn't exist yet.
 3. For cross-field or query-shaped checks that don't fit a generic test,
    add a `.sql` file under `tests/` that returns the failing rows.
 

--- a/data-qa/macros/dictionaries.sql
+++ b/data-qa/macros/dictionaries.sql
@@ -1,0 +1,139 @@
+{#
+  Single source of truth for the accepted-values dictionaries used by the
+  `accepted_values` / `accepted_values_in_array` tests across the source
+  YAMLs. Each macro returns one closed list; reference it from a test with
+  `values: "{{ dict_<name>() }}"`.
+
+  Each list mirrors the portal's hardcoded closed sets — backend Go facets
+  (`backend/internal/repository/facets.go`) and/or frontend i18n
+  (`frontend/translations/common/*.json`). The `mirrors … — keep in sync`
+  note lives here, once per dictionary, so there is a single place to update
+  when an upstream value is added. Values are raw / case-sensitive (no
+  normalization) — see data-qa/README.md.
+#}
+
+{% macro dict_chromosome() %}
+  {# Notion: https://app.notion.com/p/ferlab/550fc21aed7a4de7a3636e80c6b3978a?v=2490f606225d4f60afe5088cdc77049c #}
+  {# mirrors facets.go — keep in sync #}
+  {{ return(['1','2','3','4','5','6','7','8','9','10','11','12',
+             '13','14','15','16','17','18','19','20','21','22',
+             'X','Y','M']) }}
+{% endmacro %}
+
+{% macro dict_vep_impact() %}
+  {# Notion: https://app.notion.com/p/ferlab/08b7fcfc5a25414badffb256709d6521?v=59e0ecb4229d4bc08ddc538f76ae870f #}
+  {# mirrors impact-indicator.tsx + facets.go — keep in sync #}
+  {{ return(['HIGH', 'MODERATE', 'LOW', 'MODIFIER']) }}
+{% endmacro %}
+
+{% macro dict_variant_class() %}
+  {# Notion: https://app.notion.com/p/ferlab/8baeb6e84ee24f0788a8154f8bfecdd9?v=6a806497b9d246d1b98def1df974e7c2 #}
+  {# mirrors facets.go + i18n — keep in sync #}
+  {{ return(['insertion', 'deletion', 'SNV', 'indel',
+             'substitution', 'sequence_alteration']) }}
+{% endmacro %}
+
+{% macro dict_clinvar_interpretation() %}
+  {# Notion: https://app.notion.com/p/ferlab/79b61815da5c4fbb898d65a6e88b5256?v=af0f09733b8345d3a68ee75dafabecfb #}
+  {# mirrors facets.go + classification-badge.tsx + i18n — keep in sync #}
+  {{ return(['Affects', 'association_not_found', 'association', 'Benign',
+             'confers_sensitivity', 'Conflicting_classifications_of_pathogenicity',
+             'conflicting_data_from_submitters',
+             'Conflicting_interpretations_of_pathogenicity', 'drug_response',
+             'Established_risk_allele', 'Likely_benign',
+             'likely_pathogenic_low_penetrance', 'Likely_pathogenic',
+             'Likely_risk_allele',
+             'no_classification_for_the_single_variant', 'not_provided', 'other',
+             'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
+             'Uncertain_risk_allele', 'Uncertain_significance', '_low_penetrance']) }}
+{% endmacro %}
+
+{% macro dict_consequences() %}
+  {# Notion: https://app.notion.com/p/ferlab/faa862446e4d4498a7238bd55e468b4f?v=2de0eadfa7d34ed49aa171c57e6e6c7e #}
+  {# mirrors facets.go + i18n — keep in sync #}
+  {{ return(['3_prime_UTR_variant', '5_prime_UTR_variant',
+             'coding_sequence_variant', 'downstream_gene_variant',
+             'feature_elongation', 'feature_truncation', 'frameshift_variant',
+             'incomplete_terminal_codon_variant', 'inframe_deletion',
+             'inframe_insertion', 'intergenic_variant', 'intron_variant',
+             'mature_miRNA_variant', 'missense_variant', 'NMD_transcript_variant',
+             'non_coding_transcript_exon_variant', 'non_coding_transcript_variant',
+             'protein_altering_variant', 'regulatory_region_ablation',
+             'regulatory_region_amplification', 'regulatory_region_variant',
+             'splice_acceptor_variant', 'splice_donor_5th_base_variant',
+             'splice_donor_region_variant', 'splice_donor_variant',
+             'splice_polypyrimidine_tract_variant', 'splice_region_variant',
+             'start_lost', 'start_retained_variant', 'stop_gained', 'stop_lost',
+             'stop_retained_variant', 'synonymous_variant', 'TF_binding_site_variant',
+             'TFBS_ablation', 'TFBS_amplification', 'transcript_ablation',
+             'transcript_amplification', 'upstream_gene_variant']) }}
+{% endmacro %}
+
+{% macro dict_zygosity() %}
+  {# Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0 #}
+  {# mirrors i18n — keep in sync #}
+  {{ return(['HET', 'HOM', 'HEM', 'WT', 'UNK']) }}
+{% endmacro %}
+
+{% macro dict_transmission_mode() %}
+  {# Notion: https://app.notion.com/p/ferlab/2ef5a320b986493694e8a820d467d017?v=2808ef9b129c443e853d939a5524805d #}
+  {# mirrors facets.go + transmission-mode-badge.tsx — keep in sync #}
+  {{ return(['autosomal_dominant_de_novo', 'autosomal_dominant', 'autosomal_recessive',
+             'x_linked_dominant_de_novo', 'x_linked_recessive_de_novo', 'x_linked_dominant',
+             'x_linked_recessive', 'non_carrier_proband', 'unknown_parents_genotype',
+             'unknown_father_genotype', 'unknown_mother_genotype', 'unknown_proband_genotype']) }}
+{% endmacro %}
+
+{% macro dict_exomiser_acmg_classification() %}
+  {# Notion: https://app.notion.com/p/ferlab/1135448b7a5543e19c968fea72ea82e7?v=50ac6d7244744fc1a6b3c30347acd5e4 #}
+  {# mirrors classification-badge.tsx + i18n — keep in sync #}
+  {{ return(['pathogenic', 'likely_pathogenic', 'uncertain_significance',
+             'likely_benign', 'benign']) }}
+{% endmacro %}
+
+{% macro dict_biotype() %}
+  {# Notion: https://app.notion.com/p/ferlab/e6270b2666794b23876ff4fbcc3257fe?v=5adc1d6fe362491586e6a2feba0d8aa9 #}
+  {# mirrors facets.go + i18n — keep in sync #}
+  {{ return(['IG_C_gene', 'IG_D_gene', 'IG_J_gene', 'IG_LV_gene', 'IG_V_gene',
+             'TR_C_gene', 'TR_J_gene', 'TR_V_gene', 'TR_D_gene', 'IG_pseudogene',
+             'IG_C_pseudogene', 'IG_J_pseudogene', 'IG_V_pseudogene', 'TR_V_pseudogene',
+             'TR_J_pseudogene', 'Mt_rRNA', 'Mt_tRNA', 'miRNA', 'misc_RNA', 'rRNA',
+             'scRNA', 'snRNA', 'snoRNA', 'ribozyme', 'sRNA', 'scaRNA', 'lncRNA',
+             'Mt_tRNA_pseudogene', 'tRNA_pseudogene', 'snoRNA_pseudogene',
+             'snRNA_pseudogene', 'scRNA_pseudogene', 'rRNA_pseudogene',
+             'misc_RNA_pseudogene', 'miRNA_pseudogene', 'TEC', 'nonsense_mediated_decay',
+             'non_stop_decay', 'retained_intron', 'protein_coding', 'protein_coding_LoF',
+             'protein_coding_CDS_not_defined', 'processed_transcript', 'non_coding',
+             'ambiguous_orf', 'sense_intronic', 'sense_overlapping', 'antisense_RNA',
+             'known_ncrna', 'pseudogene', 'processed_pseudogene', 'polymorphic_pseudogene',
+             'retrotransposed', 'transcribed_processed_pseudogene',
+             'transcribed_unprocessed_pseudogene', 'transcribed_unitary_pseudogene',
+             'translated_processed_pseudogene', 'translated_unprocessed_pseudogene',
+             'unitary_pseudogene', 'unprocessed_pseudogene', 'artifact', 'lincRNA',
+             'macro_lncRNA', '3prime_overlapping_ncRNA', 'disrupted_domain', 'vault_RNA',
+             'bidirectional_promoter_lncRNA', '']) }}
+{% endmacro %}
+
+{% macro dict_sift_pred() %}
+  {# Notion: https://app.notion.com/p/ferlab/95e8abf677f146838781fec28133ab3d?v=f2bcec55623e464eb049b75122517566 #}
+  {# mirrors i18n — keep in sync #}
+  {{ return(['D', 'T']) }}
+{% endmacro %}
+
+{% macro dict_polyphen2_hvar_pred() %}
+  {# Notion: https://app.notion.com/p/ferlab/09cfb48b28d3453cbef8c5f382c782a5?v=82c36d10c03c43d48694a54d4ed0d87f #}
+  {# mirrors i18n — keep in sync #}
+  {{ return(['B', 'D', 'P']) }}
+{% endmacro %}
+
+{% macro dict_fathmm_pred() %}
+  {# Notion: https://app.notion.com/p/ferlab/c83664a3c1ce4c2dbddcdf592516ee77?v=4f747ab3a72d4c47b92b0ea640b91ba5 #}
+  {# mirrors i18n — keep in sync #}
+  {{ return(['D', 'T']) }}
+{% endmacro %}
+
+{% macro dict_lrt_pred() %}
+  {# Notion: https://app.notion.com/p/ferlab/1a62cfbdf86c48559752f011ab20903c?v=93a01edfa8a747d3a66c8efc67ec8bb9 #}
+  {# mirrors facets.go + i18n — keep in sync #}
+  {{ return(['D', 'N', 'U']) }}
+{% endmacro %}

--- a/data-qa/sources/germline_cnv_occurrence.yml
+++ b/data-qa/sources/germline_cnv_occurrence.yml
@@ -56,13 +56,9 @@ sources:
             description: "VARCHAR(20)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/550fc21aed7a4de7a3636e80c6b3978a?v=2490f606225d4f60afe5088cdc77049c
-              # mirrors facets.go — keep in sync
+              # values: dict_chromosome() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_cnv_occurrence__accepted_values_chromosome
-                  values:
-                    ['1','2','3','4','5','6','7','8','9','10','11','12',
-                     '13','14','15','16','17','18','19','20','21','22',
-                     'X','Y','M']
+                  values: "{{ dict_chromosome() }}"
                   config:
                     where: "chromosome is not null"

--- a/data-qa/sources/germline_snv_occurrence.yml
+++ b/data-qa/sources/germline_snv_occurrence.yml
@@ -60,60 +60,49 @@ sources:
             description: "CHAR(3)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
-              # mirrors i18n — keep in sync
+              # values: dict_zygosity() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_snv_occurrence__accepted_values_zygosity
-                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  values: "{{ dict_zygosity() }}"
                   config:
                     where: "zygosity is not null"
           - name: father_zygosity
             description: "CHAR(3)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
-              # mirrors i18n — keep in sync
+              # values: dict_zygosity() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_snv_occurrence__accepted_values_father_zygosity
-                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  values: "{{ dict_zygosity() }}"
                   config:
                     where: "father_zygosity is not null"
           - name: mother_zygosity
             description: "CHAR(3)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
-              # mirrors i18n — keep in sync
+              # values: dict_zygosity() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_snv_occurrence__accepted_values_mother_zygosity
-                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  values: "{{ dict_zygosity() }}"
                   config:
                     where: "mother_zygosity is not null"
           - name: transmission_mode
             description: "VARCHAR(50)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/2ef5a320b986493694e8a820d467d017?v=2808ef9b129c443e853d939a5524805d
-              # mirrors facets.go + transmission-mode-badge.tsx — keep in sync
+              # values: dict_transmission_mode() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_snv_occurrence__accepted_values_transmission_mode
-                  values:
-                    ['autosomal_dominant_de_novo', 'autosomal_dominant', 'autosomal_recessive',
-                     'x_linked_dominant_de_novo', 'x_linked_recessive_de_novo', 'x_linked_dominant',
-                     'x_linked_recessive', 'non_carrier_proband', 'unknown_parents_genotype',
-                     'unknown_father_genotype', 'unknown_mother_genotype', 'unknown_proband_genotype']
+                  values: "{{ dict_transmission_mode() }}"
                   config:
                     where: "transmission_mode is not null"
           - name: exomiser_acmg_classification
             description: "VARCHAR(300)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/1135448b7a5543e19c968fea72ea82e7?v=50ac6d7244744fc1a6b3c30347acd5e4
-              # mirrors classification-badge.tsx + i18n — keep in sync
+              # values: dict_exomiser_acmg_classification() — see macros/dictionaries.sql
               - accepted_values:
                   name: germline_snv_occurrence__accepted_values_exomiser_acmg_classification
-                  values:
-                    ['pathogenic', 'likely_pathogenic', 'uncertain_significance',
-                     'likely_benign', 'benign']
+                  values: "{{ dict_exomiser_acmg_classification() }}"
                   config:
                     where: "exomiser_acmg_classification is not null"

--- a/data-qa/sources/snv_consequence.yml
+++ b/data-qa/sources/snv_consequence.yml
@@ -1,0 +1,105 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: snv__consequence
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              # SJRA-1550 mane_select
+              name: snv_consequence__should_not_contain_only_null_SJRA-1550
+              except:
+                # Already covered by snv_consequence__should_not_contain_null__*
+                - locus_id
+                - symbol
+                - transcript_id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              # SJRA-1550 is_mane_select is_mane_plus
+              name: snv_consequence__should_not_contain_same_value_SJRA-1550
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: snv_consequence__should_not_contain_null__locus_id
+          - name: symbol
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: snv_consequence__should_not_contain_null__symbol
+          - name: transcript_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: snv_consequence__should_not_contain_null__transcript_id
+          - name: consequences
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # values: dict_consequences() — see macros/dictionaries.sql
+              - accepted_values_in_array:
+                  name: snv_consequence__accepted_values_consequences
+                  values: "{{ dict_consequences() }}"
+          - name: biotype
+            description: "VARCHAR(50)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_biotype() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_biotype
+                  values: "{{ dict_biotype() }}"
+                  config:
+                    where: "biotype is not null"
+          - name: sift_pred
+            description: "VARCHAR(1)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_sift_pred() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_sift_pred
+                  values: "{{ dict_sift_pred() }}"
+                  config:
+                    where: "sift_pred is not null"
+          - name: polyphen2_hvar_pred
+            description: "VARCHAR(1)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_polyphen2_hvar_pred() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_polyphen2_hvar_pred
+                  values: "{{ dict_polyphen2_hvar_pred() }}"
+                  config:
+                    where: "polyphen2_hvar_pred is not null"
+          - name: fathmm_pred
+            description: "VARCHAR(1)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_fathmm_pred() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_fathmm_pred
+                  values: "{{ dict_fathmm_pred() }}"
+                  config:
+                    where: "fathmm_pred is not null"
+          - name: lrt_pred
+            description: "VARCHAR(1)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_lrt_pred() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_lrt_pred
+                  values: "{{ dict_lrt_pred() }}"
+                  config:
+                    where: "lrt_pred is not null"
+          - name: vep_impact
+            description: "VARCHAR(20)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_vep_impact() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: snv_consequence__accepted_values_vep_impact
+                  values: "{{ dict_vep_impact() }}"
+                  config:
+                    where: "vep_impact is not null"

--- a/data-qa/sources/snv_variant.yml
+++ b/data-qa/sources/snv_variant.yml
@@ -61,14 +61,10 @@ sources:
               - not_null:
                   name: snv_variant__should_not_contain_null__chromosome
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/550fc21aed7a4de7a3636e80c6b3978a?v=2490f606225d4f60afe5088cdc77049c
-              # mirrors facets.go — keep in sync
+              # values: dict_chromosome() — see macros/dictionaries.sql
               - accepted_values:
                   name: snv_variant__accepted_values_chromosome
-                  values:
-                    ['1','2','3','4','5','6','7','8','9','10','11','12',
-                     '13','14','15','16','17','18','19','20','21','22',
-                     'X','Y','M']
+                  values: "{{ dict_chromosome() }}"
           - name: start
             description: "1-based start position."
             tests:
@@ -96,65 +92,33 @@ sources:
           - name: vep_impact
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/08b7fcfc5a25414badffb256709d6521?v=59e0ecb4229d4bc08ddc538f76ae870f
-              # mirrors impact-indicator.tsx + facets.go — keep in sync
+              # values: dict_vep_impact() — see macros/dictionaries.sql
               - accepted_values:
                   name: snv_variant__accepted_values_vep_impact
-                  values: ['HIGH', 'MODERATE', 'LOW', 'MODIFIER']
+                  values: "{{ dict_vep_impact() }}"
                   config:
                     where: "vep_impact is not null"
           - name: variant_class
             description: "Sequence Ontology variant class."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/8baeb6e84ee24f0788a8154f8bfecdd9?v=6a806497b9d246d1b98def1df974e7c2
-              # mirrors facets.go + i18n — keep in sync
+              # values: dict_variant_class() — see macros/dictionaries.sql
               - accepted_values:
                   name: snv_variant__accepted_values_variant_class
-                  values:
-                    ['insertion', 'deletion', 'SNV', 'indel',
-                     'substitution', 'sequence_alteration']
+                  values: "{{ dict_variant_class() }}"
                   config:
                     where: "variant_class is not null"
           - name: clinvar_interpretation
             tests:
               # --- Accepted Values (array) -----------------------------------
-              # Notion: https://app.notion.com/p/ferlab/79b61815da5c4fbb898d65a6e88b5256?v=af0f09733b8345d3a68ee75dafabecfb
-              # mirrors facets.go + classification-badge.tsx + i18n — keep in sync
+              # values: dict_clinvar_interpretation() — see macros/dictionaries.sql
               - accepted_values_in_array:
                   name: snv_variant__accepted_values_clinvar_interpretation
-                  values:
-                    ['Affects', 'association_not_found', 'association', 'Benign',
-                     'confers_sensitivity', 'Conflicting_classifications_of_pathogenicity',
-                     'conflicting_data_from_submitters',
-                     'Conflicting_interpretations_of_pathogenicity', 'drug_response',
-                     'Established_risk_allele', 'Likely_benign',
-                     'likely_pathogenic_low_penetrance', 'Likely_pathogenic',
-                     'Likely_risk_allele',
-                     'no_classification_for_the_single_variant', 'not_provided', 'other',
-                     'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
-                     'Uncertain_risk_allele', 'Uncertain_significance', '_low_penetrance']
+                  values: "{{ dict_clinvar_interpretation() }}"
           - name: consequences
             tests:
               # --- Accepted Values (array) -----------------------------------
-              # Notion: https://app.notion.com/p/ferlab/faa862446e4d4498a7238bd55e468b4f?v=2de0eadfa7d34ed49aa171c57e6e6c7e
-              # mirrors facets.go + i18n — keep in sync
+              # values: dict_consequences() — see macros/dictionaries.sql
               - accepted_values_in_array:
                   name: snv_variant__accepted_values_consequences
-                  values:
-                    ['3_prime_UTR_variant', '5_prime_UTR_variant',
-                     'coding_sequence_variant', 'downstream_gene_variant',
-                     'feature_elongation', 'feature_truncation', 'frameshift_variant',
-                     'incomplete_terminal_codon_variant', 'inframe_deletion',
-                     'inframe_insertion', 'intergenic_variant', 'intron_variant',
-                     'mature_miRNA_variant', 'missense_variant', 'NMD_transcript_variant',
-                     'non_coding_transcript_exon_variant', 'non_coding_transcript_variant',
-                     'protein_altering_variant', 'regulatory_region_ablation',
-                     'regulatory_region_amplification', 'regulatory_region_variant',
-                     'splice_acceptor_variant', 'splice_donor_5th_base_variant',
-                     'splice_donor_region_variant', 'splice_donor_variant',
-                     'splice_polypyrimidine_tract_variant', 'splice_region_variant',
-                     'start_lost', 'start_retained_variant', 'stop_gained', 'stop_lost',
-                     'stop_retained_variant', 'synonymous_variant', 'TF_binding_site_variant',
-                     'TFBS_ablation', 'TFBS_amplification', 'transcript_ablation',
-                     'transcript_amplification', 'upstream_gene_variant']
+                  values: "{{ dict_consequences() }}"

--- a/data-qa/sources/somatic_snv_occurrence.yml
+++ b/data-qa/sources/somatic_snv_occurrence.yml
@@ -89,21 +89,19 @@ sources:
             description: "CHAR(3)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
-              # mirrors i18n — keep in sync
+              # values: dict_zygosity() — see macros/dictionaries.sql
               - accepted_values:
                   name: somatic_snv_occurrence__accepted_values_tumor_zygosity
-                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  values: "{{ dict_zygosity() }}"
                   config:
                     where: "tumor_zygosity is not null"
           - name: normal_zygosity
             description: "CHAR(3)."
             tests:
               # --- Accepted Values -------------------------------------------
-              # Notion: https://app.notion.com/p/ferlab/b60cce4406dc460796882a8551454e27?v=30cfb82fd215434493c541a9b72d2dc0
-              # mirrors i18n — keep in sync
+              # values: dict_zygosity() — see macros/dictionaries.sql
               - accepted_values:
                   name: somatic_snv_occurrence__accepted_values_normal_zygosity
-                  values: ['HET', 'HOM', 'HEM', 'WT', 'UNK']
+                  values: "{{ dict_zygosity() }}"
                   config:
                     where: "normal_zygosity is not null"


### PR DESCRIPTION
# feat: SJRA-1574 Add data QA on snv__consequence table and refactor dictionaries

## 📌 Context

Les tests data-qa déclaraient leurs listes de valeurs acceptées (`accepted_values` / `accepted_values_in_array`) directement dans chaque YAML de source. Une même liste (ex. `chromosome`, `zygosity`, `consequences`) était donc dupliquée à travers plusieurs fichiers et tables, avec son commentaire `mirrors facets.go + i18n — keep in sync` répété à chaque endroit.

Ce PR introduit une source unique de vérité pour ces dictionnaires et ajoute la couverture data-qa de la table `snv__consequence`.

## 📝 Changes

- **Nouveau `macros/dictionaries.sql`** : une macro `dict_<name>()` par dictionnaire, chacune retournant une liste fermée. Les listes partagées entre tables sont désormais déclarées une seule fois. Dictionnaires couverts : `chromosome`, `vep_impact`, `variant_class`, `clinvar_interpretation`, `consequences`, `zygosity`, `transmission_mode`, `exomiser_acmg_classification`, `biotype`, `sift_pred`, `polyphen2_hvar_pred`, `fathmm_pred`, `lrt_pred`. Le lien Notion et le commentaire `mirrors … — keep in sync` vivent maintenant à un seul endroit, à côté de chaque macro.
- **Nouveau `sources/snv_consequence.yml`** : déclaration de la source `snv__consequence` avec :
  - `not_null` sur `locus_id`, `symbol`, `transcript_id` ;
  - `should_not_contain_only_null` (SJRA-1550, en excluant les colonnes déjà couvertes par `not_null`) et `should_not_contain_same_value` (SJRA-1550, `is_mane_select` / `is_mane_plus`) au niveau table ;
  - `accepted_values` / `accepted_values_in_array` sur `consequences`, `biotype`, `sift_pred`, `polyphen2_hvar_pred`, `fathmm_pred`, `lrt_pred`, `vep_impact`, chacune référençant la macro correspondante.
- **Refactor des YAML existants** (`germline_cnv_occurrence`, `germline_snv_occurrence`, `snv_variant`, `somatic_snv_occurrence`) : les listes en dur sont remplacées par `values: "{{ dict_<name>() }}"`. Aucune valeur acceptée n'est modifiée — refactor à comportement constant.
- **README data-qa** : documente la nouvelle convention (référencer un dictionnaire via `values: "{{ dict_<name>() }}"`, quoté pour la validité YAML, sans `| tojson` qui casserait les macros basées sur `return()`) et ajoute `dictionaries.sql` à l'arborescence et à la procédure d'ajout de table.
- **.gitignore** : ajout de `.testquality`.

## 🧪 Tests

Les tests data-qa impactés ont été exécutés localement et passent avec succès. Le refactor est à iso-valeurs : chaque `dict_<name>()` rend exactement la même liste que celle précédemment en dur, donc aucun test existant ne change de résultat. Les nouveaux tests sur `snv__consequence` complètent la couverture.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1574 — Ajout des tests data QA sur `snv__consequence` et refactor des dictionnaires.
- SJRA-1550 — Référencée par les tests `should_not_contain_only_null` / `should_not_contain_same_value` (`mane_select`, `is_mane_plus`).

<!-- End JIRA Issues -->
