### PR TITLE
feat: SJRA-1575 Add data QA on snv__consequence_filter_partitioned table

### DIFF
--- a/data-qa/sources/snv_consequence_filter_partitioned.yml
+++ b/data-qa/sources/snv_consequence_filter_partitioned.yml
@@ -1,0 +1,18 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: snv__consequence_filter_partitioned
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: snv_consequence_filter_partitioned__should_not_contain_only_null
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: snv_consequence_filter_partitioned__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - part

--- a/data-qa/tests/snv_consequence_filter_partitioned__validate_completeness_vs_snv_consequence.sql
+++ b/data-qa/tests/snv_consequence_filter_partitioned__validate_completeness_vs_snv_consequence.sql
@@ -1,0 +1,27 @@
+{#
+  Completeness (locus grain) — the reciprocal of
+  snv_consequence_filter_partitioned__validate_subset_of_snv_consequence.
+
+  `_filter_partitioned` derives from `snv__consequence` (UNNEST + GROUP BY)
+  then semi-joins `germline__snv__occurrence` on (locus_id, part). So a locus
+  present in `snv__consequence` AND having a germline occurrence for a given
+  `part` MUST appear in `_filter_partitioned` for that `part`. A missing one
+  signals a dropped locus — a failed / partial partition overwrite or a broken
+  semi-join.
+
+  Locus grain on purpose: it targets the partition / semi-join logic without
+  replaying the UNNEST + GROUP BY of the derivation.
+#}
+
+select
+    o.part,
+    o.locus_id
+from {{ source('radiant', 'germline__snv__occurrence') }} o
+join {{ source('radiant', 'snv__consequence') }} c
+    on c.locus_id = o.locus_id
+   and array_length(c.consequences) > 0
+left join {{ source('radiant', 'snv__consequence_filter_partitioned') }} fp
+    on fp.locus_id = o.locus_id
+   and fp.part = o.part
+where fp.locus_id is null
+group by o.part, o.locus_id

--- a/data-qa/tests/snv_consequence_filter_partitioned__validate_subset_of_snv_consequence.sql
+++ b/data-qa/tests/snv_consequence_filter_partitioned__validate_subset_of_snv_consequence.sql
@@ -1,0 +1,21 @@
+{#
+  `snv__consequence_filter_partitioned` is derived from `snv__consequence`
+  via UNNEST(consequences) + GROUP BY (locus_id, symbol, …), then filtered by
+  a semi-join to occurrences. Every row must therefore trace back to a base
+  `snv__consequence` row with the same (locus_id, symbol) whose `consequences`
+  array contains the unnested scalar `consequence`. A row that doesn't is an
+  orphan — a derivation bug or a stale partition overwrite. Matched on
+  categorical columns only (no fragile float equality).
+#}
+
+select
+    fp.part,
+    fp.locus_id,
+    fp.symbol,
+    fp.consequence
+from {{ source('radiant', 'snv__consequence_filter_partitioned') }} fp
+left join {{ source('radiant', 'snv__consequence') }} c
+    on c.locus_id = fp.locus_id
+   and c.symbol = fp.symbol
+   and array_contains(c.consequences, fp.consequence)
+where c.locus_id is null


### PR DESCRIPTION
# feat: SJRA-1575 Add data QA on snv__consequence_filter_partitioned table

## 📌 Context

La table `snv__consequence_filter_partitioned` est dérivée de `snv__consequence` (via `UNNEST(consequences)` + `GROUP BY`), puis filtrée par un semi-join sur les occurrences germinales (`germline__snv__occurrence`) par `part`. Cette PR ajoute une couverture de QA des données pour valider l'intégrité de cette dérivation et de la logique de partitionnement.

## 📝 Changes

- Ajout de la source `snv_consequence_filter_partitioned.yml` avec deux tests génériques :
  - `should_not_contain_only_null` — aucune colonne ne doit être entièrement nulle.
  - `should_not_contain_same_value` — aucune colonne ne doit contenir une valeur constante, à l'exception de `part` (constante par construction).
- Ajout du test `..._validate_subset_of_snv_consequence.sql` : chaque ligne de `_filter_partitioned` doit correspondre à une ligne de base dans `snv__consequence` (même `locus_id` + `symbol`, et `consequences` contenant la `consequence` éclatée). Détecte les lignes orphelines (bug de dérivation ou écrasement de partition obsolète). Jointure sur colonnes catégorielles uniquement (pas d'égalité fragile sur des flottants).
- Ajout du test `..._validate_completeness_vs_snv_consequence.sql` (réciproque du précédent) : tout locus présent dans `snv__consequence` ET ayant une occurrence germinale pour un `part` donné doit apparaître dans `_filter_partitioned` pour ce `part`. Détecte les locus manquants (écrasement de partition partiel/échoué ou semi-join brisé). Au grain locus pour cibler la logique de partition/semi-join sans rejouer le `UNNEST` + `GROUP BY`.

## 🧪 Tests

- Les tests de QA ajoutés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1575

<!-- End JIRA Issues -->
