### PR TITLE
feat: SJRA-1582 Add data QA on clinvar table

### DIFF
--- a/data-qa/macros/dictionaries.sql
+++ b/data-qa/macros/dictionaries.sql
@@ -45,7 +45,8 @@
              'Likely_risk_allele',
              'no_classification_for_the_single_variant', 'not_provided', 'other',
              'pathogenic_low_penetrance', 'Pathogenic', 'protective', 'risk_factor',
-             'Uncertain_risk_allele', 'Uncertain_significance', '_low_penetrance']) }}
+             'Uncertain_risk_allele', 'Uncertain_significance',
+             '_low_penetrance', 'low_penetrance']) }}
 {% endmacro %}
 
 {% macro dict_consequences() %}

--- a/data-qa/sources/clinvar.yml
+++ b/data-qa/sources/clinvar.yml
@@ -1,0 +1,72 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: clinvar
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: clinvar__should_not_contain_only_null
+              except:
+                # Already covered by clinvar__should_not_contain_null__*
+                - locus_id
+                - chromosome
+                - start
+                - reference
+                - locus
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: clinvar__should_not_contain_same_value
+              except:
+                # Already covered by clinvar__should_be_unique__*
+                - locus_id
+                - locus
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele frequencies must be in [0,1]
+          - should_be_within_range:
+              name: clinvar__should_be_within_range_af
+              like: af_
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar__should_not_contain_null__locus_id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: clinvar__should_be_unique__locus_id_SJRA-1581
+          - name: chromosome
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar__should_not_contain_null__chromosome
+          - name: start
+            description: "1-based start position."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar__should_not_contain_null__start
+          - name: reference
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar__should_not_contain_null__reference
+          - name: locus
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar__should_not_contain_null__locus
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: clinvar__should_be_unique__locus
+          - name: interpretations
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # values: dict_clinvar_interpretation() — see macros/dictionaries.sql
+              - accepted_values_in_array:
+                  name: clinvar__accepted_values_interpretations
+                  values: "{{ dict_clinvar_interpretation() }}"


### PR DESCRIPTION
# feat: SJRA-1582 Add data QA on clinvar table

## 📌 Context

Ajout de la couverture de tests « data QA » (dbt) pour la table `clinvar`, jusqu'ici non testée. L'objectif est de valider l'intégrité des données chargées dans cette table (clés, valeurs nulles, doublons, plages de fréquences alléliques et valeurs acceptées d'interprétation clinique).

## 📝 Changes

- **Nouveau fichier `data-qa/sources/clinvar.yml`** — déclare la source `radiant.clinvar` et ses tests :
  - **Tests au niveau table :**
    - `should_not_contain_only_null` — aucune colonne entièrement nulle (les colonnes clés sont exclues car déjà couvertes par les tests `not_null`).
    - `should_not_contain_same_value` — aucune colonne mono-valeur (les colonnes uniques sont exclues car déjà couvertes par les tests `unique`).
    - `should_be_within_range_af` — toutes les colonnes `af_*` (fréquences alléliques) doivent être dans l'intervalle `[0, 1]`.
  - **Tests au niveau colonne :**
    - `not_null` sur `locus_id`, `chromosome`, `start`, `reference`, `locus`.
    - `unique` sur `locus` et sur `locus_id`.
    - `accepted_values_in_array` sur `interpretations`, validé contre le dictionnaire `dict_clinvar_interpretation()`.
- **`data-qa/macros/dictionaries.sql`** — ajout de la valeur `low_penetrance` au dictionnaire `dict_clinvar_interpretation()`, afin de couvrir une valeur d'interprétation observée dans les données et absente de la liste.

## 🧪 Tests

- Tests dbt data-qa exécutés localement sur la table `clinvar` : tous passent.
- Le test d'unicité `clinvar__should_be_unique__locus_id_SJRA-1581` conserve le tag Jira **SJRA-1581** : `locus_id` n'est pas strictement unique (cas des delins 1→2). La vraie clé d'unicité est `locus`, couverte par `clinvar__should_be_unique__locus`. Le tag est maintenu pour le suivi de cette particularité de données.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1582
- SJRA-1581 (suivi : non-unicité de `locus_id`)

<!-- End JIRA Issues -->
