### PR TITLE
feat: SJRA-1584 Add data QA on gnomad_genomes_v3 topmed_bravo and 1000_genomes

### DIFF
--- a/data-qa/sources/1000_genomes.yml
+++ b/data-qa/sources/1000_genomes.yml
@@ -1,0 +1,36 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: 1000_genomes
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: 1000_genomes__should_not_contain_only_null
+              except:
+                # Already covered by 1000_genomes__should_not_contain_null__*
+                - locus_id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: 1000_genomes__should_not_contain_same_value
+              except:
+                # Already covered by 1000_genomes__should_be_unique__*
+                - locus_id
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele frequency must be in [0,1]
+          - should_be_within_range:
+              name: 1000_genomes__should_be_within_range_af
+              like: af
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: 1000_genomes__should_not_contain_null__locus_id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: 1000_genomes__should_be_unique__locus_id_SJRA-1583

--- a/data-qa/sources/gnomad_genomes_v3.yml
+++ b/data-qa/sources/gnomad_genomes_v3.yml
@@ -1,0 +1,36 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: gnomad_genomes_v3
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: gnomad_genomes_v3__should_not_contain_only_null
+              except:
+                # Already covered by gnomad_genomes_v3__should_not_contain_null__*
+                - locus_id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: gnomad_genomes_v3__should_not_contain_same_value
+              except:
+                # Already covered by gnomad_genomes_v3__should_be_unique__*
+                - locus_id
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele frequency must be in [0,1]
+          - should_be_within_range:
+              name: gnomad_genomes_v3__should_be_within_range_af
+              like: af
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: gnomad_genomes_v3__should_not_contain_null__locus_id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: gnomad_genomes_v3__should_be_unique__locus_id

--- a/data-qa/sources/topmed_bravo.yml
+++ b/data-qa/sources/topmed_bravo.yml
@@ -1,0 +1,38 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: topmed_bravo
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: topmed_bravo__should_not_contain_only_null
+              except:
+                # Already covered by topmed_bravo__should_not_contain_null__*
+                - locus_id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: topmed_bravo__should_not_contain_same_value
+              except:
+                # Already covered by topmed_bravo__should_be_unique__*
+                - locus_id
+                # Legitimately constant: TOPMed Bravo reports a fixed cohort
+                - an
+
+          # --- Should Be Within Range ----------------------------------------
+          # allele frequency must be in [0,1]
+          - should_be_within_range:
+              name: topmed_bravo__should_be_within_range_af
+              like: af
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: topmed_bravo__should_not_contain_null__locus_id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: topmed_bravo__should_be_unique__locus_id

--- a/data-qa/tests/1000_genomes__validate_allele_counts.sql
+++ b/data-qa/tests/1000_genomes__validate_allele_counts.sql
@@ -1,0 +1,15 @@
+{#
+  Allele-count sanity for the 1000 Genomes frequency table:
+    - ac (alt allele count) and an (total called alleles) must be non-negative;
+    - ac cannot exceed an
+#}
+
+select
+    locus_id,
+    af,
+    ac,
+    an
+from {{ source('radiant', '1000_genomes') }}
+where ac < 0
+   or an < 0
+   or ac > an

--- a/data-qa/tests/gnomad_genomes_v3__validate_allele_counts.sql
+++ b/data-qa/tests/gnomad_genomes_v3__validate_allele_counts.sql
@@ -1,0 +1,18 @@
+{#
+  Allele-count sanity for the gnomAD frequency table:
+    - ac (alt allele count), an (total called alleles) and hom (homozygote
+      count) must be non-negative;
+    - ac cannot exceed an
+#}
+
+select
+    locus_id,
+    af,
+    ac,
+    an,
+    hom
+from {{ source('radiant', 'gnomad_genomes_v3') }}
+where ac < 0
+   or an < 0
+   or hom < 0
+   or ac > an

--- a/data-qa/tests/topmed_bravo__validate_allele_counts.sql
+++ b/data-qa/tests/topmed_bravo__validate_allele_counts.sql
@@ -1,0 +1,18 @@
+{#
+  Allele-count sanity for the TOPMed Bravo frequency table:
+    - ac (alt allele count), an (total called alleles) and hom (homozygote
+      count) must be non-negative;
+    - ac cannot exceed an
+#}
+
+select
+    locus_id,
+    af,
+    ac,
+    an,
+    hom
+from {{ source('radiant', 'topmed_bravo') }}
+where ac < 0
+   or an < 0
+   or hom < 0
+   or ac > an


### PR DESCRIPTION
# feat: SJRA-1584 Add data QA on gnomad_genomes_v3 topmed_bravo and 1000_genomes tables

## 📌 Context

Cette PR ajoute une couverture de tests d'assurance qualité des données (data-qa) pour trois tables de fréquences alléliques de population : `1000_genomes`, `gnomad_genomes_v3` et `topmed_bravo`. L'objectif est de valider l'intégrité de ces sources de référence : absence de valeurs nulles ou constantes inattendues, fréquences alléliques dans les bornes valides et cohérence des décomptes d'allèles.

## 📝 Changes

- Ajout de trois fichiers de sources dbt (`data-qa/sources/`), un par table, déclarant les tests génériques :
  - `should_not_contain_only_null` — aucune colonne entièrement nulle (sauf `locus_id`, déjà couvert par un test `not_null` dédié).
  - `should_not_contain_same_value` — aucune colonne à valeur constante (sauf `locus_id`, déjà couvert par le test d'unicité). Pour `topmed_bravo`, la colonne `an` est aussi exclue car TOPMed Bravo rapporte une cohorte de taille fixe (valeur légitimement constante).
  - `should_be_within_range_af` — la fréquence allélique (`af`) doit être dans l'intervalle [0,1].
  - `not_null` et `unique` sur la colonne clé `locus_id`.
- Ajout de trois tests singuliers SQL (`data-qa/tests/`) validant la cohérence des décomptes d'allèles : `ac` et `an` (et `hom` pour gnomAD et TOPMed Bravo) doivent être non négatifs, et `ac` ne peut excéder `an`.

## 🧪 Tests

- Trois tests singuliers SQL (`*__validate_allele_counts.sql`) ainsi que les tests génériques déclarés dans les fichiers de sources.
- Les tests impactés ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1584 — ajout de la couverture data QA sur les trois tables.
- SJRA-1583 — un tag subsiste sur le test d'unicité `1000_genomes__should_be_unique__locus_id_SJRA-1583`, signalant un suivi encore ouvert sur l'unicité du `locus_id` pour cette table (résolution partielle ; les tables `gnomad_genomes_v3` et `topmed_bravo` ne sont pas concernées).

<!-- End JIRA Issues -->
