### PR TITLE
feat: SJRA-1600 Add data QA on exomiser table

### DIFF
--- a/data-qa/sources/exomiser.yml
+++ b/data-qa/sources/exomiser.yml
@@ -1,0 +1,60 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: exomiser
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: exomiser__should_not_contain_only_null
+              except:
+                # Already covered by exomiser__should_not_contain_null__*
+                - part
+                - seq_id
+                - locus_id
+                - id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: exomiser__should_not_contain_same_value
+              except:
+                # Single partition QA dataset
+                - part
+
+          # --- Should Be Within Range ----------------------------------------
+          # exomiser scores must be in [0,1]
+          - should_be_within_range:
+              name: exomiser__should_be_within_range_score
+              like: score
+        columns:
+          - name: part
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: exomiser__should_not_contain_null__part
+          - name: seq_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: exomiser__should_not_contain_null__seq_id
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: exomiser__should_not_contain_null__locus_id
+          - name: id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: exomiser__should_not_contain_null__id
+          - name: acmg_classification
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_exomiser_acmg_classification() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: exomiser__accepted_values_acmg_classification
+                  values: "{{ dict_exomiser_acmg_classification() }}"
+                  config:
+                    where: "acmg_classification is not null"


### PR DESCRIPTION
# feat: SJRA-1600 Add data QA on exomiser table

## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

Ajout de la couverture de tests de qualité des données (data QA) pour la table `exomiser`, qui n'en avait aucune. L'objectif est de valider l'intégrité des données produites par le pipeline Exomiser (scores de priorisation et classification ACMG), au même titre que les autres tables du projet.

## 📝 Changes

<!-- List the main changes in this PR. -->

Nouveau fichier `data-qa/sources/exomiser.yml` définissant les tests dbt suivants sur la source `radiant.exomiser` :

- **Tests au niveau de la table :**
  - `should_not_contain_only_null` — exclut les colonnes déjà couvertes par les tests `not_null` (`part`, `seq_id`, `locus_id`, `id`).
  - `should_not_contain_same_value` — exclut `part` (jeu de données QA à partition unique).
  - `should_be_within_range_score` — valide que les colonnes de type `score` sont dans l'intervalle attendu `[0,1]`.
- **Tests au niveau des colonnes :**
  - `not_null` sur `part`, `seq_id`, `locus_id` et `id`.
  - `accepted_values` sur `acmg_classification`, alimenté par le dictionnaire `dict_exomiser_acmg_classification()` (`macros/dictionaries.sql`), avec la condition `where: acmg_classification is not null`.

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

Les tests data QA ci-dessus ont été exécutés localement et passent avec succès.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1600

<!-- End JIRA Issues -->
