### PR TITLE
feat: SJRA-1613 Add data QA on cytoband ensembl_gene and ensembl_exon_by_gene tables

### DIFF
--- a/data-qa/sources/cytoband.yml
+++ b/data-qa/sources/cytoband.yml
@@ -1,0 +1,56 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: cytoband
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: cytoband__should_not_contain_only_null
+              except:
+                # Already covered by cytoband__should_not_contain_null__*
+                - chromosome
+                - cytoband
+                - end
+                - start
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: cytoband__should_not_contain_same_value
+
+          # --- Should Be Unique ----------------------------------------------
+          - dbt_utils.unique_combination_of_columns:
+              name: cytoband__should_be_unique__chromosome_cytoband
+              combination_of_columns:
+                - chromosome
+                - cytoband
+        columns:
+          - name: chromosome
+            description: "CHAR(2) — canonical UCSC cytoBand chromosomes only."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: cytoband__should_not_contain_null__chromosome
+              # --- Accepted Values -------------------------------------------
+              # values: dict_chromosome() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: cytoband__accepted_values_chromosome
+                  values: "{{ dict_chromosome() }}"
+          - name: cytoband
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: cytoband__should_not_contain_null__cytoband
+          - name: start
+            description: "1-based start position."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: cytoband__should_not_contain_null__start
+          - name: end
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: cytoband__should_not_contain_null__end

--- a/data-qa/sources/ensembl_exon_by_gene.yml
+++ b/data-qa/sources/ensembl_exon_by_gene.yml
@@ -1,0 +1,66 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: ensembl_exon_by_gene
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: ensembl_exon_by_gene__should_not_contain_only_null
+              except:
+                # Already covered by ensembl_exon_by_gene__should_not_contain_null__*
+                - chromosome
+                - end
+                - exon_id
+                - gene_id
+                - start
+                # Null by construction
+                - alias
+                - description
+                - external_name
+                - logic_name
+                - phase
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: ensembl_exon_by_gene__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - type
+
+          # --- Should Be Unique ----------------------------------------------
+          - dbt_utils.unique_combination_of_columns:
+              name: ensembl_exon_by_gene__should_be_unique__gene_id_exon_id
+              combination_of_columns:
+                - gene_id
+                - exon_id
+        columns:
+          - name: gene_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_exon_by_gene__should_not_contain_null__gene_id
+          - name: exon_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_exon_by_gene__should_not_contain_null__exon_id
+          - name: chromosome
+            description: "VARCHAR(10)."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_exon_by_gene__should_not_contain_null__chromosome
+          - name: start
+            description: "1-based start position."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_exon_by_gene__should_not_contain_null__start
+          - name: end
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_exon_by_gene__should_not_contain_null__end

--- a/data-qa/sources/ensembl_gene.yml
+++ b/data-qa/sources/ensembl_gene.yml
@@ -1,0 +1,69 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: ensembl_gene
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: ensembl_gene__should_not_contain_only_null
+              except:
+                # Already covered by ensembl_gene__should_not_contain_null__*
+                - chromosome
+                - end
+                - gene_id
+                - start
+                # Null by construction
+                - alias
+                - ccdsid
+                - constitutive
+                - ensembl_end_phase
+                - ensembl_phase
+                - external_name
+                - phase
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: ensembl_gene__should_not_contain_same_value
+              except:
+                # Already covered by ensembl_gene__should_be_unique__*
+                - gene_id
+                # Constant by construction
+                - type
+        columns:
+          - name: gene_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_gene__should_not_contain_null__gene_id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: ensembl_gene__should_be_unique__gene_id
+          - name: chromosome
+            description: "VARCHAR(10)."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_gene__should_not_contain_null__chromosome
+          - name: start
+            description: "1-based start position."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_gene__should_not_contain_null__start
+          - name: end
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: ensembl_gene__should_not_contain_null__end
+          - name: biotype
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_biotype() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: ensembl_gene__accepted_values_biotype
+                  values: "{{ dict_biotype() }}"
+                  config:
+                    where: "biotype is not null"

--- a/data-qa/tests/cytoband__validate_start_end_order.sql
+++ b/data-qa/tests/cytoband__validate_start_end_order.sql
@@ -1,0 +1,12 @@
+{#
+  Genomic coordinate sanity for the cytoband reference:
+    - start must not exceed end (band span).
+#}
+
+select
+    chromosome,
+    cytoband,
+    start,
+    `end`
+from {{ source('radiant', 'cytoband') }}
+where start > `end`

--- a/data-qa/tests/ensembl_exon_by_gene__validate_start_end_order.sql
+++ b/data-qa/tests/ensembl_exon_by_gene__validate_start_end_order.sql
@@ -1,0 +1,13 @@
+{#
+  Genomic coordinate sanity for the Ensembl exon reference:
+    - start must not exceed end (1-based inclusive span).
+#}
+
+select
+    gene_id,
+    exon_id,
+    chromosome,
+    start,
+    `end`
+from {{ source('radiant', 'ensembl_exon_by_gene') }}
+where start > `end`

--- a/data-qa/tests/ensembl_gene__validate_start_end_order.sql
+++ b/data-qa/tests/ensembl_gene__validate_start_end_order.sql
@@ -1,0 +1,12 @@
+{#
+  Genomic coordinate sanity for the Ensembl gene reference:
+    - start must not exceed end (1-based inclusive span).
+#}
+
+select
+    gene_id,
+    chromosome,
+    start,
+    `end`
+from {{ source('radiant', 'ensembl_gene') }}
+where start > `end`


### PR DESCRIPTION
# feat: SJRA-1613 Add data QA on cytoband ensembl_gene and ensembl_exon_by_gene tables

## 📌 Context

Ce PR ajoute une couverture d'assurance qualité des données (tests dbt) sur trois tables de référence génomique du schéma `radiant` : `cytoband`, `ensembl_gene` et `ensembl_exon_by_gene`. L'objectif est de valider l'intégrité de ces données de référence (non-nullité, unicité, valeurs acceptées et cohérence des coordonnées génomiques).

## 📝 Changes

- Ajout de `data-qa/sources/cytoband.yml` : tests sur la table `cytoband`
  - `should_not_contain_only_null` (avec exceptions pour les colonnes déjà couvertes par des tests `not_null`)
  - `should_not_contain_same_value`
  - unicité de la combinaison `chromosome` + `cytoband`
  - `not_null` sur `chromosome`, `cytoband`, `start`, `end`
  - `accepted_values` sur `chromosome` via le dictionnaire `dict_chromosome()`
- Ajout de `data-qa/sources/ensembl_gene.yml` : tests sur la table `ensembl_gene`
  - `should_not_contain_only_null` et `should_not_contain_same_value` (avec exceptions pour les colonnes nulles ou constantes par construction)
  - unicité de `gene_id` (+ `not_null`)
  - `not_null` sur `chromosome`, `start`, `end`
  - `accepted_values` sur `biotype` via le dictionnaire `dict_biotype()` (appliqué uniquement quand `biotype is not null`)
- Ajout de `data-qa/sources/ensembl_exon_by_gene.yml` : tests sur la table `ensembl_exon_by_gene`
  - `should_not_contain_only_null` et `should_not_contain_same_value` (avec exceptions pour les colonnes nulles ou constantes par construction)
  - unicité de la combinaison `gene_id` + `exon_id`
  - `not_null` sur `gene_id`, `exon_id`, `chromosome`, `start`, `end`
- Ajout de trois tests SQL singuliers validant l'ordre des coordonnées (`start <= end`) :
  - `data-qa/tests/cytoband__validate_start_end_order.sql`
  - `data-qa/tests/ensembl_gene__validate_start_end_order.sql`
  - `data-qa/tests/ensembl_exon_by_gene__validate_start_end_order.sql`

## 🧪 Tests

Les tests dbt ajoutés ont été exécutés localement et passent avec succès. Aucune modification de modèle ou de données — il s'agit uniquement de tests de qualité s'appuyant sur les sources existantes et les macros de dictionnaires (`dict_chromosome()`, `dict_biotype()`).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1613

<!-- End JIRA Issues -->
