### PR TITLE
feat: SJRA-1616 Add data QA on hpo_gene_panel omim_gene_panel and orphanet_gene_panel tables

### DIFF
--- a/data-qa/macros/dictionaries.sql
+++ b/data-qa/macros/dictionaries.sql
@@ -138,3 +138,14 @@
   {# mirrors facets.go + i18n — keep in sync #}
   {{ return(['D', 'N', 'U']) }}
 {% endmacro %}
+
+{% macro dict_omim_inheritance() %}
+  {# Notion: https://app.notion.com/p/ferlab/56bb564925294827989c1afde0b720e7?v=48bc6c4c68464c4fb45014f94bf527a2 #}
+  {# mirrors facets.go — keep in sync #}
+  {{ return(['?AD', '?AR', '?DD', '?DR', '?IC',
+             '?Mi', '?Mu', '?SMo', '?Smu', '?XL',
+             '?XLD', '?XLR', '?YL', 'AD', 'AR',
+             'DD', 'DR', 'IC', 'ICB', 'Mi', 'Mu',
+             'NA', 'NRP', 'NRT', 'PD', 'PR', 'SMo', 'Smu',
+             'XL', 'XLD', 'XLR', 'YL']) }}
+{% endmacro %}

--- a/data-qa/sources/hpo_gene_panel.yml
+++ b/data-qa/sources/hpo_gene_panel.yml
@@ -1,0 +1,37 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: hpo_gene_panel
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: hpo_gene_panel__should_not_contain_only_null
+              except:
+                # Already covered by hpo_gene_panel__should_not_contain_null__*
+                - hpo_term_id
+                - panel
+                - symbol
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: hpo_gene_panel__should_not_contain_same_value
+        columns:
+          - name: symbol
+            description: "VARCHAR(30)."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: hpo_gene_panel__should_not_contain_null__symbol
+          - name: panel
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: hpo_gene_panel__should_not_contain_null__panel
+          - name: hpo_term_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: hpo_gene_panel__should_not_contain_null__hpo_term_id

--- a/data-qa/sources/omim_gene_panel.yml
+++ b/data-qa/sources/omim_gene_panel.yml
@@ -1,0 +1,39 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: omim_gene_panel
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: omim_gene_panel__should_not_contain_only_null
+              except:
+                # Already covered by omim_gene_panel__should_not_contain_null__*
+                - panel
+                - symbol
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: omim_gene_panel__should_not_contain_same_value
+        columns:
+          - name: symbol
+            description: "VARCHAR(30)."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: omim_gene_panel__should_not_contain_null__symbol
+          - name: panel
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: omim_gene_panel__should_not_contain_null__panel
+          - name: inheritance_code
+            description: "ARRAY<VARCHAR(5)>."
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # values: dict_omim_inheritance() — see macros/dictionaries.sql
+              - accepted_values_in_array:
+                  name: omim_gene_panel__accepted_values_inheritance_code
+                  values: "{{ dict_omim_inheritance() }}"

--- a/data-qa/sources/orphanet_gene_panel.yml
+++ b/data-qa/sources/orphanet_gene_panel.yml
@@ -1,0 +1,31 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: orphanet_gene_panel
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: orphanet_gene_panel__should_not_contain_only_null
+              except:
+                # Already covered by orphanet_gene_panel__should_not_contain_null__*
+                - panel
+                - symbol
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: orphanet_gene_panel__should_not_contain_same_value
+        columns:
+          - name: symbol
+            description: "VARCHAR(30)."
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: orphanet_gene_panel__should_not_contain_null__symbol
+          - name: panel
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: orphanet_gene_panel__should_not_contain_null__panel


### PR DESCRIPTION
# feat: SJRA-1616 Add data QA on hpo_gene_panel omim_gene_panel and orphanet_gene_panel tables

## 📌 Context

Ce PR étend la couverture de tests data-qa (dbt) aux trois tables de panels de gènes : `hpo_gene_panel`, `omim_gene_panel` et `orphanet_gene_panel`. L'objectif est de valider l'intégrité des données chargées dans ces sources (absence de valeurs nulles sur les colonnes clés, absence de colonnes entièrement nulles ou constantes, et conformité des valeurs codées).

## 📝 Changes

- Ajout de la source `hpo_gene_panel.yml` : tests `not_null` sur `symbol`, `panel` et `hpo_term_id`, plus `should_not_contain_only_null` (exceptant les colonnes déjà couvertes par `not_null`) et `should_not_contain_same_value`.
- Ajout de la source `omim_gene_panel.yml` : tests `not_null` sur `symbol` et `panel`, `should_not_contain_only_null`, `should_not_contain_same_value`, et `accepted_values_in_array` sur `inheritance_code` (colonne de type `ARRAY<VARCHAR(5)>`).
- Ajout de la source `orphanet_gene_panel.yml` : tests `not_null` sur `symbol` et `panel`, `should_not_contain_only_null` et `should_not_contain_same_value`.
- Ajout du macro `dict_omim_inheritance()` dans `macros/dictionaries.sql` : dictionnaire des codes de transmission OMIM acceptés, aligné sur `facets.go` (commentaire « keep in sync » + lien Notion de référence).

## 🧪 Tests

- Les tests data-qa impactés ont été exécutés localement et passent avec succès.
- `inheritance_code` étant un tableau, la validation utilise `accepted_values_in_array` (valeurs brutes, sensibles à la casse) plutôt que `accepted_values`, conformément à la convention du projet.
- Les colonnes couvertes par un test `not_null` sont exclues du test `should_not_contain_only_null` via la clause `except` pour éviter une redondance.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1616

<!-- End JIRA Issues -->
