### PR TITLE
feat: SJRA-1618 Add data QA on hpo_term and mondo_term tables

### DIFF
--- a/data-qa/sources/hpo_term.yml
+++ b/data-qa/sources/hpo_term.yml
@@ -1,0 +1,36 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: hpo_term
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: hpo_term__should_not_contain_only_null
+              except:
+                # Already covered by hpo_term__should_not_contain_null__*
+                - id
+                - name
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: hpo_term__should_not_contain_same_value
+              except:
+                # Already covered by hpo_term__should_be_unique__*
+                - id
+        columns:
+          - name: id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: hpo_term__should_not_contain_null__id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: hpo_term__should_be_unique__id
+          - name: name
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: hpo_term__should_not_contain_null__name

--- a/data-qa/sources/mondo_term.yml
+++ b/data-qa/sources/mondo_term.yml
@@ -1,0 +1,36 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: mondo_term
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: mondo_term__should_not_contain_only_null
+              except:
+                # Already covered by mondo_term__should_not_contain_null__*
+                - id
+                - name
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: mondo_term__should_not_contain_same_value
+              except:
+                # Already covered by mondo_term__should_be_unique__*
+                - id
+        columns:
+          - name: id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: mondo_term__should_not_contain_null__id
+              # --- Should Be Unique ------------------------------------------
+              - unique:
+                  name: mondo_term__should_be_unique__id
+          - name: name
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: mondo_term__should_not_contain_null__name


### PR DESCRIPTION
# feat: SJRA-1618 Add data QA on hpo_term and mondo_term tables

## 📌 Context

Les tables `hpo_term` et `mondo_term` (vocabulaires HPO et MONDO) n'étaient pas couvertes par des tests de qualité de données. Ce PR ajoute la validation data-QA pour ces deux tables sources afin de détecter toute dégradation de l'ingestion (colonnes vides, doublons, valeurs nulles sur les champs clés).

## 📝 Changes

- Ajout de `data-qa/sources/hpo_term.yml` : nouvelle source `radiant.hpo_term` avec ses tests.
- Ajout de `data-qa/sources/mondo_term.yml` : nouvelle source `radiant.mondo_term` avec ses tests.

Pour chacune des deux tables, les mêmes tests sont définis :

- **Au niveau table** :
  - `should_not_contain_only_null` — aucune colonne entièrement nulle, en excluant `id` et `name` (déjà couverts par les tests `not_null` de colonne).
  - `should_not_contain_same_value` — aucune colonne ne contient une seule et même valeur, en excluant `id` (déjà couvert par le test `unique`).
- **Au niveau colonne** :
  - `id` : `not_null` + `unique`.
  - `name` : `not_null`.

Le schéma reste paramétrable via `env_var('SR_SCHEMA', 'radiant')`.

## 🧪 Tests

- Tests data-QA dbt exécutés localement sur `hpo_term` et `mondo_term` : passent avec succès.
- Aucun test existant impacté (ajout de deux nouveaux fichiers sources uniquement).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1618

<!-- End JIRA Issues -->
