### PR TITLE
feat: sjra-1641 Return TriggerEvent on missed count

### DIFF
--- a/radiant/tasks/starrocks/trigger.py
+++ b/radiant/tasks/starrocks/trigger.py
@@ -51,7 +51,7 @@ class StarRocksTaskCompleteTrigger(BaseTrigger):
             LOGGER.info("Expected variable `result` is None, retrying...")
             self._missed_count += 1
             if self._missed_count >= self._MISSED_MAX_COUNT:
-                TriggerEvent({"status": "error", "error_message": f"task {self.task_name} not found"})
+                return TriggerEvent({"status": "error", "error_message": f"task {self.task_name} not found"})
             return None
 
         self._missed_count = 0

--- a/tests/unit/starrocks/test_trigger.py
+++ b/tests/unit/starrocks/test_trigger.py
@@ -61,6 +61,9 @@ def test_get_task_completed_none(mock_connection):
     result = [trigger._get_task_completed(mock_connection) for _ in range(5)]
 
     assert result[:4] == [None, None, None, None]
+    assert isinstance(result[4], TriggerEvent)
+    assert result[4].payload.get("status") == "error"
+    assert result[4].payload.get("error_message") == "task test_task not found"
 
 
 def test_get_task_completed_unknown(mock_connection):
@@ -123,7 +126,8 @@ def test_run_trigger_until_unknown(mock_connection):
 
     assert len(result) == 1
     assert isinstance(result[0], TriggerEvent)
-    assert result[0].payload.get("error_message") == "Caught <class 'StopIteration'> caused test_task to fail"
+    assert result[0].payload.get("status") == "error"
+    assert result[0].payload.get("error_message") == "task test_task not found"
 
 
 def test_get_task_complete_programming_error(mock_connection):


### PR DESCRIPTION
  ## 📌 Context

  `StarRocksTaskCompleteTrigger._get_task_completed` built a terminal `TriggerEvent` on the "task not found" branch but never returned it. Execution fell through to `return None`, so `run()`'s `while result is None` loop kept polling — the deferred trigger never emitted the error, the triggerer slot stayed occupied, and the DAG task hung until the StarRocks task appeared or the cursor raised.

  ## 📝 Changes

  - `radiant/tasks/starrocks/trigger.py`: add missing `return` to the not-found `TriggerEvent` so the trigger fails fast after `_MISSED_MAX_COUNT` polls.

  ## ☑️ TO-DOs
  
  - [x] None

  ## 🧪 Tests

  - Updated `tests/unit/starrocks/test_trigger.py` — both affected tests previously passed *because* of the bug (the dropped event was masked by a later `StopIteration`).
    - `test_get_task_completed_none`: assert the 5th call returns a `TriggerEvent` with `status="error"`, `error_message="task test_task not found"`.
    - `test_run_trigger_until_unknown`: expect the not-found event instead of the `StopIteration` fallback.
  - Run: `pytest tests/unit/starrocks/test_trigger.py` — 9 passed. `ruff check` clean.

  ## 🔗 Related Issues

  [SJRA-1641](https://d3b.atlassian.net/browse/SJRA-1641) (parent: [SJRA-1640](https://d3b.atlassian.net/browse/SJRA-1640), TD-1)

  ## 👀 Notes for Reviewers
  
  - One-token fix; behavior change verified by the two re-pinned tests.
  - Optional follow-up (not in this PR): the exception branch at `trigger.py:47` omits the `status` key the other terminal events set — still fails correctly, just non-uniform.

[SJRA-1641]: https://d3b.atlassian.net/browse/SJRA-1641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ