### PR TITLE
feat: SJRA-1642 improve handling of S3 errors when downloading files

### DIFF
--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -5,7 +5,13 @@ from functools import wraps
 from urllib import parse
 
 import boto3
+from boto3.exceptions import Boto3Error
+from botocore.exceptions import BotoCoreError, ClientError
 from wurlitzer import pipes
+
+
+class S3DownloadError(Exception):
+    """Raised when an S3 download fails; wraps the underlying boto3/botocore/OS error."""
 
 
 def _flush_pipes(stdout, stderr):
@@ -71,9 +77,8 @@ def download_s3_file(s3_path, dest_dir, randomize_filename=False):
     local_path = os.path.join(dest_dir, filename)
     try:
         s3_client.download_file(bucket_name, object_key, local_path)
-    except Exception as e:
-        print(f"Error downloading S3 file: {e}")
-        return None
+    except (BotoCoreError, ClientError, Boto3Error, OSError) as e:
+        raise S3DownloadError(f"Failed to download S3 file {s3_path}") from e
     return local_path
 
 

--- a/radiant/tasks/vcf/cnv/germline/process.py
+++ b/radiant/tasks/vcf/cnv/germline/process.py
@@ -115,9 +115,7 @@ def import_cnv_vcf(tasks: list[dict], namespace: str) -> None:
 
         # If all files failed, we abort
         if attempted and not updated_tasks:
-            raise RuntimeError(
-                f"All {attempted} Germline CNV download(s) failed"
-            )
+            raise RuntimeError(f"All {attempted} Germline CNV download(s) failed")
 
         logger.info("Starting CNV VCF processing for all tasks")
         process_tasks(updated_tasks, namespace=namespace, vcf_threads=4)

--- a/radiant/tasks/vcf/cnv/germline/process.py
+++ b/radiant/tasks/vcf/cnv/germline/process.py
@@ -7,7 +7,7 @@ from cyvcf2 import VCF
 from pyiceberg.catalog import load_catalog
 
 from radiant.tasks.tracing.trace import get_tracer
-from radiant.tasks.utils import download_s3_file
+from radiant.tasks.utils import S3DownloadError, download_s3_file
 from radiant.tasks.vcf.cnv.germline.occurrence import process_occurrence
 from radiant.tasks.vcf.experiment import (
     ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK,
@@ -32,11 +32,16 @@ def process_tasks(
     with tracer.start_as_current_span("process_tasks"):
         occurrences_partition_commit = []
 
+        occurrences_table_name = f"{namespace}.germline_cnv_occurrence"
+        if not tasks:
+            # Overwriting with an empty buffer would wipe the table; refuse the no-op.
+            logger.warning(f"No CNV tasks to process; skipping overwrite of {occurrences_table_name}")
+            return {occurrences_table_name: occurrences_partition_commit}
+
         catalog = (
             load_catalog(catalog_name, **catalog_properties) if catalog_properties else load_catalog(catalog_name)
         )
 
-        occurrences_table_name = f"{namespace}.germline_cnv_occurrence"
         occurrence_table = catalog.load_table(occurrences_table_name)
         occurrence_buffer = []
         for task in tasks:
@@ -81,18 +86,41 @@ def import_cnv_vcf(tasks: list[dict], namespace: str) -> None:
     logger = logging.getLogger(__name__)
 
     updated_tasks = []
+    attempted = 0
+    skipped = 0
     with tempfile.TemporaryDirectory() as tmpdir:
         for task in tasks:
             if task.get("task_type") != ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK:
                 continue
 
+            attempted += 1
             logger.info(f"Downloading VCF and index files from {task['cnv_vcf_filepath']} to a temporary directory")
-            cnv_vcf_local = download_s3_file(task["cnv_vcf_filepath"], tmpdir, randomize_filename=True)
+            try:
+                cnv_vcf_local = download_s3_file(task["cnv_vcf_filepath"], tmpdir, randomize_filename=True)
+            except S3DownloadError as e:
+                skipped += 1
+                logger.warning(
+                    f"Failed to download CNV VCF for task [{task.get('task_id')}] "
+                    f"from {task['cnv_vcf_filepath']}, skipping: {e}"
+                )
+                continue
             logger.info(f"Downloaded CNV VCF to {cnv_vcf_local}")
             task["cnv_vcf_filepath"] = cnv_vcf_local
 
             task = AlignmentGermlineVariantCallingTask.model_validate(task)
             updated_tasks.append(task)
+
+        if skipped:
+            logger.warning(f"Skipped {skipped}/{attempted} CNV tasks due to download failures")
+
+        # Guard against wiping germline_cnv_occurrence: if every candidate task failed to
+        # download (e.g. an S3 outage), a full overwrite would replace the table with an
+        # empty result. Fail loudly instead so the run is retried, not silently emptied.
+        if attempted and not updated_tasks:
+            raise RuntimeError(
+                f"All {attempted} CNV download(s) failed; aborting to avoid overwriting "
+                f"{namespace}.germline_cnv_occurrence with an empty table"
+            )
 
         logger.info("Starting CNV VCF processing for all tasks")
         process_tasks(updated_tasks, namespace=namespace, vcf_threads=4)

--- a/radiant/tasks/vcf/cnv/germline/process.py
+++ b/radiant/tasks/vcf/cnv/germline/process.py
@@ -113,13 +113,10 @@ def import_cnv_vcf(tasks: list[dict], namespace: str) -> None:
         if skipped:
             logger.warning(f"Skipped {skipped}/{attempted} CNV tasks due to download failures")
 
-        # Guard against wiping germline_cnv_occurrence: if every candidate task failed to
-        # download (e.g. an S3 outage), a full overwrite would replace the table with an
-        # empty result. Fail loudly instead so the run is retried, not silently emptied.
+        # If all files failed, we abort
         if attempted and not updated_tasks:
             raise RuntimeError(
-                f"All {attempted} CNV download(s) failed; aborting to avoid overwriting "
-                f"{namespace}.germline_cnv_occurrence with an empty table"
+                f"All {attempted} Germline CNV download(s) failed"
             )
 
         logger.info("Starting CNV VCF processing for all tasks")

--- a/radiant/tasks/vcf/snv/somatic/process.py
+++ b/radiant/tasks/vcf/snv/somatic/process.py
@@ -220,11 +220,9 @@ def import_somatic_snv(tasks: list[dict], namespace: str):
     if skipped:
         logger.warning(f"Skipped {skipped}/{attempted} somatic SNV tasks due to download failures")
 
-    # If every candidate task failed to download (e.g. an S3 outage), abort instead of
-    # silently committing nothing: a fully-failed batch should fail the run so it is retried,
-    # not reported as a success.
+    # If all files failed, we abort
     if attempted and skipped == attempted:
-        raise RuntimeError(f"All {attempted} somatic SNV download(s) failed; aborting so the batch is retried")
+        raise RuntimeError(f"All {attempted} somatic SNV download(s) failed")
 
     # Merge results from all tasks and convert PartitionCommit objects to dicts
     commit_partitions(merged_partitions)

--- a/radiant/tasks/vcf/snv/somatic/process.py
+++ b/radiant/tasks/vcf/snv/somatic/process.py
@@ -9,7 +9,7 @@ from pyiceberg.catalog import load_catalog
 from radiant.tasks.iceberg.partition_commit import PartitionCommit
 from radiant.tasks.iceberg.table_accumulator import TableAccumulator
 from radiant.tasks.iceberg.utils import commit_files
-from radiant.tasks.utils import capture_libc_stderr_and_check_errors, download_s3_file
+from radiant.tasks.utils import S3DownloadError, capture_libc_stderr_and_check_errors, download_s3_file
 from radiant.tasks.vcf.experiment import RADIANT_SOMATIC_ANNOTATION_TASK, Experiment, RadiantSomaticAnnotationTask
 from radiant.tasks.vcf.snv.common import process_common
 from radiant.tasks.vcf.snv.consequence import parse_csq_header, process_consequence
@@ -187,15 +187,26 @@ def import_somatic_snv(tasks: list[dict], namespace: str):
     logger = logging.getLogger(__name__)
 
     merged_partitions = defaultdict(list)
+    attempted = 0
+    skipped = 0
 
     logger.info("Downloading VCF and index files to a temporary directory")
     for task in tasks:
         if task["task_type"] != RADIANT_SOMATIC_ANNOTATION_TASK:
             continue
 
+        attempted += 1
         with tempfile.TemporaryDirectory() as tmpdir:
-            vcf_local = download_s3_file(task["vcf_filepath"], tmpdir)
-            index_local = download_s3_file(task["vcf_filepath"] + ".tbi", tmpdir)
+            try:
+                vcf_local = download_s3_file(task["vcf_filepath"], tmpdir)
+                index_local = download_s3_file(task["vcf_filepath"] + ".tbi", tmpdir)
+            except S3DownloadError as e:
+                skipped += 1
+                logger.warning(
+                    f"Failed to download somatic VCF for task [{task.get('task_id')}] "
+                    f"from {task['vcf_filepath']}, skipping: {e}"
+                )
+                continue
             task_data = {**task, "vcf_filepath": vcf_local, "index_vcf_filepath": index_local}
 
             task = RadiantSomaticAnnotationTask.model_validate(task_data)
@@ -205,6 +216,15 @@ def import_somatic_snv(tasks: list[dict], namespace: str):
             partitions = process_task(task, namespace=namespace, vcf_threads=4)
             logger.info(f"✅ Parquet files created: {task_data['task_id']}, file {task_data['vcf_filepath']}")
             merge_partitions_in_place(merged_partitions, partitions)
+
+    if skipped:
+        logger.warning(f"Skipped {skipped}/{attempted} somatic SNV tasks due to download failures")
+
+    # If every candidate task failed to download (e.g. an S3 outage), abort instead of
+    # silently committing nothing: a fully-failed batch should fail the run so it is retried,
+    # not reported as a success.
+    if attempted and skipped == attempted:
+        raise RuntimeError(f"All {attempted} somatic SNV download(s) failed; aborting so the batch is retried")
 
     # Merge results from all tasks and convert PartitionCommit objects to dicts
     commit_partitions(merged_partitions)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,8 +1,10 @@
 import sys
 from io import StringIO
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from radiant.tasks.utils import capture_libc_stderr_and_check_errors
+import pytest
+
+from radiant.tasks.utils import S3DownloadError, capture_libc_stderr_and_check_errors, download_s3_file
 
 
 def test_raises_value_error_when_error_pattern_is_found_in_stderr():
@@ -51,3 +53,40 @@ def test_handles_exception_and_flushes_pipes_correctly(capsys):
             capture = capsys.readouterr()
             assert capture.out == "stdout content\n"
             assert capture.err == "Exception raised\nstderr content\n"
+
+
+def test_download_s3_file_returns_local_path_on_success():
+    mock_client = MagicMock()
+    with patch("radiant.tasks.utils.boto3.client", return_value=mock_client):
+        result = download_s3_file("s3://my-bucket/path/to/file.vcf.gz", "/tmp/dest")
+
+    assert result == "/tmp/dest/file.vcf.gz"
+    mock_client.download_file.assert_called_once_with(
+        "my-bucket", "path/to/file.vcf.gz", "/tmp/dest/file.vcf.gz"
+    )
+
+
+def test_download_s3_file_propagates_error_with_s3_path():
+    original = OSError("AccessDenied")
+    mock_client = MagicMock()
+    mock_client.download_file.side_effect = original
+    s3_path = "s3://my-bucket/path/to/file.vcf.gz"
+
+    with (
+        patch("radiant.tasks.utils.boto3.client", return_value=mock_client),
+        pytest.raises(S3DownloadError) as exc_info,
+    ):
+        download_s3_file(s3_path, "/tmp/dest")
+
+    assert s3_path in str(exc_info.value)
+    assert exc_info.value.__cause__ is original
+
+
+def test_download_s3_file_randomizes_filename():
+    mock_client = MagicMock()
+    with patch("radiant.tasks.utils.boto3.client", return_value=mock_client):
+        result = download_s3_file("s3://my-bucket/path/file.vcf.gz", "/tmp/dest", randomize_filename=True)
+
+    assert result.startswith("/tmp/dest/")
+    assert result.endswith("_file.vcf.gz")
+    assert result != "/tmp/dest/file.vcf.gz"

--- a/tests/unit/vcf/germline/test_germline_cnv_process.py
+++ b/tests/unit/vcf/germline/test_germline_cnv_process.py
@@ -1,0 +1,73 @@
+from unittest.mock import patch
+
+import pytest
+
+from radiant.tasks.utils import S3DownloadError
+from radiant.tasks.vcf.cnv.germline import process as cnv_process
+from radiant.tasks.vcf.experiment import ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK
+
+
+def _task(task_id: int, filepath: str) -> dict:
+    return {
+        "task_id": task_id,
+        "task_type": ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK,
+        "cnv_vcf_filepath": filepath,
+    }
+
+
+def test_import_cnv_vcf_skips_task_when_not_all_download_fails():
+    """A least one (but not all) failed S3 download must not crash the whole batch."""
+    tasks = [_task(1, "s3://bucket/bad.vcf.gz"), _task(2, "s3://bucket/good.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        if s3_path == "s3://bucket/bad.vcf.gz":
+            raise S3DownloadError("Failed to download S3 file s3://bucket/bad.vcf.gz")
+        return "/tmp/good.vcf.gz"
+
+    with (
+        patch.object(cnv_process, "download_s3_file", side_effect=fake_download),
+        patch.object(cnv_process.AlignmentGermlineVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+    ):
+        cnv_process.import_cnv_vcf(tasks, namespace="radiant")
+
+    # Only the good task reaches processing; the failed download is skipped, not fatal.
+    mock_process.assert_called_once()
+    processed = mock_process.call_args.args[0]
+    assert [t["task_id"] for t in processed] == [2]
+    assert processed[0]["cnv_vcf_filepath"] == "/tmp/good.vcf.gz"
+
+
+def test_import_cnv_vcf_raises_when_all_downloads_fail():
+    """When all downloads fail, we must stop the whole batch."""
+    tasks = [_task(1, "s3://bucket/a.vcf.gz"), _task(2, "s3://bucket/b.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        raise S3DownloadError(f"Failed to download S3 file {s3_path}")
+
+    with (
+        patch.object(cnv_process, "download_s3_file", side_effect=fake_download),
+        patch.object(cnv_process.AlignmentGermlineVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+        pytest.raises(RuntimeError, match="aborting to avoid overwriting"),
+    ):
+        cnv_process.import_cnv_vcf(tasks, namespace="radiant")
+
+    mock_process.assert_not_called()
+
+
+def test_import_cnv_vcf_processes_all_when_downloads_succeed():
+    tasks = [_task(1, "s3://bucket/a.vcf.gz"), _task(2, "s3://bucket/b.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        return f"/tmp/{s3_path[-8:]}"
+
+    with (
+        patch.object(cnv_process, "download_s3_file", side_effect=fake_download),
+        patch.object(cnv_process.AlignmentGermlineVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+    ):
+        cnv_process.import_cnv_vcf(tasks, namespace="radiant")
+
+    processed = mock_process.call_args.args[0]
+    assert [t["task_id"] for t in processed] == [1, 2]

--- a/tests/unit/vcf/germline/test_germline_cnv_process.py
+++ b/tests/unit/vcf/germline/test_germline_cnv_process.py
@@ -49,7 +49,7 @@ def test_import_cnv_vcf_raises_when_all_downloads_fail():
         patch.object(cnv_process, "download_s3_file", side_effect=fake_download),
         patch.object(cnv_process.AlignmentGermlineVariantCallingTask, "model_validate", side_effect=lambda t: t),
         patch.object(cnv_process, "process_tasks") as mock_process,
-        pytest.raises(RuntimeError, match="aborting to avoid overwriting"),
+        pytest.raises(RuntimeError, match=r"download\(s\) failed"),
     ):
         cnv_process.import_cnv_vcf(tasks, namespace="radiant")
 

--- a/tests/unit/vcf/somatic/test_somatic_snv_process.py
+++ b/tests/unit/vcf/somatic/test_somatic_snv_process.py
@@ -1,8 +1,10 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from radiant.tasks.vcf.experiment import Experiment
+from radiant.tasks.utils import S3DownloadError
+from radiant.tasks.vcf.experiment import RADIANT_SOMATIC_ANNOTATION_TASK, Experiment
+from radiant.tasks.vcf.snv.somatic import process as somatic_process
 from radiant.tasks.vcf.snv.somatic.process import get_somatic_indexes
 
 
@@ -99,3 +101,58 @@ def test_returns_tuple_of_two_ints():
     assert isinstance(result, tuple)
     assert len(result) == 2
     assert all(isinstance(i, int) for i in result)
+
+
+def _somatic_task(task_id: int, filepath: str) -> dict:
+    return {
+        "task_id": task_id,
+        "task_type": RADIANT_SOMATIC_ANNOTATION_TASK,
+        "vcf_filepath": filepath,
+    }
+
+
+def test_import_somatic_snv_skips_task_when_download_fails():
+    """A single failed S3 download must not abort the whole somatic batch."""
+    tasks = [_somatic_task(1, "s3://bucket/bad.vcf.gz"), _somatic_task(2, "s3://bucket/good.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        if s3_path.startswith("s3://bucket/bad"):
+            raise S3DownloadError("Failed to download S3 file s3://bucket/bad.vcf.gz")
+        return f"/tmp/{s3_path.rsplit('/', 1)[-1]}"
+
+    with (
+        patch.object(somatic_process, "download_s3_file", side_effect=fake_download),
+        patch.object(somatic_process.RadiantSomaticAnnotationTask, "model_validate", side_effect=lambda d: d),
+        patch.object(somatic_process, "process_task", return_value={"radiant.snv": [{"id": "x"}]}) as mock_proc,
+        patch.object(somatic_process, "commit_partitions") as mock_commit,
+    ):
+        somatic_process.import_somatic_snv(tasks, namespace="radiant")
+
+    # Only the good task is processed; the failed download is skipped, not fatal.
+    assert mock_proc.call_count == 1
+    processed_task = mock_proc.call_args.args[0]
+    assert processed_task["task_id"] == 2
+    # The batch still commits the good task's partitions exactly once.
+    mock_commit.assert_called_once()
+    assert dict(mock_commit.call_args.args[0]) == {"radiant.snv": [{"id": "x"}]}
+
+
+def test_import_somatic_snv_raises_when_all_downloads_fail():
+    """A total S3 outage must fail the batch (so Airflow retries), not report success."""
+    tasks = [_somatic_task(1, "s3://bucket/a.vcf.gz"), _somatic_task(2, "s3://bucket/b.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        raise S3DownloadError(f"Failed to download S3 file {s3_path}")
+
+    with (
+        patch.object(somatic_process, "download_s3_file", side_effect=fake_download),
+        patch.object(somatic_process.RadiantSomaticAnnotationTask, "model_validate", side_effect=lambda d: d),
+        patch.object(somatic_process, "process_task") as mock_proc,
+        patch.object(somatic_process, "commit_partitions") as mock_commit,
+        pytest.raises(RuntimeError, match="aborting so the batch is retried"),
+    ):
+        somatic_process.import_somatic_snv(tasks, namespace="radiant")
+
+    # Nothing processed and nothing committed — the run fails instead of silently succeeding.
+    mock_proc.assert_not_called()
+    mock_commit.assert_not_called()

--- a/tests/unit/vcf/somatic/test_somatic_snv_process.py
+++ b/tests/unit/vcf/somatic/test_somatic_snv_process.py
@@ -149,7 +149,7 @@ def test_import_somatic_snv_raises_when_all_downloads_fail():
         patch.object(somatic_process.RadiantSomaticAnnotationTask, "model_validate", side_effect=lambda d: d),
         patch.object(somatic_process, "process_task") as mock_proc,
         patch.object(somatic_process, "commit_partitions") as mock_commit,
-        pytest.raises(RuntimeError, match="aborting so the batch is retried"),
+        pytest.raises(RuntimeError, match=r"download\(s\) failed"),
     ):
         somatic_process.import_somatic_snv(tasks, namespace="radiant")
 


### PR DESCRIPTION
  ## 📌 Context

  When a VCF file couldn't be downloaded from S3, the error was swallowed (just printed) and the file was silently skipped. Affected data simply went missing with no clear signal of what failed or why. This PR makes download failures explicit and gives the batch imports sensible, visible   behavior when files can't be fetched.


  ## 📝 Changes

  - Failed S3 downloads now raise a clear error (with the file path) instead of being swallowed.
  - CNV and somatic imports skip individual files that fail to download and keep going.
  - If *every* file in a batch fails (e.g. an S3 outage), the run stops and fails.

## 🧪 Tests
  
  - Added unit tests covering: a failed download raises, a single bad file is skipped while the rest succeed, and a fully-failed batch stops the run.

##  🔗 Related Issues

  <!-- Begin JIRA Issues -->
- https://d3b.atlassian.net/browse/SJRA-1642
  <!-- End JIRA Issues -->
  