### PR TITLE
feat: SJRA-1544 implement dag for running starrocks qa data tests

### DIFF
--- a/radiant/dags/data_integrity_starrocks.py
+++ b/radiant/dags/data_integrity_starrocks.py
@@ -1,0 +1,247 @@
+"""Run the data_qa dbt test suite (StarRocks) from Airflow.
+
+Run the dbt tests, then in parallel:
+    - push the results to TestQuality as a JUnit report (optional, see below)
+    - fail the run on test failures, ignoring known errors
+
+The TestQuality push can be turned off per-run via the `skip_testquality_push` DAG param (default off, i.e. push
+enabled), and is also skipped if the corresponding connection is missing.
+
+The TestQuality connection (`testquality_conn`) should contain:
+    - password: TestQuality access token (required)
+    - host:     API base URL (optional, defaults to https://api.testquality.com)
+    - extra:    fields for the body of the import_xml request, e.g.
+                {"project_id": "1234", "run_name": "Clin QA - {date} - Data",
+                 "plan_name": "my_plan", "milestone_name": "my_milestone"}
+
+In the extra, project_id and run_name are required; other import_xml fields are optional.
+In run_name, the {date} placeholder is replaced with the run date (DD/MM/YYYY).
+See the upload_test_run command for the full list of fields:
+https://github.com/BitModern/testQualityCli/blob/master/src/UploadTestRunCommand.ts
+
+The task running dbt is based on the PythonVirtualenvOperator. It essentially mimic the local dbt setup,
+i.e. we create a venv on the fly, inject expected environment variable, and then run the python commands.
+
+The PythonVirtualenvOperator runs synchronously, so a long-running StarRocks query holds a worker until
+it returns. We assume that this is acceptable for now. The dag can be paused to free workers.
+"""
+
+import logging
+import os
+import pathlib
+import re
+
+import pendulum
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+from radiant.dags import DEFAULT_ARGS, NAMESPACE
+
+LOGGER = logging.getLogger(__name__)
+
+DATA_QA_DIR = str(pathlib.Path(__file__).resolve().parent.parent / "data_qa")
+
+
+TESTQUALITY_CONN_ID = "testquality_conn"
+TESTQUALITY_DEFAULT_API_URL = "https://api.testquality.com"
+
+# Jira project ids whose tagged failing tests are treated as known errors
+KNOWN_ERROR_JIRA_PROJECTS = ("SJRA",)
+# Matches a known error tag in a test name, e.g. SJRA-1234 (case-insensitive)
+KNOWN_ERROR_TAG = re.compile(rf"(?:{'|'.join(KNOWN_ERROR_JIRA_PROJECTS)})-\d+", re.IGNORECASE)
+
+
+# Create required environment variables for dbt
+def export_starrocks_env(context) -> None:
+    from airflow.hooks.base import BaseHook
+
+    conn = BaseHook.get_connection("starrocks_conn")
+    os.environ["SR_HOST"] = conn.host
+    os.environ["SR_PORT"] = str(conn.port)
+    os.environ["SR_USER"] = conn.login or "root"
+    os.environ["SR_PASSWORD"] = conn.password or ""
+
+
+# Clear environment variables once dbt has run
+# Most executors run each task on it's own short-lived process (fork or pod), but we clean up for prevention.
+def clear_starrocks_env(context, result=None) -> None:
+    for var in ("SR_HOST", "SR_PORT", "SR_USER", "SR_PASSWORD"):
+        os.environ.pop(var, None)
+
+
+@dag(
+    dag_id=f"{NAMESPACE}-data-integrity-starrocks",
+    default_args=DEFAULT_ARGS,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    tags=["radiant", "dbt", "starrocks"],
+    dag_display_name="Radiant - Data Integrity Checks (StarRocks)",
+    params={
+        "skip_testquality_push": Param(
+            False,
+            type="boolean",
+            title="Skip TestQuality push",
+            description="When enabled, the TestQuality upload task is skipped for this run.",
+        ),
+    },
+)
+def data_integrity_starrocks():
+    @task.virtualenv(
+        task_id="run_dbt",
+        task_display_name="[VenvOp] Run dbt data tests",
+        requirements=["dbt-core~=1.9.0", "dbt-starrocks~=1.9.0"],
+        system_site_packages=False,  # avoid conflicts with airflow dependencies
+        venv_cache_path=None,  # starts from a fresh venv; required to automatically cleanup files written by dbt
+        pre_execute=export_starrocks_env,
+        post_execute=clear_starrocks_env,
+    )
+    def run_dbt(data_qa_dir: str) -> str:
+        """Run the data_qa dbt test suite against StarRocks.
+
+        Returns dbt's run_results.json artifact (as dict) via XCom.
+        """
+        import json
+        import os
+        import shutil
+        import sys
+        from pathlib import Path
+
+        from dbt.cli.main import dbtRunner
+
+        os.environ["DBT_SEND_ANONYMOUS_USAGE_STATS"] = "false"
+
+        # When it is run, dbt writes files to disk.
+        # To avoid polluting the worker filesystem, we work from a copy of the dbt project in the
+        # virtual env. This assumes venv_cache_path=None (airflow's default).
+        proj_dir = os.path.join(sys.prefix, "data_qa")
+        shutil.copytree(
+            data_qa_dir,
+            proj_dir,
+            ignore=shutil.ignore_patterns(".venv", "target", "dbt_packages", "logs", "__pycache__", ".env"),
+        )
+
+        runner = dbtRunner()
+
+        global_flags = [
+            "--use-colors",  # force ANSI colors as these won't be added by default as the worker stdout isn't a TTY
+            "--printer-width",
+            "120",
+        ]
+        command_flags = ["--project-dir", proj_dir, "--profiles-dir", proj_dir]
+
+        deps = runner.invoke([*global_flags, "deps", *command_flags])
+        if not deps.success:
+            raise RuntimeError(f"`dbt deps` failed: {deps.exception}")
+
+        res = runner.invoke([*global_flags, "test", *command_flags])
+        if res.exception:
+            raise RuntimeError(f"dbt itself failed to run (not a data-test failure): {res.exception}")
+
+        run_results_path = Path(proj_dir) / "target" / "run_results.json"
+        if not run_results_path.exists():
+            raise RuntimeError("dbt produced no run_results.json — likely a StarRocks connection failure.")
+        return json.loads(run_results_path.read_text(encoding="utf-8"))
+
+    @task(
+        task_id="upload_to_testquality",
+        task_display_name="Upload JUnit report to TestQuality",
+    )
+    def upload_to_testquality(run_results_json: dict) -> None:
+        """Convert dbt's run_results.json to JUnit XML and push it to TestQuality.
+
+        Skips when the `skip_testquality_push` DAG param is enabled, or when the testquality_conn
+        connection is absent.
+        """
+        import requests
+        from airflow.exceptions import AirflowFailException, AirflowNotFoundException, AirflowSkipException
+        from airflow.hooks.base import BaseHook
+        from airflow.operators.python import get_current_context
+
+        from radiant.data_qa.scripts.run_results_to_junit import to_junit_xml
+
+        context = get_current_context()
+        if context["params"]["skip_testquality_push"]:
+            raise AirflowSkipException(
+                "TestQuality upload disabled via the 'skip_testquality_push' DAG param — skipping."
+            )
+
+        try:
+            conn = BaseHook.get_connection(TESTQUALITY_CONN_ID)
+        except AirflowNotFoundException:
+            raise AirflowSkipException(
+                f"Connection '{TESTQUALITY_CONN_ID}' not configured — skipping TestQuality upload."
+            ) from None
+
+        junit_xml = to_junit_xml(run_results_json)
+
+        extra = conn.extra_dejson
+        missing = {"run_name", "project_id"} - extra.keys()
+        if missing:
+            raise AirflowFailException(
+                f"testquality_conn extra is missing required keys: {', '.join(sorted(missing))}"
+            )
+        run_name = extra.pop("run_name").replace("{date}", context["logical_date"].strftime("%d/%m/%Y"))
+        data = {"run_name": run_name, "filepath": "junit.xml", **extra}
+
+        resp = requests.post(
+            f"{conn.host or TESTQUALITY_DEFAULT_API_URL}/api/import_xml",  # CLI's default upload route
+            headers={"Authorization": f"Bearer {conn.password}"},
+            data=data,
+            files={"file": ("junit.xml", junit_xml, "text/xml")},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        LOGGER.info("TestQuality import_xml response: %s", resp.text)
+        LOGGER.info("Uploaded JUnit report to TestQuality as run '%s'.", run_name)
+
+    @task(
+        task_id="check_qa_results",
+        task_display_name="Assert no failing data tests",
+    )
+    def check_results(run_results_json: dict) -> None:
+        """Fail the run if unexpected data tests failed
+
+        Failing tests tagged with a Jira ticket (SJRA-XXXX) are known errors: they are reported
+        but do not fail the run.
+        """
+
+        from collections import Counter
+
+        from airflow.exceptions import AirflowFailException
+
+        results = run_results_json.get("results", [])
+        status_counts: Counter = Counter()
+        known, unexpected = [], []
+        for r in results:
+            status = (r.get("status") or "").lower()
+            status_counts[status] += 1
+            if status in ("fail", "error"):
+                uid = r["unique_id"]
+                (known if KNOWN_ERROR_TAG.search(uid) else unexpected).append(uid)
+
+        LOGGER.info(
+            "%d passed · %d warned · %d failed — %d known, %d unexpected (of %d)",
+            status_counts["pass"],
+            status_counts["warn"],
+            len(known) + len(unexpected),
+            len(known),
+            len(unexpected),
+            len(results),
+        )
+        if known:
+            LOGGER.warning("Known errors (tagged with a Jira ticket), not failing the run:\n%s", "\n".join(known))
+
+        if unexpected:
+            raise AirflowFailException(
+                f"{len(unexpected)} DATA QA test(s) failed. "
+                f"See the 'Run dbt data tests' task logs for the full dbt output.\n"
+                f"Failed tests:\n" + "\n".join(unexpected)
+            )
+
+    run_results = run_dbt(data_qa_dir=DATA_QA_DIR)
+    upload_to_testquality(run_results)
+    check_results(run_results)
+
+
+data_integrity_starrocks()

--- a/radiant/dags/import_radiant.py
+++ b/radiant/dags/import_radiant.py
@@ -140,12 +140,21 @@ def import_radiant():
         map_index_template="Partition: {{ task.conf['part'] }}",
     ).expand(conf=priority)
 
+    run_data_integrity_checks = TriggerDagRunOperator(
+        task_id="data_integrity_checks",
+        task_display_name="[DAG] Data Integrity Checks (StarRocks)",
+        trigger_dag_id=f"{NAMESPACE}-data-integrity-starrocks",
+        reset_dag_run=True,
+        wait_for_completion=True,
+    )
+
     (
         start
         >> tg_partition_group
         >> updated_deleted_sequencing_experiment
         >> fetch_sequencing_experiment
         >> import_parts
+        >> run_data_integrity_checks
     )
 
 

--- a/radiant/data_qa/README.md
+++ b/radiant/data_qa/README.md
@@ -46,7 +46,7 @@ yet handle**. "The portal" hardcodes behaviour in two places:
 
 A new upstream value not present in **either** source is fully unhandled.
 A value present in only one is a portal-internal inconsistency (out of
-scope for data-qa, but worth flagging).
+scope for data_qa, but worth flagging).
 
 Each test's accepted-values list mirrors the relevant source(s) — the
 **union** of backend facets and frontend i18n for scalar columns. The lists
@@ -75,7 +75,7 @@ custom `accepted_values_in_array` generic test (`macros/`), which `array_filter`
 each array down to the offending elements *before* unnesting (so valid rows
 emit nothing instead of exploding) and flags any element not in `values`. Both are declared in the
 source YAML with a `name:` (append the Jira id when a ticket tracks a known
-gap, e.g. `..._SJRA1552`) and a `values:` list.
+gap, e.g. `..._SJRA-1552`) and a `values:` list.
 
 Values are tested **raw / case-sensitive** — no normalization. For array
 columns the dictionary therefore mirrors backend `facets.go` in its data
@@ -93,7 +93,7 @@ invariants that don't fit a generic test (e.g. `no_star_alternate`).
 ## Setup
 
 ```bash
-cd data-qa
+cd data_qa
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -142,7 +142,7 @@ investigate.
 ## Layout
 
 ```
-data-qa/
+data_qa/
 ├── macros/    # custom generic tests + dictionaries.sql
 ├── sources/   # source + generic-test declarations, one YAML per table
 ├── tests/     # singular tests (cross-field invariants), one SQL per check

--- a/radiant/data_qa/macros/dictionaries.sql
+++ b/radiant/data_qa/macros/dictionaries.sql
@@ -9,7 +9,7 @@
   (`frontend/translations/common/*.json`). The `mirrors … — keep in sync`
   note lives here, once per dictionary, so there is a single place to update
   when an upstream value is added. Values are raw / case-sensitive (no
-  normalization) — see data-qa/README.md.
+  normalization) — see data_qa/README.md.
 #}
 
 {% macro dict_chromosome() %}

--- a/radiant/data_qa/scripts/run_results_to_junit.py
+++ b/radiant/data_qa/scripts/run_results_to_junit.py
@@ -35,16 +35,13 @@ def _test_name(unique_id: str) -> str:
     return unique_id
 
 
-def convert(run_results_path: Path, junit_path: Path) -> int:
-    if not run_results_path.exists():
-        print(
-            f"ERROR: {run_results_path} not found — dbt likely failed before "
-            f"producing results (connection/setup error).",
-            file=sys.stderr,
-        )
-        return 1
+def to_junit_xml(data: dict) -> str:
+    """Render a parsed dbt run_results dict as a JUnit XML report string (no disk I/O).
 
-    data = json.loads(run_results_path.read_text())
+    NOTE: imported by the data-integrity-starrocks Airflow DAG (radiant/dags/).
+    Renaming this function or changing its signature/return type breaks that DAG —
+    see tests/unit/dags/test_data_integrity_starrocks.py::test_to_junit_xml_contract.
+    """
     results = data.get("results", [])
     project = data.get("metadata", {}).get("project_name") or "radiant_data_qa"
     elapsed = data.get("elapsed_time", 0.0)
@@ -102,15 +99,28 @@ def convert(run_results_path: Path, junit_path: Path) -> int:
         testsuites.set(k, v)
     testsuites.append(testsuite)
 
-    tree = ET.ElementTree(testsuites)
-    ET.indent(tree, space="  ")
-    junit_path.parent.mkdir(parents=True, exist_ok=True)
-    tree.write(junit_path, encoding="utf-8", xml_declaration=True)
+    ET.indent(testsuites, space="  ")
+    return ET.tostring(testsuites, encoding="utf-8", xml_declaration=True).decode("utf-8")
 
+
+def convert(run_results_path: Path, junit_path: Path) -> int:
+    if not run_results_path.exists():
+        print(
+            f"ERROR: {run_results_path} not found — dbt likely failed before "
+            f"producing results (connection/setup error).",
+            file=sys.stderr,
+        )
+        return 1
+
+    xml = to_junit_xml(json.loads(run_results_path.read_text()))
+    junit_path.parent.mkdir(parents=True, exist_ok=True)
+    junit_path.write_text(xml, encoding="utf-8")
+
+    root = ET.fromstring(xml)
     print(
-        f"Wrote {junit_path}: {total} tests, "
-        f"{counts['fail']} failures, {counts['error']} errors, "
-        f"{counts['skipped']} skipped, {counts['warn']} warnings."
+        f"Wrote {junit_path}: {root.get('tests')} tests, "
+        f"{root.get('failures')} failures, {root.get('errors')} errors, "
+        f"{root.get('skipped')} skipped."
     )
     return 0
 

--- a/requirements-airflow.txt
+++ b/requirements-airflow.txt
@@ -12,3 +12,6 @@ sqlalchemy>=1.4,<2.0
 tabulate>=0.8.10
 werkzeug>=2.2.0
 flask>=2.2.0
+
+# Required by PythonVirtualenvOperator (data_integrity_starrocks DAG)
+virtualenv>=21.5.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,12 @@ psycopg2-binary==2.9.10
 ruff==0.11.4
 pymysql
 cyvcf2
+
 # flask 3.7.0 removed support for some features used in Airflow
 flask-limiter<3.7.0
+
 # Needed for filesystem abstraction in tests
 fs>=2.4.16
+
+# Required by PythonVirtualenvOperator (data_integrity_starrocks DAG)
+virtualenv>=21.5.1

--- a/tests/unit/dags/test_data_integrity_starrocks.py
+++ b/tests/unit/dags/test_data_integrity_starrocks.py
@@ -1,0 +1,45 @@
+import xml.etree.ElementTree as ET
+
+
+def test_to_junit_xml_contract():
+    """Lock the contract the DAG relies on (upload_to_testquality task): given a
+    run_results-shaped dict, to_junit_xml returns a parsable JUnit XML string.
+
+    If a QA change to data_qa/scripts/run_results_to_junit.py breaks this test, the
+    data-integrity-starrocks DAG is broken too. The DAG only needs the function to
+    exist, accept a dict, and return valid XML — internal XML structure is QA's concern.
+    """
+    from radiant.data_qa.scripts.run_results_to_junit import to_junit_xml
+
+    run_results = {
+        "metadata": {"project_name": "radiant_data_qa"},
+        "elapsed_time": 1.0,
+        "results": [
+            {"unique_id": "test.radiant.should_be_unique_x.abc", "status": "pass", "execution_time": 0.1},
+            {
+                "unique_id": "test.radiant.should_not_contain_null_y.def",
+                "status": "fail",
+                "execution_time": 0.2,
+                "failures": 3,
+                "message": "3 rows",
+            },
+        ],
+    }
+
+    xml = to_junit_xml(run_results)  # 1. import exists + 2. signature accepts a dict
+
+    assert isinstance(xml, str)  # 3. returns a string
+    root = ET.fromstring(xml)  # 3. parsable XML
+    assert root.get("tests") == "2"  # DAG expects a coherent JUnit report
+    assert root.get("failures") == "1"
+
+
+def test_data_integrity_dag_loads(dag_bag):
+    dag = dag_bag.get_dag("radiant-data-integrity-starrocks")
+    assert dag is not None
+    assert not dag_bag.import_errors
+
+
+def test_data_integrity_dag_has_expected_tasks(dag_bag):
+    dag = dag_bag.get_dag("radiant-data-integrity-starrocks")
+    assert set(dag.task_ids) == {"run_dbt", "upload_to_testquality", "check_qa_results"}

--- a/tests/unit/dags/test_import_radiant.py
+++ b/tests/unit/dags/test_import_radiant.py
@@ -15,6 +15,7 @@ def test_dag_has_expected_tasks(dag_bag):
         "assign_priority",
         "import_part",
         "update_sequencing_experiment_deleted",
+        "data_integrity_checks",
     }
     assert set(dag.task_ids) == expected_tasks
 
@@ -40,3 +41,4 @@ def test_dag_task_dependencies_are_correct(dag_bag):
     assert fetch_exp in update_deleted_exp.get_direct_relatives(upstream=False)
     assert assign_priority in fetch_exp.get_direct_relatives(upstream=False)
     assert import_part in assign_priority.get_direct_relatives(upstream=False)
+    assert "data_integrity_checks" in import_part.downstream_task_ids


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
 This PR introduces a new DAG that runs data-integrity checks against the StarRocks tables.

  Specifically, the DAG runs the dbt project under `radiant/data_qa`. After, it performs these 2 steps in parallel:

  - **Upload to TestQuality (optional):** if a `testquality_conn` connection is configured, it converts dbt's
    `run_results.json` report to JUnit XML and pushes it to TestQuality.
  - **Check results:**  inspects the dbt report and fails the run if any test failed.
    Known errors — tests tagged with a JIRA ticket (e.g. `SJRA-1234`) — are excluded: they are
    reported but do not fail the run.

  The DAG is triggered automatically at the end of the scheduled import DAG.
  It can also be run manually. A `skip_testquality_push` parameter lets a run skip the TestQuality upload when it
  isn't appropriate — e.g. a developer's quick check that shouldn't disturb the QA team yet.


## 📝 Changes

<!-- List the main changes in this PR. -->
  - Add the `radiant-data-integrity-starrocks` DAG that runs the `radiant/data_qa` dbt tests.
  - Trigger the new DAG automatically at the end of the import DAG.
  - Minor tweaks in `radiant/data_qa` to reuse JSON→JUnit-XML logic (`to_junit_xml`)
  - Update / add unit tests (see below)

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->


## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

Unit tests:
  - Added a test that the new DAG compiles and exposes the expected tasks.
  - Added a contract test (`test_to_junit_xml_contract`) so that a QA change to
    `run_results_to_junit.py` breaking the DAG's dependency fails CI in the same PR.
  - Updated the import DAG test to include the new task that triggers the data-integrity checks.
  - Manual tests in sandbox, see below

Integration tests in sandbox, on Airflow 2 and Airflow 3:
  - [x] without connection settings
  - [x] with missing `project_id`
  - [x] with missing `run_name`
  - [x] with `skip_testquality_push` enabled
  - [x] with correct connection settings
  - [x] triggered via the scheduled import DAG

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

-  Test quality credentials / settings are passed via an airflow connection.  This is documented in the dag (see comment in this review).

 - We upload the JUnit report via `POST /api/import_xml`. It is the same call that the
    official TestQuality command line client makes (`UploadTestRunCommand.ts`).  The endpoint isn't
    in the API reference, but the docs mention that it is ok to use it here:
     https://doc.testquality.com/importing_data#additional-information
    ```
    If you want to import test result XML files via the CLI tool or API, you can refer to our open-source CLI tool on GitHub: [TestQuality CLI](https://github.com/BitModern/testQualityCli).
    ```
   If the push breaks, the impact is contained: the test results won't be visible in test quality, but the tests still run and results are still visible through airflow logs.
   
   - The test quality connection isn't configured in the different environments yet. The DAG will detect its absence and skips the push to test quality.  Once the connection is added, pushing will be enabled automatically.