### PR TITLE
feat: SJRA-1663 Add data QA on clinvar_rcv_summary table

### DIFF
--- a/radiant/data_qa/sources/clinvar_rcv_summary.yml
+++ b/radiant/data_qa/sources/clinvar_rcv_summary.yml
@@ -1,0 +1,54 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: clinvar_rcv_summary
+        tests:
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: clinvar_rcv_summary__should_not_contain_only_null
+              except:
+                # Already covered by clinvar_rcv_summary__should_not_contain_null__*
+                - accession
+                - clinvar_id
+                - locus_id
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: clinvar_rcv_summary__should_not_contain_same_value
+              except:
+                # count(distinct) unsupported on nested STRUCT/MAP types
+                - clinical_significance_count
+                - submissions
+
+          # --- Should Be Within Range ----------------------------------------
+          - should_be_within_range:
+              name: clinvar_rcv_summary__should_be_within_range_review_status_stars
+              like: review_status_stars
+              min_value: 0
+              max_value: 4
+        columns:
+          - name: locus_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar_rcv_summary__should_not_contain_null__locus_id
+          - name: clinvar_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar_rcv_summary__should_not_contain_null__clinvar_id
+          - name: accession
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: clinvar_rcv_summary__should_not_contain_null__accession
+          - name: clinical_significance
+            tests:
+              # --- Accepted Values (array) -----------------------------------
+              # values: dict_clinvar_interpretation() — see macros/dictionaries.sql
+              - accepted_values_in_array:
+                  name: clinvar_rcv_summary__accepted_values_clinical_significance_SJRA-1624
+                  values: "{{ dict_clinvar_interpretation() }}"

--- a/radiant/data_qa/tests/clinvar_rcv_summary__validate_submission_count.sql
+++ b/radiant/data_qa/tests/clinvar_rcv_summary__validate_submission_count.sql
@@ -1,0 +1,10 @@
+{#
+  submission_count is a count of ClinVar submissions and must be non-negative.
+#}
+
+select
+    locus_id,
+    clinvar_id,
+    submission_count
+from {{ source('radiant', 'clinvar_rcv_summary') }}
+where submission_count < 0


### PR DESCRIPTION
# feat: SJRA-1663 Add data QA on clinvar_rcv_summary table

## 📌 Context

Ajout de tests de qualité de données (data QA) sur la table `clinvar_rcv_summary`, dans la continuité du travail de validation des tables ClinVar. Aucune table n'était couverte pour cette source jusqu'ici.

## 📝 Changes

- Nouveau fichier source `radiant/data_qa/sources/clinvar_rcv_summary.yml` définissant les tests :
  - **should_not_contain_only_null** sur la table, avec exception des colonnes `accession`, `clinvar_id` et `locus_id` (déjà couvertes par des tests `not_null` dédiés).
  - **should_not_contain_same_value** sur la table, avec exception de `clinical_significance_count` et `submissions` (`count(distinct)` non supporté sur les types imbriqués STRUCT/MAP).
  - **should_be_within_range** sur `review_status_stars` (valeurs attendues entre 0 et 4).
  - **not_null** sur les colonnes clés `locus_id`, `clinvar_id` et `accession`.
  - **accepted_values_in_array** sur `clinical_significance`, basé sur le dictionnaire `dict_clinvar_interpretation()` (macros/dictionaries.sql).
- Nouveau test SQL singulier `radiant/data_qa/tests/clinvar_rcv_summary__validate_submission_count.sql` validant que `submission_count` est toujours non négatif.

## 🧪 Tests

Tests exécutés localement avec succès. Les nouveaux tests dbt couvrent les colonnes clés (non-null), les bornes de `review_status_stars`, les valeurs acceptées de `clinical_significance` et la non-négativité de `submission_count`.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1663
- SJRA-1624 — référencé dans le nom du test `accepted_values_clinical_significance` (validation des valeurs acceptées via dictionnaire).

<!-- End JIRA Issues -->
