### PR TITLE
feat SJRA-1669 Add relationship data QA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ logs
 
 *.DS_STORE
 .testquality
+.copilot

--- a/radiant/data_qa/.gitignore
+++ b/radiant/data_qa/.gitignore
@@ -6,6 +6,7 @@ logs/
 dbt_packages/
 *.pyc
 __pycache__/
+.testquality
 
 # Generated reports (keep the folder, ignore the outputs)
 reports/*.xml

--- a/radiant/data_qa/sources/cytoband.yml
+++ b/radiant/data_qa/sources/cytoband.yml
@@ -28,7 +28,7 @@ sources:
                 - cytoband
         columns:
           - name: chromosome
-            description: "CHAR(2) — canonical UCSC cytoBand chromosomes only."
+            description: "CHAR(2)."
             tests:
               # --- Should Not Contain Null -----------------------------------
               - not_null:

--- a/radiant/data_qa/sources/exomiser.yml
+++ b/radiant/data_qa/sources/exomiser.yml
@@ -44,6 +44,12 @@ sources:
               # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: exomiser__should_not_contain_null__locus_id
+              # --- Relationships ---------------------------------------------
+              # exomiser locus must exist in the snv__variant
+              - relationships:
+                  name: exomiser__relationships__locus_id__snv_variant
+                  to: source('radiant', 'snv__variant')
+                  field: locus_id
           - name: id
             tests:
               # --- Should Not Contain Null -----------------------------------

--- a/radiant/data_qa/sources/germline_snv_occurrence.yml
+++ b/radiant/data_qa/sources/germline_snv_occurrence.yml
@@ -50,6 +50,12 @@ sources:
               # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: germline_snv_occurrence__should_not_contain_null__locus_id
+              # --- Relationships ---------------------------------------------
+              # occurrence locus must exist in the snv__variant
+              - relationships:
+                  name: germline_snv_occurrence__relationships__locus_id__snv_variant
+                  to: source('radiant', 'snv__variant')
+                  field: locus_id
           - name: phased
             description: "BOOLEAN."
             tests:

--- a/radiant/data_qa/sources/snv_consequence.yml
+++ b/radiant/data_qa/sources/snv_consequence.yml
@@ -26,6 +26,12 @@ sources:
               # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: snv_consequence__should_not_contain_null__locus_id
+              # --- Relationships ---------------------------------------------
+              # consequence locus must exist in the snv__variant
+              - relationships:
+                  name: snv_consequence__relationships__locus_id__snv_variant
+                  to: source('radiant', 'snv__variant')
+                  field: locus_id
           - name: symbol
             tests:
               # --- Should Not Contain Null -----------------------------------

--- a/radiant/data_qa/sources/snv_variant.yml
+++ b/radiant/data_qa/sources/snv_variant.yml
@@ -89,6 +89,16 @@ sources:
               # --- Should Be Unique ------------------------------------------
               - unique:
                   name: snv_variant__should_be_unique__locus
+          - name: symbol
+            tests:
+              # --- Relationships ---------------------------------------------
+              # gene symbol must exist in the ensembl_gene.name
+              - relationships:
+                  name: snv_variant__relationships__symbol__ensembl_gene_SJRA-1667
+                  to: source('radiant', 'ensembl_gene')
+                  field: name
+                  config:
+                    where: "symbol is not null and symbol <> ''"
           - name: vep_impact
             tests:
               # --- Accepted Values -------------------------------------------
@@ -99,7 +109,6 @@ sources:
                   config:
                     where: "vep_impact is not null"
           - name: variant_class
-            description: "Sequence Ontology variant class."
             tests:
               # --- Accepted Values -------------------------------------------
               # values: dict_variant_class() — see macros/dictionaries.sql

--- a/radiant/data_qa/sources/somatic_snv_occurrence.yml
+++ b/radiant/data_qa/sources/somatic_snv_occurrence.yml
@@ -85,6 +85,12 @@ sources:
               # --- Should Not Contain Null -----------------------------------
               - not_null:
                   name: somatic_snv_occurrence__should_not_contain_null__locus_id
+              # --- Relationships ---------------------------------------------
+              # occurrence locus must exist in the snv__variant
+              - relationships:
+                  name: somatic_snv_occurrence__relationships__locus_id__snv_variant
+                  to: source('radiant', 'snv__variant')
+                  field: locus_id
           - name: tumor_zygosity
             description: "CHAR(3)."
             tests:

--- a/radiant/data_qa/tests/hpo_gene_panel__validate_hpo_term_id_format_SJRA-1668.sql
+++ b/radiant/data_qa/tests/hpo_gene_panel__validate_hpo_term_id_format_SJRA-1668.sql
@@ -1,0 +1,13 @@
+{#
+  hpo_term_id must be a well-formed HPO id (HP:NNNNNNN). Catches CSV header rows or
+  malformed values leaking into the panel during ingestion (e.g. the literal 'hpo_id'
+  header row observed with symbol='gene_symbol', panel='hpo_name(hpo_id)').
+#}
+
+select
+    symbol,
+    panel,
+    hpo_term_id
+from {{ source('radiant', 'hpo_gene_panel') }}
+where hpo_term_id is not null
+  and hpo_term_id not regexp '^HP:[0-9]{7}$'


### PR DESCRIPTION
# feat SJRA-1669 Add relationship data QA

## 📌 Context

Cette PR renforce la couverture data QA (dbt) du projet `radiant/data_qa` en ajoutant des tests d'intégrité référentielle entre les sources, ainsi qu'une validation de format sur les identifiants HPO. L'objectif est de détecter en amont les ruptures de cohérence entre tables (loci orphelins, symboles de gènes inconnus) et les valeurs malformées issues de l'ingestion.

## 📝 Changes

- **Tests de relations (intégrité référentielle)** :
  - `germline_snv_occurrence.locus_id` doit exister dans `snv__variant.locus_id`.
  - `snv_consequence.locus_id` doit exister dans `snv__variant.locus_id`.
  - `snv_variant.symbol` doit exister dans `ensembl_gene.name` (test `SJRA-1667`, filtré sur les symboles non nuls et non vides).
- **Nouveau test de format HPO** (`SJRA-1668`) : `hpo_gene_panel.hpo_term_id` doit respecter le format `HP:NNNNNNN`. Ce test attrape les lignes d'en-tête CSV ou valeurs malformées qui fuient lors de l'ingestion (ex. la valeur littérale `hpo_id`).
- **Nettoyage** : simplification des descriptions de colonnes (`cytoband.chromosome`, `snv_variant.variant_class`) pour s'aligner sur le style « type seul ».
- **`.gitignore`** : ajout de `.copilot` (racine) et de `.testquality` (`data_qa`).

## 🧪 Tests

- Les nouveaux tests dbt (`relationships` et test SQL singulier HPO) ont été exécutés localement et passent avec succès.
- Tests concernés :
  - `germline_snv_occurrence__relationships__locus_id__snv_variant`
  - `snv_consequence__relationships__locus_id__snv_variant`
  - `snv_variant__relationships__symbol__ensembl_gene_SJRA-1667`
  - `hpo_gene_panel__validate_hpo_term_id_format_SJRA-1668`

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1669
- SJRA-1667 — tag conservé dans le nom du test (suivi en cours)
- SJRA-1668 — tag conservé dans le nom du test (suivi en cours)

<!-- End JIRA Issues -->
