### PR TITLE
feat: SJRA-1671 Add non-empty and cross-field data QA

### DIFF
--- a/radiant/data_qa/README.md
+++ b/radiant/data_qa/README.md
@@ -13,6 +13,7 @@ invariants on tables.
 | Should Not Contain Only Null   | `should_not_contain_only_null` (dynamic, custom)              |
 | Should Not Contain Same Value  | `should_not_contain_same_value` (dynamic, custom)             |
 | Should Be Unique               | `tests: [unique]` (built-in, displayed via custom `name:`)    |
+| Should Not Be Empty            | `should_not_be_empty` (custom generic, table-level)           |
 | Values Contained In Dictionary | scalar: `accepted_values` (built-in); array: `accepted_values_in_array` (custom) |
 | Should Be Within Range         | `should_be_within_range` (dynamic, custom)                    |
 | Cross-Field / Custom Invariant | Singular tests in `tests/*.sql`                               |

--- a/radiant/data_qa/macros/test_should_not_be_empty.sql
+++ b/radiant/data_qa/macros/test_should_not_be_empty.sql
@@ -1,0 +1,25 @@
+{#
+  Generic test — Should Not Be Empty. Fails when the relation has zero
+  rows: a silently empty source table means an upstream load dropped 
+  or never produced data.
+
+  On an empty relation `count(*)` is 0, the `having` keeps that single
+  aggregate row, and the test reports one failing row. On a populated
+  relation the `having` filters it out and the test passes.
+
+  Usage in a sources.yml / schema.yml:
+
+    tables:
+      - name: snv__variant
+        tests:
+          - should_not_be_empty:
+              name: snv_variant__should_not_be_empty
+#}
+
+{% test should_not_be_empty(model) %}
+
+    select count(*) as n_rows
+    from {{ model }}
+    having count(*) = 0
+
+{% endtest %}

--- a/radiant/data_qa/sources/1000_genomes.yml
+++ b/radiant/data_qa/sources/1000_genomes.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: 1000_genomes
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: 1000_genomes__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: 1000_genomes__should_not_contain_only_null

--- a/radiant/data_qa/sources/clinvar.yml
+++ b/radiant/data_qa/sources/clinvar.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: clinvar
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: clinvar__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: clinvar__should_not_contain_only_null

--- a/radiant/data_qa/sources/clinvar_rcv_summary.yml
+++ b/radiant/data_qa/sources/clinvar_rcv_summary.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: clinvar_rcv_summary
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: clinvar_rcv_summary__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: clinvar_rcv_summary__should_not_contain_only_null

--- a/radiant/data_qa/sources/cytoband.yml
+++ b/radiant/data_qa/sources/cytoband.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: cytoband
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: cytoband__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: cytoband__should_not_contain_only_null

--- a/radiant/data_qa/sources/ensembl_exon_by_gene.yml
+++ b/radiant/data_qa/sources/ensembl_exon_by_gene.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: ensembl_exon_by_gene
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: ensembl_exon_by_gene__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: ensembl_exon_by_gene__should_not_contain_only_null

--- a/radiant/data_qa/sources/ensembl_gene.yml
+++ b/radiant/data_qa/sources/ensembl_gene.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: ensembl_gene
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: ensembl_gene__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: ensembl_gene__should_not_contain_only_null

--- a/radiant/data_qa/sources/exomiser.yml
+++ b/radiant/data_qa/sources/exomiser.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: exomiser
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: exomiser__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: exomiser__should_not_contain_only_null

--- a/radiant/data_qa/sources/germline_cnv_occurrence.yml
+++ b/radiant/data_qa/sources/germline_cnv_occurrence.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: germline__cnv__occurrence
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: germline_cnv_occurrence__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: germline_cnv_occurrence__should_not_contain_only_null

--- a/radiant/data_qa/sources/germline_snv_occurrence.yml
+++ b/radiant/data_qa/sources/germline_snv_occurrence.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: germline__snv__occurrence
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: germline_snv_occurrence__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               # SJRA-1559: info_culprit info_haplotype_score info_vqslod info_ds info_r2_5p_bias info_inbreed_coeff

--- a/radiant/data_qa/sources/gnomad_genomes_v3.yml
+++ b/radiant/data_qa/sources/gnomad_genomes_v3.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: gnomad_genomes_v3
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: gnomad_genomes_v3__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: gnomad_genomes_v3__should_not_contain_only_null

--- a/radiant/data_qa/sources/hpo_gene_panel.yml
+++ b/radiant/data_qa/sources/hpo_gene_panel.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: hpo_gene_panel
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: hpo_gene_panel__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: hpo_gene_panel__should_not_contain_only_null

--- a/radiant/data_qa/sources/hpo_term.yml
+++ b/radiant/data_qa/sources/hpo_term.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: hpo_term
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: hpo_term__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: hpo_term__should_not_contain_only_null

--- a/radiant/data_qa/sources/mondo_term.yml
+++ b/radiant/data_qa/sources/mondo_term.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: mondo_term
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: mondo_term__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: mondo_term__should_not_contain_only_null

--- a/radiant/data_qa/sources/omim_gene_panel.yml
+++ b/radiant/data_qa/sources/omim_gene_panel.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: omim_gene_panel
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: omim_gene_panel__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: omim_gene_panel__should_not_contain_only_null

--- a/radiant/data_qa/sources/orphanet_gene_panel.yml
+++ b/radiant/data_qa/sources/orphanet_gene_panel.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: orphanet_gene_panel
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: orphanet_gene_panel__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: orphanet_gene_panel__should_not_contain_only_null

--- a/radiant/data_qa/sources/snv_consequence.yml
+++ b/radiant/data_qa/sources/snv_consequence.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: snv__consequence
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: snv_consequence__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               # SJRA-1550 mane_select

--- a/radiant/data_qa/sources/snv_consequence_filter_partitioned.yml
+++ b/radiant/data_qa/sources/snv_consequence_filter_partitioned.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: snv__consequence_filter_partitioned
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: snv_consequence_filter_partitioned__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: snv_consequence_filter_partitioned__should_not_contain_only_null

--- a/radiant/data_qa/sources/snv_variant.yml
+++ b/radiant/data_qa/sources/snv_variant.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: snv__variant
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: snv_variant__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               # SJRA-1550 mane_select

--- a/radiant/data_qa/sources/somatic_snv_occurrence.yml
+++ b/radiant/data_qa/sources/somatic_snv_occurrence.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: somatic__snv__occurrence
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: somatic_snv_occurrence__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: somatic_snv_occurrence__should_not_contain_only_null

--- a/radiant/data_qa/sources/topmed_bravo.yml
+++ b/radiant/data_qa/sources/topmed_bravo.yml
@@ -6,6 +6,9 @@ sources:
     tables:
       - name: topmed_bravo
         tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: topmed_bravo__should_not_be_empty
           # --- Should Not Contain Only Null ----------------------------------
           - should_not_contain_only_null:
               name: topmed_bravo__should_not_contain_only_null

--- a/radiant/data_qa/tests/germline_cnv_occurrence__validate_start_end_order.sql
+++ b/radiant/data_qa/tests/germline_cnv_occurrence__validate_start_end_order.sql
@@ -1,0 +1,12 @@
+{#
+  Genomic coordinate sanity for germline CNV occurrences:
+    - start must not exceed end (1-based inclusive span).
+#}
+
+select
+    cnv_id,
+    chromosome,
+    start,
+    `end`
+from {{ source('radiant', 'germline__cnv__occurrence') }}
+where start > `end`

--- a/radiant/data_qa/tests/germline_snv_occurrence__validate_exclusive_with_somatic.sql
+++ b/radiant/data_qa/tests/germline_snv_occurrence__validate_exclusive_with_somatic.sql
@@ -1,0 +1,13 @@
+{#
+  A given (locus_id, sequencing) call must not be reported as BOTH a germline
+  occurrence and a somatic TUMOR occurrence: a tumor sequencing analyzed as
+  germline (or vice-versa) is contradictory.
+#}
+
+select
+    g.locus_id,
+    g.seq_id
+from {{ source('radiant', 'germline__snv__occurrence') }} g
+join {{ source('radiant', 'somatic__snv__occurrence') }} s
+    on s.locus_id = g.locus_id
+   and s.tumor_seq_id = g.seq_id


### PR DESCRIPTION
# feat: SJRA-1671 Add non-empty and cross-field data QA

## 📌 Context

Ajout de nouveaux contrôles de qualité de données (data QA) dans le projet dbt `radiant/data_qa`. L'objectif est de détecter deux familles de problèmes jusqu'ici non couverts :

- Une table source **silencieusement vide** (un chargement amont a échoué ou n'a jamais produit de données).
- Des **incohérences inter-champs / inter-tables** sur les occurrences génomiques (coordonnées invalides, chevauchement germinal/somatique).

## 📝 Changes

- **Nouveau test générique `should_not_be_empty`** ([macros/test_should_not_be_empty.sql](radiant/data_qa/macros/test_should_not_be_empty.sql)) : échoue lorsqu'une relation contient zéro ligne. Sur une relation vide, `count(*)` vaut 0, la clause `having` conserve la ligne agrégée et le test rapporte une ligne en échec ; sur une relation peuplée, le `having` la filtre et le test passe.
- **Application du test à toutes les sources** (21 fichiers `sources/*.yml`) : ajout d'une entrée `should_not_be_empty` nommée `<table>__should_not_be_empty` au niveau table, placée en tête de la liste des tests.
- **Deux nouveaux tests singuliers inter-champs** ([tests/](radiant/data_qa/tests/)) :
  - `germline_cnv_occurrence__validate_start_end_order` : vérifie que `start` n'excède pas `end` (intervalle 1-based inclusif) sur les CNV germinaux.
  - `germline_snv_occurrence__validate_exclusive_with_somatic` : vérifie qu'un même couple `(locus_id, sequencing)` n'est pas rapporté à la fois comme occurrence germinale et comme occurrence somatique de type tumeur (situation contradictoire).
- **README** : ajout de la ligne « Should Not Be Empty » dans le tableau des types de tests disponibles.

## 🧪 Tests

- Les nouveaux tests data QA ont été exécutés localement et passent avec succès.
- Le test générique `should_not_be_empty` se déclenche correctement sur une relation vide (1 ligne en échec) et passe sur une relation peuplée.
- Les deux tests singuliers ne retournent aucune ligne sur les données courantes (aucune violation détectée).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

- SJRA-1671

<!-- End JIRA Issues -->
