### PR TITLE
feat: SJRA-1694 Update consequence and variant to include somatic tables as well in tenants

### DIFF
--- a/radiant/dags/sql/radiant/snv_consequence_filter_insert_part.sql
+++ b/radiant/dags/sql/radiant/snv_consequence_filter_insert_part.sql
@@ -8,6 +8,10 @@ LEFT SEMI JOIN (
     SELECT locus_id
     FROM {{ per_tenant_mapping(t).starrocks_germline_snv_occurrence }}
     WHERE part in (%(part)s)
+    UNION ALL
+    SELECT locus_id
+    FROM {{ per_tenant_mapping(t).starrocks_somatic_snv_occurrence }}
+    WHERE part in (%(part)s)
     {% if not loop.last %}UNION ALL{% endif %}
     {% endfor %}
 ) o ON o.locus_id = c.locus_id;

--- a/radiant/dags/sql/radiant/snv_variant_part_insert_part.sql
+++ b/radiant/dags/sql/radiant/snv_variant_part_insert_part.sql
@@ -9,6 +9,10 @@ LEFT SEMI JOIN (
     SELECT locus_id
     FROM {{ per_tenant_mapping(t).starrocks_germline_snv_occurrence }}
     WHERE part >= %(part_lower)s AND part < %(part_upper)s
+    UNION ALL
+    SELECT locus_id
+    FROM {{ per_tenant_mapping(t).starrocks_somatic_snv_occurrence }}
+    WHERE part >= %(part_lower)s AND part < %(part_upper)s
     {% if not loop.last %}UNION ALL{% endif %}
     {% endfor %}
 ) o ON v.locus_id = o.locus_id;

--- a/tests/unit/dags/test_pooled_sql_render.py
+++ b/tests/unit/dags/test_pooled_sql_render.py
@@ -7,32 +7,53 @@ _RADIANT_SQL = DAGS_DIR / "sql" / "radiant"
 _CONF = {"RADIANT_TABLES_DATABASE": "radiant"}
 
 
-def _render(filename: str) -> str:
-    """Render a pooled-build SQL with a 2-tenant context, mirroring the operator's Jinja context."""
+def _render(filename: str, tenants: list[str] | None = None) -> str:
+    """Render a pooled-build SQL with a multi-tenant context, mirroring the operator's Jinja context."""
     text = (_RADIANT_SQL / filename).read_text()
     ctx = {
         "mapping": get_radiant_mapping(_CONF),
         "per_tenant_mapping": lambda t: get_radiant_mapping(_CONF, tenant_code=t),
-        "tenants": ["chop", "chusj"],
+        "tenants": tenants if tenants is not None else ["chop", "chusj"],
         "partition": 5,
     }
     return jinja2.Template(text).render(**ctx)
 
 
+def _assert_balanced_unions(sql: str, n_selects: int):
+    assert sql.count("SELECT locus_id") == n_selects
+    assert sql.count("UNION ALL") == n_selects - 1
+
+
 def test_snv_variant_part_unions_occurrences_across_tenant_dbs():
     sql = _render("snv_variant_part_insert_part.sql")
-    assert "chop_tenant.germline__snv__occurrence" in sql
-    assert "chusj_tenant.germline__snv__occurrence" in sql
+    for tenant in ("chop", "chusj"):
+        assert f"{tenant}_tenant.germline__snv__occurrence" in sql
+        assert f"{tenant}_tenant.somatic__snv__occurrence" in sql
     assert "UNION ALL" in sql
     assert "radiant.snv__variant_partitioned" in sql  # base target
+    _assert_balanced_unions(sql, n_selects=4)  # (germline + somatic) x 2 tenants
 
 
 def test_consequence_filter_part_unions_occurrences_across_tenant_dbs():
     sql = _render("snv_consequence_filter_insert_part.sql")
-    assert "chop_tenant.germline__snv__occurrence" in sql
-    assert "chusj_tenant.germline__snv__occurrence" in sql
+    for tenant in ("chop", "chusj"):
+        assert f"{tenant}_tenant.germline__snv__occurrence" in sql
+        assert f"{tenant}_tenant.somatic__snv__occurrence" in sql
     assert "UNION ALL" in sql
     assert "radiant.snv__consequence_filter_partitioned" in sql  # base target
+    _assert_balanced_unions(sql, n_selects=4)  # (germline + somatic) x 2 tenants
+
+
+def test_snv_variant_part_single_tenant_has_no_trailing_union():
+    sql = _render("snv_variant_part_insert_part.sql", tenants=["chop"])
+    assert "chop_tenant.somatic__snv__occurrence" in sql
+    _assert_balanced_unions(sql, n_selects=2)
+
+
+def test_consequence_filter_part_single_tenant_has_no_trailing_union():
+    sql = _render("snv_consequence_filter_insert_part.sql", tenants=["chop"])
+    assert "chop_tenant.somatic__snv__occurrence" in sql
+    _assert_balanced_unions(sql, n_selects=2)
 
 
 def test_snv_variant_pools_freqs_across_tenant_dbs():


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

With the recent multi-tenant integration, imports are now done by combining tenant specific tables. 

Specifically, for some tables `snv__variant` and `snv__consequence*` this mean aggregating from both `germline` and `somatic` tables for occurrences in the tenant databases.

Germline was covered, but not somatic. 

This PR fixes that and brings the somatic occurrences in the query. 

## 📝 Changes

<!-- List the main changes in this PR. -->

- Add unions on somatic occurrences (for each tenant) when importing variants and consequences. 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- Extended unit tests to cover `somatic` as well as `germline` where relevant. 
- Tested end-to-end using the Sandbox. 

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- https://d3b.atlassian.net/browse/SJRA-1694
<!-- End JIRA Issues -->