### PR TITLE
fix: SJRA-1524 add radiant code in plugins.zip  for the MWAA Airflow 3 triggerer

### DIFF
--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -49,7 +49,9 @@ You should now have `plugins-af2.zip` in the current directory.
 **Airflow 3:**
 
 ```sh
-docker build -f airflow3/Dockerfile-mwaa-deps-builder -t radiant-mwaa-deps-af3 airflow3
+# Context is the repo root (`..`) so the image can bundle the radiant wheel
+# (it needs pyproject.toml and radiant/). Run this from the mwaa/ directory.
+docker build -f airflow3/Dockerfile-mwaa-deps-builder -t radiant-mwaa-deps-af3 ..
 docker run --rm -v $(pwd):/mwaa radiant-mwaa-deps-af3 \
   cp /home/airflow/.venv/radiant/plugins.zip /mwaa/plugins-af3.zip
 ```

--- a/mwaa/airflow3/Dockerfile-mwaa-deps-builder
+++ b/mwaa/airflow3/Dockerfile-mwaa-deps-builder
@@ -34,10 +34,17 @@ RUN python${PYTHON_VERSION} -m venv /home/airflow/.venv/radiant && \
     /home/airflow/.venv/radiant/bin/pip install wheel --no-cache-dir
 
 # Copy requirements and install dependencies with uv
-COPY requirements-deps.txt /home/airflow/.venv/radiant/requirements.txt
-COPY constraints-3.12.txt  /usr/local/airflow/plugins/constraints-3.12.txt
+COPY mwaa/airflow3/requirements-deps.txt /home/airflow/.venv/radiant/requirements.txt
+COPY mwaa/airflow3/constraints-3.12.txt  /usr/local/airflow/plugins/constraints-3.12.txt
 RUN uv pip compile /home/airflow/.venv/radiant/requirements.txt --output-file /home/airflow/.venv/radiant/requirements.lock.txt
 
 RUN /home/airflow/.venv/radiant/bin/pip wheel -w /home/airflow/.venv/radiant/wheels -r /home/airflow/.venv/radiant/requirements.lock.txt
+
+# Build the radiant wheel into the same wheels/ dir (required for airflow triggerer)
+COPY pyproject.toml /src/pyproject.toml
+COPY radiant        /src/radiant
+RUN /home/airflow/.venv/radiant/bin/pip wheel --no-deps \
+      -w /home/airflow/.venv/radiant/wheels /src
+
 RUN cp /usr/local/airflow/plugins/constraints-3.12.txt /home/airflow/.venv/radiant/wheels/constraints-3.12.txt
 RUN zip -j /home/airflow/.venv/radiant/plugins.zip /home/airflow/.venv/radiant/wheels/*.whl /home/airflow/.venv/radiant/wheels/constraints-3.12.txt

--- a/mwaa/airflow3/requirements-mwaa.txt
+++ b/mwaa/airflow3/requirements-mwaa.txt
@@ -4,3 +4,7 @@
 
 # Radiant specific additional requirements for MWAA
 apache-airflow-providers-mysql==6.5.2
+
+# Radiant itself, from the locally-built wheel in plugins.zip (for the triggerer).
+# Intentionally unpinned: rebuilt from source on every deploy.
+radiant

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,23 @@
+# This file exists solely to build an installable `radiant` wheel for the MWAA
+# (AWS) deployment.
+#
+# The Airflow 3 triggerer is the only component that needs radiant packaged this
+# way. Unlike the scheduler and workers, it has no access to the code in the
+# dags folder (it does not load DAG bundles).
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "radiant"
+
+# Keeping the version static for simplicity, as radiant will always be installed
+# from a locally-built wheel (with the --no-index option in requirements.txt) and
+# never published to a PyPI repository.
+version = "0.0.0"
+
+requires-python = ">=3.12"
+
+[tool.setuptools.packages.find]
+include = ["radiant*"]


### PR DESCRIPTION
Fixes deferrable StarRocks tasks failing on MWAA with Airflow 3 (CHOP QA environment).

## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
Deferrable StarRocks tasks failed in this environment with:
`ModuleNotFoundError: No module named 'radiant'`

The error comes from the **triggerer**. In Airflow 3, the triggerer no longer loads DAG bundles, so it cannot import the trigger class shipped under the `dags/` folder. This is stated in the Airflow 3 documentation:

https://airflow.apache.org/docs/apache-airflow/3.2.2/authoring-and-scheduling/deferring.html#writing-triggers

> Your trigger must not come from a Dag bundle - anywhere else on sys.path is fine. The triggerer does not initialize any bundles when running a trigger.

The problem does not occur on airflow 2 as, for this version, the triggerer component has access to the code in the dags folder (no concept of dag bundle).

To address this, we package `radiant` as a wheel, bundle it into plugins.zip  and install it via `requirements-mwaa.txt`. This way it lands in site packages and becomes importable by the triggerrer.

## 📝 Changes

<!-- List the main changes in this PR. -->

  - Add `pyproject.toml` at the repo root (required to build the `radiant` wheel).
  - Update the Dockerfile that produces `plugins.zip` to also build the `radiant`
    wheel and drop it alongside the other wheels. Its build context becomes the repo
    root (instead of `mwaa/`) so it can access `radiant/` and `pyproject.toml`.
  - Add `radiant` to `requirements-mwaa.txt` so MWAA installs it from the bundled wheel.
  - Update the MWAA documentation

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- Built `plugins-af3.zip` following the MWAA README and confirmed the `radiant` wheel is bundled inside.
- Installed `radiant` from the bundle offline (`--no-index`, as MWAA does) into a fresh venv and confirmed the trigger     class lands in `site-packages` — i.e importable by the triggerer without the dags folder.
- Simulated a component with the dags folder on `PYTHONPATH` (worker/scheduler) and confirmed the dags-folder copy of `radiant` takes precedence, with its SQL templates still reachable — the wheel coexists without shadowing it.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

-  On MWAA, `radiant` now exists in two places: installed from the wheel (`site-packages`) and in the dags folder.  It is very hard to fully confirm that it won't cause import problems on all components without deploying, so we propose to validate directly in the CHOP QA environment (already broken anyway) and adjust if needed.