### PR TITLE
fix: SJRA-1524 include radiant.dags data files in the wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 # dags folder (it does not load DAG bundles).
 
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=64"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -21,3 +21,8 @@ requires-python = ">=3.12"
 
 [tool.setuptools.packages.find]
 include = ["radiant*"]
+
+[tool.setuptools.package-data]
+# On MWAA, the radiant.dags package loads from the wheel and resolves these resource
+# paths relative to itself, so they must be included in the wheel too.
+"radiant.dags" = ["docs/*.md", "sql/**/*.sql"]


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->

This PR is related to a recent fix that packaged radiant code as a wheel into plugins.zip for MWAA. We tried the fix in the CHOP QA environment as planned and unfortunately we realized that we need to add extra resource files in the radiant wheel.

The behaviour that we observe is that the installed wheel shadows the radiant copy from the dag bundle in the component responsible for parsing the DAGs. The radiant.dags package resolves its SQL and doc resource paths relative to the wheel's location, not the bundle's. The previous fix shipped only the .py files in the wheel, so those resources aren't found.

Symptom: the import_part DAG fails to import (can't find its doc file). Other DAGs import fine, but their SQL resource paths likely point to nothing and would fail at run time.

Fix: ship the SQL and doc files in the wheel too, so the paths resolve whether they're relative to the wheel copy or the dag-bundle copy.

  ---
## 📝 Changes

<!-- List the main changes in this PR. -->

- Modify pyproject.toml to include sql and doc files in the wheel

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

- [ ] 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

  - Built plugins.zip following the MWAA README procedure (Airflow 3 only).
  - Inspected plugins.zip and confirmed the radiant wheel is still bundled inside.
  - Inspected the radiant wheel and confirmed the SQL and doc files are now included.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- 