### PR TITLE
feat: SJRA-1544 implement dag for running starrocks qa data tests

### DIFF
--- a/.github/workflows/build_and_push_dbt.yml
+++ b/.github/workflows/build_and_push_dbt.yml
@@ -1,0 +1,63 @@
+# This workflow builds and pushes a Docker image to GitHub Packages
+name: Build and Push Docker Image for the Radiant dbt Data QA
+
+env:
+  IMAGE_NAME: radiant-dbt
+  NAMESPACE: radiant-network
+  REGISTRY: ghcr.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_and_push:
+    name: Build and Push Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
+            type=sha,format=short
+
+          flavor: |
+            latest=auto
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Dockerfile.radiant.dbt
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile.radiant.dbt
+++ b/Dockerfile.radiant.dbt
@@ -1,0 +1,23 @@
+FROM --platform=linux/amd64 python:3.12-slim
+
+RUN useradd --create-home --uid 1000 dbt
+
+RUN pip install --no-cache-dir --upgrade pip
+
+ENV DBT_PROFILES_DIR=/opt/dbt/data_qa \
+    DBT_SEND_ANONYMOUS_USAGE_STATS=false
+
+# Install python requirements; boto3 is to upload reports to S3
+COPY radiant/data_qa/requirements.txt /opt/dbt/data_qa/requirements.txt
+RUN pip install --no-cache-dir -r /opt/dbt/data_qa/requirements.txt "boto3~=1.43.36"
+
+COPY --chown=dbt:dbt radiant/data_qa/ /opt/dbt/data_qa/
+COPY --chown=dbt:dbt scripts/dbt/entrypoint.py /opt/dbt/entrypoint.py
+
+RUN chown -R dbt:dbt /opt/dbt                                                                                                                                    
+USER dbt
+
+# Install dbt packages
+RUN dbt deps --project-dir /opt/dbt/data_qa
+
+ENTRYPOINT ["python", "/opt/dbt/entrypoint.py"]

--- a/mwaa/README.md
+++ b/mwaa/README.md
@@ -9,6 +9,7 @@ Radiant runs on two MWAA environments — Airflow 2 (Python 3.11) and Airflow 3 
 - [ ] Upload artifacts to S3 (step 2)
 - [ ] Upload dags to S3 (step 3)
 - [ ] Build and push the radiant operator image (step 4).
+- [ ] Build and push the dbt data-quality image (step 4b).
 - [ ] Run terraform apply (step 5)
 
 
@@ -49,9 +50,7 @@ You should now have `plugins-af2.zip` in the current directory.
 **Airflow 3:**
 
 ```sh
-# Context is the repo root (`..`) so the image can bundle the radiant wheel
-# (it needs pyproject.toml and radiant/). Run this from the mwaa/ directory.
-docker build -f airflow3/Dockerfile-mwaa-deps-builder -t radiant-mwaa-deps-af3 ..
+docker build -f airflow3/Dockerfile-mwaa-deps-builder -t radiant-mwaa-deps-af3 airflow3
 docker run --rm -v $(pwd):/mwaa radiant-mwaa-deps-af3 \
   cp /home/airflow/.venv/radiant/plugins.zip /mwaa/plugins-af3.zip
 ```
@@ -110,6 +109,23 @@ To push the radiant operator image to ECR, use the following commands (replace `
 ```
 aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.us-east-1.amazonaws.com
 docker push <aws_account_id>.dkr.ecr.us-east-1.amazonaws.com/radiant/radiant-vcf-operator:latest
+```
+
+## Step 4b — Build and push the dbt data-quality image
+
+This is the image referenced by the `radiant-dbt` ECS task definition (used by the
+`data-integrity-starrocks` DAG). Build and push it once. Terraform reads the tag from the
+dbt image version variable.
+
+To build the dbt image, run:
+```
+docker build --platform linux/amd64 -t <aws_account_id>.dkr.ecr.us-east-1.amazonaws.com/radiant/radiant-dbt:latest -f Dockerfile.radiant.dbt .
+```
+
+To push it to ECR (replace `<aws_account_id>` with your AWS account ID):
+```
+aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin <aws_account_id>.dkr.ecr.us-east-1.amazonaws.com
+docker push <aws_account_id>.dkr.ecr.us-east-1.amazonaws.com/radiant/radiant-dbt:latest
 ```
 
 ## Step 5 - Run terraform apply

--- a/radiant/dags/data_integrity_starrocks.py
+++ b/radiant/dags/data_integrity_starrocks.py
@@ -1,0 +1,192 @@
+"""Run the data_qa dbt test suite (StarRocks) from Airflow.
+
+Run the dbt tests in a dedicated container (ECS or K8s) that uploads its results to S3,
+then, reading those results back from S3:
+- push the results to TestQuality as a JUnit report (optional, see below)
+- inspect the results and fail the dag run on test failures, ignoring known errors
+
+
+TestQuality push
+----------------
+
+Can be turned off per-run via the `skip_testquality_push` DAG param (default off, i.e. push
+enabled), and is skipped if the `testquality_conn` connection is missing.
+
+The connection should contain:
+    - password: TestQuality access token (required)
+    - host:     API base URL (optional, defaults to https://api.testquality.com)
+    - extra:    fields for the import_xml request body, e.g.
+        {"project_id": "1234", "run_name": "Clin QA - {date} - Data", ...}
+
+project_id and run_name are required; other fields optional. In run_name, {date} is replaced
+with the run date (DD/MM/YYYY). Full field list:
+https://github.com/BitModern/testQualityCli/blob/master/src/UploadTestRunCommand.ts
+"""
+
+import logging
+import os
+import re
+
+import pendulum
+from airflow.decorators import dag, task
+from airflow.models.param import Param
+
+from radiant.dags import DEFAULT_ARGS, IS_AWS, NAMESPACE, ECSEnv
+
+if IS_AWS:
+    from radiant.dags.operators import ecs as operators
+else:
+    from radiant.dags.operators import k8s as operators
+
+LOGGER = logging.getLogger(__name__)
+
+TESTQUALITY_DEFAULT_API_URL = "https://api.testquality.com"
+
+# Jira project ids whose tagged failing tests are treated as known errors
+KNOWN_ERROR_JIRA_PROJECTS = ("SJRA",)
+# Matches a known error tag in a test name, e.g. SJRA-1234 (case-insensitive)
+KNOWN_ERROR_TAG = re.compile(rf"(?:{'|'.join(KNOWN_ERROR_JIRA_PROJECTS)})-\d+", re.IGNORECASE)
+
+
+# we store dbt result files in a folder specific to the dag run
+def _dbt_s3_uri(filename: str, run_id: str) -> str:
+    bucket = os.getenv("RADIANT_DBT_S3_WORKSPACE")
+    return f"s3://{bucket}/dbt-qa/{run_id}/{filename}"
+
+
+def _download_from_s3(uri: str) -> bytes:
+    from urllib.parse import urlparse
+
+    import boto3
+
+    parsed = urlparse(uri)
+    obj = boto3.client("s3").get_object(Bucket=parsed.netloc, Key=parsed.path.lstrip("/"))
+    return obj["Body"].read()
+
+
+@dag(
+    dag_id=f"{NAMESPACE}-data-integrity-starrocks",
+    default_args=DEFAULT_ARGS,
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    tags=["radiant", "dbt", "starrocks"],
+    dag_display_name="Radiant - Data Integrity Checks (StarRocks)",
+    params={
+        "skip_testquality_push": Param(
+            False,
+            type="boolean",
+            title="Skip TestQuality push",
+            description="When enabled, the TestQuality upload task is skipped for this run.",
+        ),
+    },
+)
+def data_integrity_starrocks():
+    @task(
+        task_id="upload_to_testquality",
+        task_display_name="Upload JUnit report to TestQuality",
+    )
+    def upload_to_testquality(junit_s3_uri: str) -> None:
+        """Push the JUnit report produced by the container to TestQuality.
+
+        Skips when the `skip_testquality_push` DAG param is enabled, or when the testquality_conn
+        connection is absent.
+        """
+        import requests
+        from airflow.exceptions import AirflowFailException, AirflowNotFoundException, AirflowSkipException
+        from airflow.hooks.base import BaseHook
+        from airflow.operators.python import get_current_context
+
+        context = get_current_context()
+        if context["params"]["skip_testquality_push"]:
+            raise AirflowSkipException(
+                "TestQuality upload disabled via the 'skip_testquality_push' DAG param — skipping."
+            )
+
+        try:
+            conn = BaseHook.get_connection("testquality_conn")
+        except AirflowNotFoundException:
+            raise AirflowSkipException(
+                "Connection 'testquality_conn' not configured — skipping TestQuality upload."
+            ) from None
+
+        junit_xml = _download_from_s3(junit_s3_uri)
+
+        extra = conn.extra_dejson
+        missing = {"run_name", "project_id"} - extra.keys()
+        if missing:
+            raise AirflowFailException(
+                f"testquality_conn extra is missing required keys: {', '.join(sorted(missing))}"
+            )
+        run_name = extra.pop("run_name").replace("{date}", context["logical_date"].strftime("%d/%m/%Y"))
+        data = {"run_name": run_name, "filepath": "junit.xml", **extra}
+
+        resp = requests.post(
+            f"{conn.host or TESTQUALITY_DEFAULT_API_URL}/api/import_xml",  # CLI's default upload route
+            headers={"Authorization": f"Bearer {conn.password}"},
+            data=data,
+            files={"file": ("junit.xml", junit_xml, "text/xml")},
+            timeout=120,
+        )
+        resp.raise_for_status()
+        LOGGER.info("TestQuality import_xml response: %s", resp.text)
+        LOGGER.info("Uploaded JUnit report to TestQuality as run '%s'.", run_name)
+
+    @task(
+        task_id="check_qa_results",
+        task_display_name="Assert no failing data tests",
+    )
+    def check_results(run_results_s3_uri: str) -> None:
+        """Fail the run if unexpected data tests failed.
+
+        Failing tests tagged with a Jira ticket (SJRA-XXXX) are known errors: they are reported
+        but do not fail the run.
+        """
+        import json
+        from collections import Counter
+
+        from airflow.exceptions import AirflowFailException
+
+        run_results_json = json.loads(_download_from_s3(run_results_s3_uri))
+
+        results = run_results_json.get("results", [])
+        status_counts: Counter = Counter()
+        known, unexpected = [], []
+        for r in results:
+            status = (r.get("status") or "").lower()
+            status_counts[status] += 1
+            if status in ("fail", "error"):
+                uid = r["unique_id"]
+                (known if KNOWN_ERROR_TAG.search(uid) else unexpected).append(uid)
+
+        LOGGER.info(
+            "%d passed · %d warned · %d failed — %d known, %d unexpected (of %d)",
+            status_counts["pass"],
+            status_counts["warn"],
+            len(known) + len(unexpected),
+            len(known),
+            len(unexpected),
+            len(results),
+        )
+        if known:
+            LOGGER.warning("Known errors (tagged with a Jira ticket), not failing the run:\n%s", "\n".join(known))
+
+        if unexpected:
+            raise AirflowFailException(
+                f"{len(unexpected)} DATA QA test(s) failed. "
+                f"See the 'Run dbt data tests' task logs for the full dbt output.\n"
+                f"Failed tests:\n" + "\n".join(unexpected)
+            )
+
+    run_results_s3_uri = _dbt_s3_uri("run_results.json", "{{ run_id }}")
+    junit_s3_uri = _dbt_s3_uri("junit.xml", "{{ run_id }}")
+
+    if IS_AWS:
+        run_dbt = operators.CheckDataIntegrity.get_run_dbt(run_results_s3_uri, junit_s3_uri, ECSEnv())
+    else:
+        run_dbt = operators.CheckDataIntegrity.get_run_dbt(run_results_s3_uri, junit_s3_uri)
+
+    run_dbt >> [check_results(run_results_s3_uri), upload_to_testquality(junit_s3_uri)]
+
+
+data_integrity_starrocks()

--- a/radiant/dags/data_integrity_starrocks.py
+++ b/radiant/dags/data_integrity_starrocks.py
@@ -21,6 +21,12 @@ The connection should contain:
 project_id and run_name are required; other fields optional. In run_name, {date} is replaced
 with the run date (DD/MM/YYYY). Full field list:
 https://github.com/BitModern/testQualityCli/blob/master/src/UploadTestRunCommand.ts
+
+
+StarRocks connection secret
+---------------------------
+The StarRocks connection must be stored as JSON (not a connection URI): the dbt
+container parses it with json.loads (see scripts/dbt/entrypoint.py).
 """
 
 import logging

--- a/radiant/dags/import_radiant.py
+++ b/radiant/dags/import_radiant.py
@@ -188,6 +188,14 @@ def import_radiant():
         map_index_template="Partition: {{ task.conf['part'] }}",
     ).expand(conf=priority)
 
+    run_data_integrity_checks = TriggerDagRunOperator(
+        task_id="data_integrity_checks",
+        task_display_name="[DAG] Data Integrity Checks (StarRocks)",
+        trigger_dag_id=f"{NAMESPACE}-data-integrity-starrocks",
+        reset_dag_run=True,
+        wait_for_completion=True,
+    )
+
     (
         start
         >> tg_partition_group
@@ -195,6 +203,7 @@ def import_radiant():
         >> fetch_sequencing_experiment
         >> prepare_tenants
         >> import_parts
+        >> run_data_integrity_checks
     )
 
 

--- a/radiant/dags/operators/ecs.py
+++ b/radiant/dags/operators/ecs.py
@@ -6,7 +6,7 @@ from airflow.providers.amazon.aws.operators import ecs
 from radiant.dags import ECSEnv
 
 
-class BaseECSOperator:
+class RadiantTaskECSOperator:
     @staticmethod
     def _get_ecs_context(ecs_cluster: str, ecs_subnets: list[str], ecs_security_groups: list[str]):
         return dict(
@@ -29,7 +29,7 @@ class BaseECSOperator:
         )
 
 
-class ImportGermlineSNVVCF(BaseECSOperator):
+class ImportGermlineSNVVCF(RadiantTaskECSOperator):
     @staticmethod
     def get_create_parquet_files(radiant_namespace: str, ecs_env: ECSEnv):
         return ecs.EcsRunTaskOperator.partial(
@@ -96,7 +96,7 @@ class ImportGermlineSNVVCF(BaseECSOperator):
         )
 
 
-class InitIcebergTables(BaseECSOperator):
+class InitIcebergTables(RadiantTaskECSOperator):
     @staticmethod
     def get_init_iceberg(radiant_namespace: str, table_name: str, ecs_env: ECSEnv):
         return ecs.EcsRunTaskOperator(
@@ -126,7 +126,7 @@ class InitIcebergTables(BaseECSOperator):
         )
 
 
-class ImportPart(BaseECSOperator):
+class ImportPart(RadiantTaskECSOperator):
     @staticmethod
     def get_import_cnv_vcf(radiant_namespace: str, ecs_env: ECSEnv):
         return ecs.EcsRunTaskOperator.partial(
@@ -210,4 +210,42 @@ class ImportPart(BaseECSOperator):
                 ecs_subnets=ecs_env.ECS_SUBNETS,
                 ecs_security_groups=ecs_env.ECS_SECURITY_GROUPS,
             )
+        )
+
+
+class CheckDataIntegrity:
+    """Runs dbt data-quality checks. Uses its own ECS task definition, as we use
+    a Docker image specific to dbt instead of the standard radiant-task image."""
+
+    @staticmethod
+    def get_run_dbt(run_results_s3_uri: str, junit_s3_uri: str, ecs_env: ECSEnv):
+        return ecs.EcsRunTaskOperator(
+            task_id="run_dbt",
+            task_display_name="[ECS] Run dbt data tests",
+            cluster=ecs_env.ECS_CLUSTER,
+            launch_type="FARGATE",
+            task_definition=os.getenv("RADIANT_DBT_TASK_DEFINITION"),
+            awslogs_group=os.getenv("RADIANT_DBT_LOG_GROUP"),
+            awslogs_region=os.getenv("RADIANT_DBT_LOG_REGION"),
+            awslogs_stream_prefix=os.getenv("RADIANT_DBT_LOG_PREFIX"),
+            awslogs_fetch_interval=timedelta(seconds=5),
+            overrides={
+                "containerOverrides": [
+                    {
+                        "name": "radiant-dbt-container",
+                        "environment": [
+                            {"name": "RUN_RESULTS_S3_URI", "value": run_results_s3_uri},
+                            {"name": "JUNIT_S3_URI", "value": junit_s3_uri},
+                        ],
+                    }
+                ]
+            },
+            network_configuration={
+                "awsvpcConfiguration": {
+                    "subnets": ecs_env.ECS_SUBNETS,
+                    "assignPublicIp": "DISABLED",
+                    "securityGroups": ecs_env.ECS_SECURITY_GROUPS,
+                }
+            },
+            aws_conn_id="aws_default",
         )

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -1,9 +1,11 @@
 import os
 
 from airflow.decorators import task
+from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
+from airflow.providers.cncf.kubernetes.secret import Secret
 
 
-class BaseK8SOperator:
+class RadiantTaskK8SOperator:
     @staticmethod
     def _get_k8s_context(radiant_namespace: str):
         iceberg_env_vars = {
@@ -30,7 +32,7 @@ class BaseK8SOperator:
         )
 
 
-class ImportGermlineSNVVCF(BaseK8SOperator):
+class ImportGermlineSNVVCF(RadiantTaskK8SOperator):
     @staticmethod
     def get_create_parquet_files(radiant_namespace: str):
         @task.kubernetes(
@@ -75,7 +77,7 @@ class ImportGermlineSNVVCF(BaseK8SOperator):
         return k8s_commit_partitions
 
 
-class ImportPart(BaseK8SOperator):
+class ImportPart(RadiantTaskK8SOperator):
     @staticmethod
     def get_import_cnv_vcf(radiant_namespace: str):
         @task.kubernetes(
@@ -119,7 +121,7 @@ class ImportPart(BaseK8SOperator):
         return get_import_somatic_snv_vcf
 
 
-class InitIcebergTables(BaseK8SOperator):
+class InitIcebergTables(RadiantTaskK8SOperator):
     @staticmethod
     def get_init_database(radiant_namespace: str):
         @task.kubernetes(
@@ -224,3 +226,41 @@ class InitIcebergTables(BaseK8SOperator):
             initialization.create_somatic_snv_occurrence_table()
 
         return create_somatic_snv_occurrence_table
+
+
+class CheckDataIntegrity:
+    """dbt data-quality run. Reuses the shared Radiant K8s deployment settings
+    (namespace, service account) but overrides the image and launches it
+    directly via KubernetesPodOperator."""
+
+    @staticmethod
+    def get_run_dbt(run_results_s3_uri: str, junit_s3_uri: str) -> KubernetesPodOperator:
+        return KubernetesPodOperator(
+            task_id="run_dbt",
+            task_display_name="[K8s] Run dbt data tests",
+            name="data-integrity-dbt",
+            namespace=os.getenv("RADIANT_TASK_OPERATOR_KUBERNETES_NAMESPACE"),
+            service_account_name=os.getenv("RADIANT_TASK_OPERATOR_SERVICE_ACCOUNT_NAME"),
+            image=os.getenv("RADIANT_DBT_OPERATOR_IMAGE"),
+            image_pull_policy="IfNotPresent",
+            secrets=[
+                Secret("env", "AIRFLOW_CONN_STARROCKS_CONN", "starrocks-airflow-conn", "AIRFLOW_CONN_STARROCKS_CONN"),
+            ],
+            env_vars={
+                "RUN_RESULTS_S3_URI": run_results_s3_uri,
+                "JUNIT_S3_URI": junit_s3_uri,
+                # We inject these for the local sandbox (like the other k8s operators).
+                # In prod (EKS), boto3 uses Pod Identity instead, so these resolve to empty.
+                "AWS_REGION": os.getenv("AWS_REGION"),
+                "AWS_ACCESS_KEY_ID": os.getenv("AWS_ACCESS_KEY_ID"),
+                "AWS_SECRET_ACCESS_KEY": os.getenv("AWS_SECRET_ACCESS_KEY"),
+                "AWS_ENDPOINT_URL": os.getenv("AWS_ENDPOINT_URL"),
+                "AWS_ALLOW_HTTP": os.getenv("AWS_ALLOW_HTTP"),
+            },
+            get_logs=True,
+            # We only use this operator with the KubernetesExecutor, which runs
+            # this task in its own ephemeral pod. Using non-deferrable does not
+            # block other tasks.
+            deferrable=False,
+            is_delete_operator_pod=True,
+        )

--- a/radiant/data_qa/README.md
+++ b/radiant/data_qa/README.md
@@ -47,7 +47,7 @@ yet handle**. "The portal" hardcodes behaviour in two places:
 
 A new upstream value not present in **either** source is fully unhandled.
 A value present in only one is a portal-internal inconsistency (out of
-scope for data-qa, but worth flagging).
+scope for data_qa, but worth flagging).
 
 Each test's accepted-values list mirrors the relevant source(s) — the
 **union** of backend facets and frontend i18n for scalar columns. The lists
@@ -76,7 +76,7 @@ custom `accepted_values_in_array` generic test (`macros/`), which `array_filter`
 each array down to the offending elements *before* unnesting (so valid rows
 emit nothing instead of exploding) and flags any element not in `values`. Both are declared in the
 source YAML with a `name:` (append the Jira id when a ticket tracks a known
-gap, e.g. `..._SJRA1552`) and a `values:` list.
+gap, e.g. `..._SJRA-1552`) and a `values:` list.
 
 Values are tested **raw / case-sensitive** — no normalization. For array
 columns the dictionary therefore mirrors backend `facets.go` in its data
@@ -94,7 +94,7 @@ invariants that don't fit a generic test (e.g. `no_star_alternate`).
 ## Setup
 
 ```bash
-cd data-qa
+cd data_qa
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
@@ -143,7 +143,7 @@ investigate.
 ## Layout
 
 ```
-data-qa/
+data_qa/
 ├── macros/    # custom generic tests + dictionaries.sql
 ├── sources/   # source + generic-test declarations, one YAML per table
 ├── tests/     # singular tests (cross-field invariants), one SQL per check

--- a/radiant/data_qa/macros/dictionaries.sql
+++ b/radiant/data_qa/macros/dictionaries.sql
@@ -9,7 +9,7 @@
   (`frontend/translations/common/*.json`). The `mirrors … — keep in sync`
   note lives here, once per dictionary, so there is a single place to update
   when an upstream value is added. Values are raw / case-sensitive (no
-  normalization) — see data-qa/README.md.
+  normalization) — see data_qa/README.md.
 #}
 
 {% macro dict_chromosome() %}

--- a/radiant/data_qa/scripts/run_qa.sh
+++ b/radiant/data_qa/scripts/run_qa.sh
@@ -6,6 +6,11 @@
 # Exit 0 when the JUnit report was produced (data-test failures are encoded
 # in the XML, not treated as a mechanism failure). Exit non-zero only when
 # the run itself could not execute (e.g. no connection).
+#
+# Note: the Airflow pipeline runs this same script automatically. It relies on
+# the two files created here (target/run_results.json and reports/junit.xml)
+# and on the script exit code. If you change any of those, the pipeline needs
+# to be updated too.
 set -uo pipefail
 
 DATA_QA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/scripts/dbt/entrypoint.py
+++ b/scripts/dbt/entrypoint.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Container entrypoint for the data_qa dbt run (K8s pod / ECS task).
+
+Parses the StarRocks Airflow connection into the SR_* env vars profiles.yml
+expects, runs scripts/run_qa.sh verbatim, then uploads run_results.json and
+junit.xml to the S3 URIs provided by the DAG.
+"""
+import json
+import os
+import subprocess
+import sys
+from urllib.parse import urlparse
+
+import boto3
+
+DATA_QA_DIR = "/opt/dbt/data_qa"
+
+
+def export_starrocks_env(env):
+    conn = json.loads(os.environ["AIRFLOW_CONN_STARROCKS_CONN"])
+    env["SR_HOST"] = conn["host"]
+    env["SR_PORT"] = str(conn.get("port") or 9030)
+    env["SR_USER"] = conn.get("login") or "root"
+    env["SR_PASSWORD"] = conn.get("password") or ""
+    if conn.get("schema"):
+        env["SR_SCHEMA"] = conn["schema"]
+
+
+def upload(local_path, s3_uri):
+    parsed = urlparse(s3_uri)
+    boto3.client("s3").upload_file(local_path, parsed.netloc, parsed.path.lstrip("/"))
+    print(f"Uploaded {local_path} -> {s3_uri}", flush=True)
+
+
+def main():
+    env = os.environ.copy()
+    export_starrocks_env(env)
+
+    # A non-zero exit means dbt could not run at all (e.g. no StarRocks connection):
+    # there is nothing to upload, so fail the task.
+    result = subprocess.run([f"{DATA_QA_DIR}/scripts/run_qa.sh"], env=env)
+    if result.returncode != 0:
+        print("dbt could not run (no run_results.json produced) — failing the task.", file=sys.stderr, flush=True)
+        sys.exit(result.returncode)
+
+    # Upload reports to s3 (overwrites if already present)
+    upload(f"{DATA_QA_DIR}/target/run_results.json", os.environ["RUN_RESULTS_S3_URI"])
+    upload(f"{DATA_QA_DIR}/reports/junit.xml", os.environ["JUNIT_S3_URI"])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/dags/operators/ecs/test_check_data_integrity_ecs_operator.py
+++ b/tests/unit/dags/operators/ecs/test_check_data_integrity_ecs_operator.py
@@ -1,0 +1,50 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from radiant.dags.operators.ecs import CheckDataIntegrity
+
+
+def test_get_run_dbt():
+    fake_env = {
+        "RADIANT_DBT_TASK_DEFINITION": "radiant-dbt",
+        "RADIANT_DBT_LOG_GROUP": "apps-qa/radiant-etl",
+        "RADIANT_DBT_LOG_REGION": "us-east-1",
+        "RADIANT_DBT_LOG_PREFIX": "ecs/radiant-dbt-container",
+    }
+    ecs_env = SimpleNamespace(
+        ECS_CLUSTER="my-cluster",
+        ECS_SUBNETS=["subnet-1", "subnet-2"],
+        ECS_SECURITY_GROUPS=["sg-1"],
+    )
+    with patch.dict(os.environ, fake_env, clear=True):
+        op = CheckDataIntegrity.get_run_dbt(
+            run_results_s3_uri="s3://bucket/dbt-qa/run1/run_results.json",
+            junit_s3_uri="s3://bucket/dbt-qa/run1/junit.xml",
+            ecs_env=ecs_env,
+        )
+
+    assert op.task_id == "run_dbt"
+    assert op.cluster == "my-cluster"
+    assert op.launch_type == "FARGATE"
+    assert op.task_definition == "radiant-dbt"
+    assert op.aws_conn_id == "aws_default"
+
+    # awslogs config
+    assert op.awslogs_group == "apps-qa/radiant-etl"
+    assert op.awslogs_region == "us-east-1"
+    assert op.awslogs_stream_prefix == "ecs/radiant-dbt-container"
+
+    # container name must match the override target
+    (container,) = op.overrides["containerOverrides"]
+    assert container["name"] == "radiant-dbt-container"
+
+    # verify per-run S3 URIs are injected via containerOverrides
+    env = {e["name"]: e["value"] for e in container["environment"]}
+    assert env["RUN_RESULTS_S3_URI"] == "s3://bucket/dbt-qa/run1/run_results.json"
+    assert env["JUNIT_S3_URI"] == "s3://bucket/dbt-qa/run1/junit.xml"
+
+    # network config from ecs_env
+    vpc = op.network_configuration["awsvpcConfiguration"]
+    assert vpc["subnets"] == ["subnet-1", "subnet-2"]
+    assert vpc["securityGroups"] == ["sg-1"]

--- a/tests/unit/dags/operators/k8s/test_check_data_integrity_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_check_data_integrity_k8s_operator.py
@@ -1,0 +1,47 @@
+import os
+from unittest.mock import patch
+
+from radiant.dags.operators.k8s import CheckDataIntegrity
+
+
+def test_get_run_dbt():
+    fake_env = {
+        "RADIANT_TASK_OPERATOR_KUBERNETES_NAMESPACE": "airflow",
+        "RADIANT_TASK_OPERATOR_SERVICE_ACCOUNT_NAME": "airflow-sa",
+        "RADIANT_DBT_OPERATOR_IMAGE": "my-registry/radiant-dbt:test",
+        "AWS_REGION": "ca-central-1",
+        "AWS_ACCESS_KEY_ID": "my-access-key",
+        "AWS_SECRET_ACCESS_KEY": "my-secret-key",
+        "AWS_ENDPOINT_URL": "http://minio:9000",
+        "AWS_ALLOW_HTTP": "true",
+    }
+    with patch.dict(os.environ, fake_env, clear=True):
+        op = CheckDataIntegrity.get_run_dbt(
+            run_results_s3_uri="s3://bucket/dbt-qa/run1/run_results.json",
+            junit_s3_uri="s3://bucket/dbt-qa/run1/junit.xml",
+        )
+
+    assert op.task_id == "run_dbt"
+    assert op.namespace == "airflow"
+    assert op.service_account_name == "airflow-sa"
+    assert op.image == "my-registry/radiant-dbt:test"
+    assert op.deferrable is False
+    assert op.get_logs is True
+
+    # StarRocks connection injected from the existing K8s secret.
+    (secret,) = op.secrets
+    assert secret.deploy_type == "env"
+    assert secret.deploy_target == "AIRFLOW_CONN_STARROCKS_CONN"
+    assert secret.secret == "starrocks-airflow-conn"
+    assert secret.key == "AIRFLOW_CONN_STARROCKS_CONN"
+
+    # verify env vars are injected. The AWS creds (key/secret/endpoint/http) are
+    # for the local sandbox only — empty in prod (EKS) → boto3 uses Pod Identity.
+    env = {e.name: e.value for e in op.env_vars}
+    assert env["RUN_RESULTS_S3_URI"] == "s3://bucket/dbt-qa/run1/run_results.json"
+    assert env["JUNIT_S3_URI"] == "s3://bucket/dbt-qa/run1/junit.xml"
+    assert env["AWS_REGION"] == "ca-central-1"
+    assert env["AWS_ACCESS_KEY_ID"] == "my-access-key"
+    assert env["AWS_SECRET_ACCESS_KEY"] == "my-secret-key"
+    assert env["AWS_ENDPOINT_URL"] == "http://minio:9000"
+    assert env["AWS_ALLOW_HTTP"] == "true"

--- a/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
@@ -1,7 +1,7 @@
 import os
 from unittest.mock import patch
 
-from radiant.dags.operators.k8s import BaseK8SOperator
+from radiant.dags.operators.k8s import RadiantTaskK8SOperator
 
 
 def test_get_k8s_context():
@@ -19,7 +19,7 @@ def test_get_k8s_context():
         "RADIANT_TASK_OPERATOR_LD_LIBRARY_PATH": "/lib",
     }
     with patch.dict(os.environ, fake_env, clear=True):
-        context = BaseK8SOperator._get_k8s_context("my-iceberg-namespace")
+        context = RadiantTaskK8SOperator._get_k8s_context("my-iceberg-namespace")
 
     assert context["namespace"] == "my-kubernetes-namespace"
     assert context["image"] == "test-image"

--- a/tests/unit/dags/test_data_integrity_starrocks.py
+++ b/tests/unit/dags/test_data_integrity_starrocks.py
@@ -1,0 +1,9 @@
+def test_data_integrity_dag_loads(dag_bag):
+    dag = dag_bag.get_dag("radiant-data-integrity-starrocks")
+    assert dag is not None
+    assert not dag_bag.import_errors
+
+
+def test_data_integrity_dag_has_expected_tasks(dag_bag):
+    dag = dag_bag.get_dag("radiant-data-integrity-starrocks")
+    assert set(dag.task_ids) == {"run_dbt", "upload_to_testquality", "check_qa_results"}

--- a/tests/unit/dags/test_import_radiant.py
+++ b/tests/unit/dags/test_import_radiant.py
@@ -16,6 +16,7 @@ def test_dag_has_expected_tasks(dag_bag):
         "assign_priority",
         "import_part",
         "update_sequencing_experiment_deleted",
+        "data_integrity_checks",
     }
     assert set(dag.task_ids) == expected_tasks
 
@@ -41,3 +42,4 @@ def test_dag_task_dependencies_are_correct(dag_bag):
     assert fetch_exp in update_deleted_exp.get_direct_relatives(upstream=False)
     assert assign_priority in fetch_exp.get_direct_relatives(upstream=False)
     assert import_part in assign_priority.get_direct_relatives(upstream=False)
+    assert "data_integrity_checks" in import_part.downstream_task_ids


### PR DESCRIPTION
## 📌 Context

<!-- Briefly describe the purpose of this PR. Include any relevant context. -->
This PR introduces a new DAG that runs data-integrity checks against the StarRocks tables.

The dag perform three steps:
- 1) Run dbt in a dedicated container (radiant/data_qa/scripts/run_qa.sh) and upload the resulting reports (run_results.json + junit.xml) to S3.
- 2) (Optional) Push the JUnit report to our QA tool, TestQuality.
- 3) Inspect the JSON report and fail the run on unexpected test failures (failures tagged with a Jira ticket SJRA-xxxx are treated as known errors and don't fail the run).

The DAG is triggered automatically at the end of the Scheduled Import DAG, and can also be run manually. Step 2 can be skipped via the skip_testquality_push DAG param, and is skipped automatically if the testquality_conn connection is absent.

## 📝 Changes

<!-- List the main changes in this PR. -->

- Add the data-integrity-starrocks DAG (dbt data-quality checks).
- Add a dedicated dbt Docker image (Dockerfile.radiant.dbt) + its build-and-push GitHub workflow.
- Add two operators (CheckDataIntegrity for ECS and K8s) that run the data-qa script in that image
- Trigger the new DAG at the end of the Scheduled Import DAG.

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->


## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

- Add unit tests for new k8s and ecs operators
- Add unit tests for the check data integrity dag

Tested manually with the sandbox. Here is a screenshot to show how the dag steps look like:
<img width="1010" height="444" alt="Capture d’écran 2026-07-28 à 11 52 11" src="https://github.com/user-attachments/assets/f91f6d10-56ec-435a-8d28-6cb98f4a2b34" />

The final task inspecting results fail because the sandbox data is not perfectly realistic.  Here is an excerpt of the logs for this task:
```
[2026-07-28 11:50:37] INFO - 130 passed · 0 warned · 63 failed — 8 known, 55 unexpected (of 193)
[2026-07-28 11:50:37] WARNING - Known errors (tagged with a Jira ticket), not failing the run:
test.radiant_data_qa.clinvar_rcv_summary__accepted_values_clinical_significance_SJRA-1624.205e41be86
test.radiant_data_qa.germline_snv_occurrence__should_not_contain_only_null_SJRA-1559.508213240e
test.radiant_data_qa.hpo_gene_panel__validate_hpo_term_id_format_SJRA-1668
test.radiant_data_qa.snv_consequence__should_not_contain_only_null_SJRA-1550.dcc0cce732
test.radiant_data_qa.snv_consequence__should_not_contain_same_value_SJRA-1550.166c57f4f8
test.radiant_data_qa.snv_variant__relationships__symbol__ensembl_gene_SJRA-1667.5e6b13ed21
test.radiant_data_qa.snv_variant__should_not_contain_only_null_SJRA-1550.c7136bb095
test.radiant_data_qa.snv_variant__should_not_contain_same_value_SJRA-1550.8884da8508
[2026-07-28 11:50:37] ERROR - Task failed with exception
AirflowFailException: 55 DATA QA test(s) failed. See the 'Run dbt data tests' task logs for the full dbt output.
Failed tests:
test.radiant_data_qa.1000_genomes__should_not_contain_same_value.143e2f22a8
test.radiant_data_qa.clinvar__should_not_contain_only_null.d8c33a308b
test.radiant_data_qa.clinvar__should_not_contain_same_value.124e62f970
test.radiant_data_qa.exomiser__accepted_values_acmg_classification.78fe6a9969
...
```

Reports stored on s3 (here minio):
<img width="1369" height="422" alt="Capture d’écran 2026-07-28 à 11 55 18" src="https://github.com/user-attachments/assets/e4d9096b-9965-4f20-ae8d-9954a8faee3a" />


TestQuality screenshots (after successful push):
<img width="1449" height="779" alt="Capture d’écran 2026-07-28 à 15 41 17" src="https://github.com/user-attachments/assets/e83ed885-abf9-4325-ac5b-4c3d5f7121cc" />
<img width="1449" height="732" alt="Capture d’écran 2026-07-28 à 15 40 56" src="https://github.com/user-attachments/assets/07ee4b86-317b-403c-aced-fddc6265dacf" />


## 🔗 Related Issues

<!-- Begin JIRA Issues -->

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->
  -  the worker tasks (steps 2 & 3) use boto3 to read the reports back from S3. We did not update requirements-airflow.txt — it still targets Airflow 2 and does not seem to be used anymore. In prod, boto3 is available via the AWS provider. MWAA bundles it by default. To the best of my knowledge, the EKS/qlin worker runs the standard non-slim airflow image (AWS provider included). 
  - The initial implementation used a PythonVirtualenvOperator that pip installed dbt + ran dbt deps at runtime. Both hit PyPI / the dbt hub, which are blocked by the network constraints . So we pre-install dbt and its packages in a dedicated Docker image and run it via a container-friendly operator (ECS task / K8s pod)

These PR must also be merged after this PR:
 - https://github.com/radiant-network/radiant-portal-sandbox/pull/12
 - https://github.com/Ferlab-Ste-Justine/qlin-qa-infra/pull/91
 - https://github.com/radiant-network/radiant-portal-deployment/pull/336
