### PR TITLE
fix: SJRA-1754 build the SNV variant catalog per tenant

### DIFF
--- a/radiant/dags/import_part.py
+++ b/radiant/dags/import_part.py
@@ -180,8 +180,8 @@ def import_part():
 
     @task.short_circuit(task_id="extract_all_tenants", task_display_name="[PyOp] Extract All Tenants")
     def extract_all_tenants() -> list[str]:
-        # Every tenant known to the platform (not just this batch). The shared variant catalog pools
-        # frequencies across all of these, so it reflects the current state of all tenants.
+        # Every tenant known to the platform (not just this batch). The shared consequence filter
+        # pools loci across all of these, so it reflects the current state of all tenants.
         from airflow.hooks.base import BaseHook
         from airflow.operators.python import get_current_context
 
@@ -455,15 +455,6 @@ def import_part():
         )
 
     with TaskGroup(group_id="snv_variant") as tg_variants:
-        variant_sql = render_pooled_sql.override(
-            task_id="render_snv_variant_sql",
-            task_display_name="[PyOp] Render Pooled SNV Variant SQL",
-        )("radiant/snv_variant_insert.sql", all_tenants)
-        variant_part_sql = render_pooled_sql.override(
-            task_id="render_snv_variant_part_sql",
-            task_display_name="[PyOp] Render Pooled SNV Variant Part SQL",
-        )("radiant/snv_variant_part_insert_part.sql", all_tenants)
-
         insert_snv_staging_variants = RadiantStarRocksOperator(
             task_id="insert_snv_staging_variant",
             task_display_name="[StarRocks] Insert Staging SNV Variants",
@@ -472,13 +463,15 @@ def import_part():
             trigger_rule=TriggerRule.ALL_SUCCESS,
         )
 
-        insert_snv_variants_with_freqs = RadiantStarRocksOperator(
+        insert_snv_variants_with_freqs = RadiantStarRocksOperator.partial(
             task_id="insert_snv_variant",
             task_display_name="[StarRocks] Insert SNV Variants",
-            sql=variant_sql,
+            sql="./sql/radiant/snv_variant_insert.sql",
+            map_index_template="{{ task.tenant_code }}",
             submit_task_options=std_submit_task_opts,
             trigger_rule=TriggerRule.ALL_SUCCESS,
-        )
+            max_active_tis_per_dagrun=1,
+        ).expand(tenant_code=tenants)
 
         @task(task_id="compute_parts", trigger_rule=TriggerRule.NONE_FAILED)
         def compute_part(params):
@@ -492,14 +485,16 @@ def import_part():
 
         _compute_part = compute_part()
 
-        insert_snv_variants_part = RadiantStarRocksOperator(
+        insert_snv_variants_part = RadiantStarRocksOperator.partial(
             task_id="insert_snv_variant_part",
-            sql=variant_part_sql,
+            sql="./sql/radiant/snv_variant_part_insert_part.sql",
             task_display_name="[StarRocks] Insert SNV Variants Part",
+            map_index_template="{{ task.tenant_code }}",
             submit_task_options=std_submit_task_opts,
             parameters=_compute_part,
             trigger_rule=TriggerRule.ALL_SUCCESS,
-        )
+            max_active_tis_per_dagrun=1,
+        ).expand(tenant_code=tenants)
 
         (
             sanity_check_any_snv(tasks=tasks)
@@ -623,9 +618,9 @@ def import_part():
         >> tg_consequences
         >> checkpoint_variants
     )
-    # We re-compute variants frequencies across all tenants, therefore we need
-    # the list of all tenants in the system to be loaded before importing variants.
-    checkpoint_after_exomiser >> all_tenants >> tg_variants
+    # The consequence filter is still pooled across every tenant, therefore we need the list of all
+    # tenants in the system to be loaded before importing consequences.
+    checkpoint_after_exomiser >> all_tenants >> tg_consequences
 
     # Final Phase: Update Sequencing Experiments (deletions and updates)
     checkpoint_variants >> [delete_sequencing_experiments, update_sequencing_experiments]

--- a/radiant/dags/init_starrocks_tables.py
+++ b/radiant/dags/init_starrocks_tables.py
@@ -19,8 +19,6 @@ _BASE_TABLES = [
     "staging_sequencing_experiment_delta",
     "snv_tmp_variant",
     "snv_staging_variant",
-    "snv_variant",
-    "snv_variant_partitioned",
     "variant_lookup",
     "staging_exomiser",
     "germline_snv_staging_variant_frequency",

--- a/radiant/dags/sql/radiant/snv_variant_insert.sql
+++ b/radiant/dags/sql/radiant/snv_variant_insert.sql
@@ -1,58 +1,21 @@
 INSERT OVERWRITE {{ mapping.starrocks_snv_variant }}
-WITH germline_freq AS (
-    SELECT locus_id,
-           SUM(pc_wgs)              AS pc_wgs,
-           SUM(pc_wgs_affected)     AS pc_wgs_affected,
-           SUM(pc_wgs_not_affected) AS pc_wgs_not_affected,
-           SUM(pc_wxs)              AS pc_wxs,
-           SUM(pc_wxs_affected)     AS pc_wxs_affected,
-           SUM(pc_wxs_not_affected) AS pc_wxs_not_affected
-    FROM (
-        {% for t in tenants %}
-        SELECT locus_id, pc_wgs, pc_wgs_affected, pc_wgs_not_affected, pc_wxs, pc_wxs_affected, pc_wxs_not_affected
-        FROM {{ per_tenant_mapping(t).starrocks_germline_snv_variant_frequency }}
-        {% if not loop.last %}UNION ALL{% endif %}
-        {% endfor %}
-    ) g
-    GROUP BY locus_id
-),
-germline_pn AS (
-    SELECT SUM(pn_wgs)              AS pn_wgs,
-           SUM(pn_wgs_affected)     AS pn_wgs_affected,
-           SUM(pn_wgs_not_affected) AS pn_wgs_not_affected,
-           SUM(pn_wxs)              AS pn_wxs,
-           SUM(pn_wxs_affected)     AS pn_wxs_affected,
-           SUM(pn_wxs_not_affected) AS pn_wxs_not_affected
-    FROM (
-        {% for t in tenants %}
-        SELECT ANY_VALUE(pn_wgs) AS pn_wgs, ANY_VALUE(pn_wgs_affected) AS pn_wgs_affected,
-               ANY_VALUE(pn_wgs_not_affected) AS pn_wgs_not_affected, ANY_VALUE(pn_wxs) AS pn_wxs,
-               ANY_VALUE(pn_wxs_affected) AS pn_wxs_affected, ANY_VALUE(pn_wxs_not_affected) AS pn_wxs_not_affected
-        FROM {{ per_tenant_mapping(t).starrocks_germline_snv_variant_frequency }}
-        {% if not loop.last %}UNION ALL{% endif %}
-        {% endfor %}
-    ) g
-),
-somatic_freq AS (
-    SELECT locus_id, SUM(pc_tn_wgs) AS pc_tn_wgs, SUM(pc_tn_wxs) AS pc_tn_wxs
-    FROM (
-        {% for t in tenants %}
-        SELECT locus_id, pc_tn_wgs, pc_tn_wxs
-        FROM {{ per_tenant_mapping(t).starrocks_somatic_snv_variant_frequency }}
-        {% if not loop.last %}UNION ALL{% endif %}
-        {% endfor %}
-    ) s
-    GROUP BY locus_id
+WITH germline_pn AS (
+    SELECT ANY_VALUE(pn_wgs)              AS pn_wgs,
+           ANY_VALUE(pn_wgs_affected)     AS pn_wgs_affected,
+           ANY_VALUE(pn_wgs_not_affected) AS pn_wgs_not_affected,
+           ANY_VALUE(pn_wxs)              AS pn_wxs,
+           ANY_VALUE(pn_wxs_affected)     AS pn_wxs_affected,
+           ANY_VALUE(pn_wxs_not_affected) AS pn_wxs_not_affected
+    FROM {{ mapping.starrocks_germline_snv_variant_frequency }}
 ),
 somatic_pn AS (
-    SELECT SUM(pn_tn_wgs) AS pn_tn_wgs, SUM(pn_tn_wxs) AS pn_tn_wxs
-    FROM (
-        {% for t in tenants %}
-        SELECT ANY_VALUE(pn_tn_wgs) AS pn_tn_wgs, ANY_VALUE(pn_tn_wxs) AS pn_tn_wxs
-        FROM {{ per_tenant_mapping(t).starrocks_somatic_snv_variant_frequency }}
-        {% if not loop.last %}UNION ALL{% endif %}
-        {% endfor %}
-    ) s
+    SELECT ANY_VALUE(pn_tn_wgs) AS pn_tn_wgs, ANY_VALUE(pn_tn_wxs) AS pn_tn_wxs
+    FROM {{ mapping.starrocks_somatic_snv_variant_frequency }}
+),
+tenant_loci AS (
+    SELECT locus_id FROM {{ mapping.starrocks_germline_snv_variant_frequency }}
+    UNION
+    SELECT locus_id FROM {{ mapping.starrocks_somatic_snv_variant_frequency }}
 )
 SELECT
     v.locus_id,
@@ -109,5 +72,6 @@ SELECT
     v.transcript_id,
     v.omim_inheritance_code
 FROM {{ mapping.starrocks_snv_staging_variant }} v
-LEFT JOIN germline_freq gf ON gf.locus_id = v.locus_id
-LEFT JOIN somatic_freq sf ON sf.locus_id = v.locus_id
+LEFT SEMI JOIN tenant_loci tl ON tl.locus_id = v.locus_id
+LEFT JOIN {{ mapping.starrocks_germline_snv_variant_frequency }} gf ON gf.locus_id = v.locus_id
+LEFT JOIN {{ mapping.starrocks_somatic_snv_variant_frequency }} sf ON sf.locus_id = v.locus_id

--- a/radiant/dags/sql/radiant/snv_variant_part_insert_part.sql
+++ b/radiant/dags/sql/radiant/snv_variant_part_insert_part.sql
@@ -5,14 +5,11 @@ SELECT
 FROM
     {{ mapping.starrocks_snv_variant }} v
 LEFT SEMI JOIN (
-    {% for t in tenants %}
     SELECT locus_id
-    FROM {{ per_tenant_mapping(t).starrocks_germline_snv_occurrence }}
+    FROM {{ mapping.starrocks_germline_snv_occurrence }}
     WHERE part >= %(part_lower)s AND part < %(part_upper)s
     UNION ALL
     SELECT locus_id
-    FROM {{ per_tenant_mapping(t).starrocks_somatic_snv_occurrence }}
+    FROM {{ mapping.starrocks_somatic_snv_occurrence }}
     WHERE part >= %(part_lower)s AND part < %(part_upper)s
-    {% if not loop.last %}UNION ALL{% endif %}
-    {% endfor %}
 ) o ON v.locus_id = o.locus_id;

--- a/radiant/tasks/data/radiant_tables.py
+++ b/radiant/tasks/data/radiant_tables.py
@@ -92,8 +92,6 @@ STARROCKS_RADIANT_BASE_MAPPING = {
     "starrocks_snv_consequence_filter": "snv__consequence_filter",
     "starrocks_snv_consequence_filter_partitioned": "snv__consequence_filter_partitioned",
     "starrocks_snv_tmp_variant": "snv__tmp_variant",
-    "starrocks_snv_variant": "snv__variant",
-    "starrocks_snv_variant_partitioned": "snv__variant_partitioned",
     "starrocks_snv_staging_variant": "snv__staging_variant",
     # Tenant partitioned staging tables
     "starrocks_staging_exomiser": "raw_exomiser",
@@ -106,6 +104,8 @@ STARROCKS_RADIANT_PER_TENANT_MAPPING = {
     "starrocks_germline_cnv_occurrence": "germline__cnv__occurrence",
     "starrocks_germline_snv_occurrence": "germline__snv__occurrence",
     "starrocks_germline_snv_variant_frequency": "germline__snv__variant_frequency",
+    "starrocks_snv_variant": "snv__variant",
+    "starrocks_snv_variant_partitioned": "snv__variant_partitioned",
     "starrocks_somatic_snv_occurrence": "somatic__snv__occurrence",
     "starrocks_somatic_snv_variant_frequency": "somatic__snv__variant_frequency",
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,10 @@ RESOURCES_DIR = CURRENT_DIR.parent / "resources" / "integration"
 
 RADIANT_DIR = CURRENT_DIR.parent.parent / "radiant"
 
+# Tenants used by the fixtures that need real per-tenant databases.
+TENANT_CODES = ("chusj", "chop")
+TENANT_CODE = TENANT_CODES[0]
+
 
 class StarRocksDatabase:
     def __init__(self, host, query_port, user, password, database):
@@ -69,6 +73,33 @@ def starrocks_database(starrocks_instance, random_test_id):
             database=test_db_name,
         )
         cursor.execute(f"DROP DATABASE IF EXISTS {test_db_name};")
+        connection.commit()
+        return
+
+
+@pytest.fixture(scope="session")
+def starrocks_tenant_database(starrocks_instance, random_test_id):
+    """Real databases for TENANT_CODES, so per-tenant SQL is exercised across database boundaries.
+
+    Yields the RADIANT_TENANT_DB_TEMPLATE value.
+    """
+    template = f"{STARROCKS_DATABASE_PREFIX}_{random_test_id}_{{tenant}}"
+
+    with (
+        pymysql.connect(
+            host=starrocks_instance.host,
+            port=int(starrocks_instance.query_port),
+            user=starrocks_instance.user,
+            password=starrocks_instance.password,
+        ) as connection,
+        connection.cursor() as cursor,
+    ):
+        for tenant in TENANT_CODES:
+            cursor.execute(f"CREATE DATABASE IF NOT EXISTS {template.format(tenant=tenant)};")
+        connection.commit()
+        yield template
+        for tenant in TENANT_CODES:
+            cursor.execute(f"DROP DATABASE IF EXISTS {template.format(tenant=tenant)};")
         connection.commit()
         return
 

--- a/tests/integration/dags/sql/test_queries.py
+++ b/tests/integration/dags/sql/test_queries.py
@@ -4,6 +4,8 @@ import os
 import jinja2
 
 from radiant.dags import DAGS_DIR
+from radiant.tasks.data.radiant_tables import RadiantConfigKeys
+from tests.integration.conftest import TENANT_CODE
 
 _SQL_DIR = os.path.join(DAGS_DIR, "sql")
 
@@ -54,10 +56,10 @@ def _execute_query(cursor, query, args=None):
         raise Exception(f"Query failed: {query}, with exception: {e}") from e
 
 
-def _execute_file(cursor, sql_file, args=None):
+def _execute_file(cursor, sql_file, args=None, tenant_code=None):
     from radiant.tasks.data.radiant_tables import get_radiant_mapping
 
-    context = {"mapping": get_radiant_mapping()}
+    context = {"mapping": get_radiant_mapping(tenant_code=tenant_code)}
     if "udf" in sql_file:
         context["params"] = {"udf_release_version": "v1.1.0"}
 
@@ -67,14 +69,14 @@ def _execute_file(cursor, sql_file, args=None):
     return _execute_query(cursor, rendered_sql, args=args)
 
 
-def _validate_init(starrocks_session, sql_dir, tables=None, views=None, udfs=None):
+def _validate_init(starrocks_session, sql_dir, tables=None, views=None, udfs=None, tenant_code=None):
     with starrocks_session.cursor() as cursor:
         # Create UDFs first because some queries may depend on them
         for udf in udfs or []:
-            _execute_file(cursor, os.path.join(sql_dir, udf + "_udf.sql"))
+            _execute_file(cursor, os.path.join(sql_dir, udf + "_udf.sql"), tenant_code=tenant_code)
 
         for filename in itertools.chain(tables or [], views or []):
-            _execute_file(cursor, os.path.join(sql_dir, filename + "_create_table.sql"))
+            _execute_file(cursor, os.path.join(sql_dir, filename + "_create_table.sql"), tenant_code=tenant_code)
 
 
 def _explain_insert(starrocks_session, sql_dir):
@@ -116,11 +118,35 @@ def _explain_insert(starrocks_session, sql_dir):
             _execute_query(cursor, f"EXPLAIN {rendered_sql}", args=_MOCK_PARAMS)
 
 
+def _explain_tenant_scoped_insert(starrocks_session, sql_files, tenant_code):
+    """EXPLAIN the per-tenant variant catalog SQL against a real second database.
+
+    `_explain_insert` renders without a tenant, so every table collapses onto the base test DB and
+    cross-database name resolution is never exercised. These files write to `<tenant>_db` while
+    still reading `snv__staging_variant` from the base DB, so they need both.
+    """
+    from radiant.tasks.data.radiant_tables import get_radiant_mapping
+
+    mapping = get_radiant_mapping(tenant_code=tenant_code)
+    with starrocks_session.cursor() as cursor:
+        for filename in sql_files:
+            with open(os.path.join(_RADIANT_INSERT_DIR, filename)) as f:
+                rendered_sql = jinja2.Template(f.read()).render({"mapping": mapping})
+            _execute_query(cursor, f"EXPLAIN {rendered_sql}", args=_MOCK_PARAMS)
+
+
 def test_queries_are_valid(
-    monkeypatch, iceberg_client, starrocks_session, setup_iceberg_namespace, open_data_iceberg_tables, mapping_conf
+    monkeypatch,
+    iceberg_client,
+    starrocks_session,
+    setup_iceberg_namespace,
+    open_data_iceberg_tables,
+    mapping_conf,
+    starrocks_tenant_database,
 ):
     for k, v in mapping_conf.items():
         monkeypatch.setenv(k.upper(), v)
+    monkeypatch.setenv(RadiantConfigKeys.RADIANT_TENANT_DB_TEMPLATE.env_key, starrocks_tenant_database)
     # Validate table creation for Open Data & Radiant
     _validate_init(
         starrocks_session,
@@ -176,3 +202,23 @@ def test_queries_are_valid(
     # Validate table insertion using SQL `EXPLAIN` for Open Data & Radiant (Requires existing tables)
     _explain_insert(starrocks_session, sql_dir=_OPEN_DATA_INSERT_DIR)
     _explain_insert(starrocks_session, sql_dir=_RADIANT_INSERT_DIR)
+
+    # Same again for the variant catalog, but against a real tenant database.
+    _validate_init(
+        starrocks_session,
+        sql_dir=_RADIANT_INIT_DIR,
+        tables=[
+            "germline_snv_occurrence",
+            "germline_snv_variant_frequency",
+            "snv_variant",
+            "snv_variant_partitioned",
+            "somatic_snv_occurrence",
+            "somatic_snv_variant_frequency",
+        ],
+        tenant_code=TENANT_CODE,
+    )
+    _explain_tenant_scoped_insert(
+        starrocks_session,
+        sql_files=["snv_variant_insert.sql", "snv_variant_part_insert_part.sql"],
+        tenant_code=TENANT_CODE,
+    )

--- a/tests/integration/dags/sql/test_snv_variant_tenant_isolation.py
+++ b/tests/integration/dags/sql/test_snv_variant_tenant_isolation.py
@@ -1,0 +1,110 @@
+"""The variant catalog must never expose another tenant's cohort.
+
+`snv_variant_insert.sql` used to pool every tenant's frequency tables, so `germline_pn_*` was the
+sum of all cohorts and a locus carried by one tenant showed up in everyone's catalog. This test
+seeds two real tenant databases with overlapping and disjoint loci, runs the real insert once per
+tenant, and asserts each catalog only ever sees its own numbers.
+"""
+
+import os
+
+import jinja2
+
+from radiant.dags import DAGS_DIR
+from radiant.tasks.data.radiant_tables import RadiantConfigKeys, get_radiant_mapping
+from tests.integration.conftest import TENANT_CODES
+
+_SQL_DIR = os.path.join(DAGS_DIR, "sql", "radiant")
+
+_TENANT_A, _TENANT_B = TENANT_CODES
+
+# Locus 4 is carried by no tenant: it exists in the shared staging catalog (open-data annotations
+# have no tenant), so it proves the insert restricts to the loci the tenant actually carries.
+_STAGING_LOCI = (1, 2, 3, 4)
+
+# locus_id -> (pc_wgs, pn_wgs). `pn_*` is the tenant's whole cohort, broadcast onto every row by
+# germline_snv_variant_frequency_insert.sql.
+_GERMLINE_FREQ = {
+    _TENANT_A: {1: (3, 10), 2: (5, 10)},
+    _TENANT_B: {2: (1, 4), 3: (2, 4)},
+}
+# locus_id -> (pc_tn_wgs, pn_tn_wgs). Tenant B has no somatic experiments at all.
+_SOMATIC_FREQ = {
+    _TENANT_A: {2: (1, 7)},
+    _TENANT_B: {},
+}
+
+
+def _reset_table(cursor, table, mapping):
+    with open(os.path.join(_SQL_DIR, "init", f"{table}_create_table.sql")) as f_in:
+        cursor.execute(jinja2.Template(f_in.read()).render({"mapping": mapping}))
+    cursor.execute(f"TRUNCATE TABLE {mapping[f'starrocks_{table}']};")
+
+
+def _seed(cursor, table, columns, rows):
+    if not rows:
+        return
+    placeholders = ", ".join(["%s"] * len(columns))
+    cursor.executemany(f"INSERT INTO {table} ({', '.join(columns)}) VALUES ({placeholders})", rows)
+
+
+def test_snv_variant_is_isolated_per_tenant(starrocks_session, mapping_conf, starrocks_tenant_database):
+    conf = {**mapping_conf, RadiantConfigKeys.RADIANT_TENANT_DB_TEMPLATE.env_key: starrocks_tenant_database}
+    base_mapping = get_radiant_mapping(conf)
+    mappings = {tenant: get_radiant_mapping(conf, tenant_code=tenant) for tenant in TENANT_CODES}
+
+    with starrocks_session.cursor() as cursor:
+        # The annotation source is shared: both tenants read the same staging catalog.
+        _reset_table(cursor, "snv_staging_variant", base_mapping)
+        _seed(
+            cursor,
+            base_mapping["starrocks_snv_staging_variant"],
+            ("locus_id", "chromosome", "start", "reference", "alternate"),
+            [(locus_id, "1", 1000 + locus_id, "A", "T") for locus_id in _STAGING_LOCI],
+        )
+
+        for tenant, mapping in mappings.items():
+            for table in ("germline_snv_variant_frequency", "somatic_snv_variant_frequency", "snv_variant"):
+                _reset_table(cursor, table, mapping)
+
+            _seed(
+                cursor,
+                mapping["starrocks_germline_snv_variant_frequency"],
+                ("locus_id", "pc_wgs", "pn_wgs"),
+                [(locus_id, pc, pn) for locus_id, (pc, pn) in _GERMLINE_FREQ[tenant].items()],
+            )
+            _seed(
+                cursor,
+                mapping["starrocks_somatic_snv_variant_frequency"],
+                ("locus_id", "pc_tn_wgs", "pn_tn_wgs"),
+                [(locus_id, pc, pn) for locus_id, (pc, pn) in _SOMATIC_FREQ[tenant].items()],
+            )
+
+        with open(os.path.join(_SQL_DIR, "snv_variant_insert.sql")) as f_in:
+            insert_template = f_in.read()
+
+        catalogs = {}
+        for tenant, mapping in mappings.items():
+            cursor.execute(jinja2.Template(insert_template).render({"mapping": mapping}))
+            cursor.execute(
+                "SELECT locus_id, germline_pc_wgs, germline_pn_wgs, somatic_pc_tn_wgs, somatic_pn_tn_wgs "
+                f"FROM {mapping['starrocks_snv_variant']} ORDER BY locus_id"
+            )
+            catalogs[tenant] = {row[0]: row[1:] for row in cursor.fetchall()}
+
+    # Each catalog holds exactly the loci that tenant carries — never the other tenant's, and never
+    # locus 4, which no tenant carries.
+    assert set(catalogs[_TENANT_A]) == {1, 2}
+    assert set(catalogs[_TENANT_B]) == {2, 3}
+
+    # pn_* is the tenant's own cohort. Pooled, locus 2 would have read 10 + 4 = 14 patients.
+    assert {pn for _, pn, _, _ in catalogs[_TENANT_A].values()} == {10}
+    assert {pn for _, pn, _, _ in catalogs[_TENANT_B].values()} == {4}
+
+    # pc_* on the shared locus counts only the tenant's own carriers (pooled it would have been 6).
+    assert catalogs[_TENANT_A][2][0] == 5
+    assert catalogs[_TENANT_B][2][0] == 1
+
+    # Tenant A's somatic cohort stays out of tenant B, which has no somatic experiments.
+    assert catalogs[_TENANT_A][2][2:] == (1, 7)
+    assert {row[3] for row in catalogs[_TENANT_B].values()} == {0}

--- a/tests/unit/dags/test_import_part.py
+++ b/tests/unit/dags/test_import_part.py
@@ -210,8 +210,6 @@ def test_dag_contains_all_tasks(dag_bag):
         "somatic_snv_occurrence.aggregate_somatic_snv_variant_freq",
         "somatic_snv_occurrence.sanity_check_delta_somatic_snv",
         "snv_variant.sanity_check_any_snv",
-        "snv_variant.render_snv_variant_sql",
-        "snv_variant.render_snv_variant_part_sql",
         "snv_variant.insert_snv_staging_variant",
         "snv_variant.insert_snv_variant",
         "snv_variant.compute_parts",
@@ -235,3 +233,12 @@ def test_dag_task_dependencies_are_valid(dag_bag):
     namespace_task = dag.get_task("get_iceberg_namespace")
     import_cnv_vcf_k8s_task = dag.get_task("import_cnv_vcf_k8s")
     assert namespace_task in import_cnv_vcf_k8s_task.get_flat_relatives(upstream=True)
+
+    # `compute_parts` is only referenced through `.partial(parameters=...)`; the edge exists because
+    # `parameters` is a template field, so `MappedOperator` applies the XComArg relationship.
+    assert "snv_variant.insert_snv_variant_part" in dag.get_task("snv_variant.compute_parts").downstream_task_ids
+
+    # Only the consequence filter is still pooled across every tenant.
+    all_tenants_downstream = dag.get_task("extract_all_tenants").downstream_task_ids
+    assert "snv_consequence.render_snv_consequence_filter_part_sql" in all_tenants_downstream
+    assert not any(task_id.startswith("snv_variant.") for task_id in all_tenants_downstream)

--- a/tests/unit/dags/test_init_starrocks_tables.py
+++ b/tests/unit/dags/test_init_starrocks_tables.py
@@ -11,8 +11,6 @@ _BASE_TABLES = [
     "staging_sequencing_experiment_delta",
     "snv_tmp_variant",
     "snv_staging_variant",
-    "snv_variant",
-    "snv_variant_partitioned",
     "variant_lookup",
     "staging_exomiser",
     "germline_snv_staging_variant_frequency",
@@ -27,8 +25,8 @@ def test_dag_is_importable(dag_bag):
 
 def test_dag_has_correct_number_of_tasks(dag_bag):
     dag = dag_bag.get_dag(_BASE_DAG_ID)
-    # 14 base radiant tables + 2 clinical tables + 20 open data tables + 2 UDFs
-    assert len(dag.tasks) == 38
+    # 12 base radiant tables + 2 clinical tables + 20 open data tables + 2 UDFs
+    assert len(dag.tasks) == 36
 
 
 def test_dag_has_all_base_tasks(dag_bag):

--- a/tests/unit/dags/test_pooled_sql_render.py
+++ b/tests/unit/dags/test_pooled_sql_render.py
@@ -1,4 +1,5 @@
 import jinja2
+import pytest
 
 from radiant.dags import DAGS_DIR
 from radiant.tasks.data.radiant_tables import get_radiant_mapping
@@ -24,16 +25,6 @@ def _assert_balanced_unions(sql: str, n_selects: int):
     assert sql.count("UNION ALL") == n_selects - 1
 
 
-def test_snv_variant_part_unions_occurrences_across_tenant_dbs():
-    sql = _render("snv_variant_part_insert_part.sql")
-    for tenant in ("chop", "chusj"):
-        assert f"{tenant}_tenant.germline__snv__occurrence" in sql
-        assert f"{tenant}_tenant.somatic__snv__occurrence" in sql
-    assert "UNION ALL" in sql
-    assert "radiant.snv__variant_partitioned" in sql  # base target
-    _assert_balanced_unions(sql, n_selects=4)  # (germline + somatic) x 2 tenants
-
-
 def test_consequence_filter_part_unions_occurrences_across_tenant_dbs():
     sql = _render("snv_consequence_filter_insert_part.sql")
     for tenant in ("chop", "chusj"):
@@ -44,23 +35,45 @@ def test_consequence_filter_part_unions_occurrences_across_tenant_dbs():
     _assert_balanced_unions(sql, n_selects=4)  # (germline + somatic) x 2 tenants
 
 
-def test_snv_variant_part_single_tenant_has_no_trailing_union():
-    sql = _render("snv_variant_part_insert_part.sql", tenants=["chop"])
-    assert "chop_tenant.somatic__snv__occurrence" in sql
-    _assert_balanced_unions(sql, n_selects=2)
-
-
 def test_consequence_filter_part_single_tenant_has_no_trailing_union():
     sql = _render("snv_consequence_filter_insert_part.sql", tenants=["chop"])
     assert "chop_tenant.somatic__snv__occurrence" in sql
     _assert_balanced_unions(sql, n_selects=2)
 
 
-def test_snv_variant_pools_freqs_across_tenant_dbs():
-    sql = _render("snv_variant_insert.sql")
+# The variant catalog is built once per tenant, from that tenant's own tables only. These renders
+# mirror the operator's Jinja context, which exposes `mapping` but neither `tenants` nor
+# `per_tenant_mapping`.
+_TENANT_SCOPED = ["snv_variant_insert.sql", "snv_variant_part_insert_part.sql"]
+
+
+def _render_for_tenant(filename: str, tenant_code: str = "chop") -> str:
+    text = (_RADIANT_SQL / filename).read_text()
+    return jinja2.Template(text).render(mapping=get_radiant_mapping(_CONF, tenant_code=tenant_code))
+
+
+@pytest.mark.parametrize("filename", _TENANT_SCOPED)
+def test_no_other_tenant_leaks_into_the_render(filename):
+    sql = _render_for_tenant(filename)
+    assert "chusj" not in sql
+    assert sql.count("_tenant.") == sql.count("chop_tenant.")
+
+
+def test_snv_variant_reads_only_the_tenant_frequencies():
+    sql = _render_for_tenant("snv_variant_insert.sql")
+    assert "INSERT OVERWRITE chop_tenant.snv__variant\n" in sql
     assert "chop_tenant.germline__snv__variant_frequency" in sql
-    assert "chusj_tenant.germline__snv__variant_frequency" in sql
     assert "chop_tenant.somatic__snv__variant_frequency" in sql
-    assert "chusj_tenant.somatic__snv__variant_frequency" in sql
-    assert "UNION ALL" in sql
-    assert "radiant.snv__variant" in sql  # base target + staging source
+    # A cross-tenant UNION ALL is what made every frequency a pooled number.
+    assert "UNION ALL" not in sql
+    # The catalog only holds the loci this tenant carries.
+    assert "LEFT SEMI JOIN tenant_loci" in sql
+    # The annotation source is open data, so it stays shared.
+    assert "radiant.snv__staging_variant" in sql
+
+
+def test_snv_variant_part_reads_only_the_tenant_occurrences():
+    sql = _render_for_tenant("snv_variant_part_insert_part.sql")
+    assert "OVERWRITE chop_tenant.snv__variant_partitioned" in sql
+    assert "chop_tenant.snv__variant v" in sql
+    _assert_balanced_unions(sql, n_selects=2)  # germline + somatic, current tenant only

--- a/tests/unit/data/test_radiant_tables.py
+++ b/tests/unit/data/test_radiant_tables.py
@@ -14,6 +14,7 @@ def test_no_tenant_routes_everything_to_shared_database():
     # Legacy single-database behaviour: per-tenant tables fall back to the shared database.
     assert mapping["starrocks_germline_snv_occurrence"] == "radiant.germline__snv__occurrence"
     assert mapping["starrocks_snv_variant"] == "radiant.snv__variant"
+    assert mapping["starrocks_snv_staging_variant"] == "radiant.snv__staging_variant"
 
 
 def test_tenant_routes_per_tenant_tables_to_tenant_database():
@@ -22,9 +23,10 @@ def test_tenant_routes_per_tenant_tables_to_tenant_database():
     assert mapping["starrocks_germline_snv_occurrence"] == "chop_tenant.germline__snv__occurrence"
     assert mapping["starrocks_somatic_snv_occurrence"] == "chop_tenant.somatic__snv__occurrence"
     assert mapping["starrocks_exomiser"] == "chop_tenant.exomiser"
-    # ... while base tables (including the global variant catalog) stay in RADIANT_DATABASE.
-    assert mapping["starrocks_snv_variant"] == "radiant.snv__variant"
-    assert mapping["starrocks_snv_variant_partitioned"] == "radiant.snv__variant_partitioned"
+    assert mapping["starrocks_snv_variant"] == "chop_tenant.snv__variant"
+    assert mapping["starrocks_snv_variant_partitioned"] == "chop_tenant.snv__variant_partitioned"
+    # ... while base tables stay in RADIANT_DATABASE.
+    assert mapping["starrocks_snv_staging_variant"] == "radiant.snv__staging_variant"
     assert mapping["starrocks_staging_sequencing_experiment"] == "radiant.staging_sequencing_experiment"
 
 

--- a/tests/unit/starrocks/test_operator.py
+++ b/tests/unit/starrocks/test_operator.py
@@ -96,8 +96,9 @@ def test_prepare_context_routes_per_tenant_mapping():
     op = RadiantStarRocksOperator(task_id="t", sql="SELECT 1", tenant_code="chop")
     mapping = op.prepare_template_context(_ctx(_SHARED_CONF))["mapping"]
     assert mapping["starrocks_germline_snv_occurrence"] == "chop_tenant.germline__snv__occurrence"
-    # Base tables (incl. the global variant catalog) stay in the shared database.
-    assert mapping["starrocks_snv_variant"] == "radiant.snv__variant"
+    assert mapping["starrocks_snv_variant"] == "chop_tenant.snv__variant"
+    # Base tables stay in the shared database.
+    assert mapping["starrocks_snv_staging_variant"] == "radiant.snv__staging_variant"
 
 
 def test_prepare_context_without_tenant_uses_base_db():
@@ -120,13 +121,13 @@ def test_mapped_render_injects_mapping_and_tenant_code():
     op = RadiantStarRocksOperator(
         task_id="t",
         sql="INSERT INTO {{ mapping.starrocks_germline_snv_occurrence }} "
-        "SELECT '{{ tenant_code }}' FROM {{ mapping.starrocks_snv_variant }}",
+        "SELECT '{{ tenant_code }}' FROM {{ mapping.starrocks_snv_staging_variant }}",
         tenant_code="chop",
     )
     op._do_render_template_fields(op, op.template_fields, _ctx(_SHARED_CONF), _native_env(), set())
     # Per-tenant table routes to <tenant>_db; base table stays in the shared database; tenant_code resolves.
     assert "chop_tenant.germline__snv__occurrence" in op.sql
-    assert "radiant.snv__variant" in op.sql
+    assert "radiant.snv__staging_variant" in op.sql
     assert "'chop'" in op.sql
 
 


### PR DESCRIPTION
## 📌 Context

`radiant.snv__variant` and `radiant.snv__variant_partitioned` are shared base-DB tables built by
pooling across every tenant. `snv_variant_insert.sql` unions all tenants' frequency tables and
computes **one global `pn_*` denominator**, so every `germline_pc_*/pn_*/pf_*` and
`somatic_pc_tn_*/pn_tn_*/pf_tn_*` a tenant's portal displays is a cross-tenant number.
`snv_variant_part_insert_part.sql` leaks locus membership the same way.

The inputs were already correct per tenant — `germline_snv_variant_frequency_insert.sql` computes
the right per-tenant figures; the pooling step threw that isolation away.

This PR routes both tables to `{tenant}_tenant` and fans the two inserts out per tenant. Each
catalog is restricted to the loci that tenant carries (semi-join on its own frequency tables), so
most tenants end up with a `snv__variant` smaller than today's shared table.

**ETL only.** The portal, the migration/backfill, and `radiant/data_qa/` are follow-ups.

## 📝 Changes

- `radiant_tables.py` — `starrocks_snv_variant` / `starrocks_snv_variant_partitioned` move to
  `STARROCKS_RADIANT_PER_TENANT_MAPPING`. No DDL changes needed: `prepare_tenants_tables` derives
  filenames from those keys, so per-tenant DDL becomes automatic.
- `snv_variant_insert.sql` — tenant loops removed. The frequency tables are already one row per
  locus with identical column names, so they are joined directly and the outer `SELECT` is
  untouched; `pn_*` become `ANY_VALUE` over the tenant's own table. New `tenant_loci` semi-join.
- `snv_variant_part_insert_part.sql` — semi-join narrowed to the current tenant's occurrences.
- `import_part.py` — both inserts become `.partial(...).expand(tenant_code=tenants)` over *this
  batch*, matching `aggregate_germline_snv_variant_freq`. The two `render_pooled_sql` call sites
  are gone; `all_tenants` now feeds `tg_consequences`, which keeps its pooling.
- `init_starrocks_tables.py` — the two tables leave `_BASE_TABLES`.

## ☑️ TO-DOs

- [ ] None blocking merge. Do **not** deploy without the migration below — the portal still reads
      `radiant.snv__variant*`, which this pipeline stops writing.

## 🧪 Tests

- **New integration test** `test_snv_variant_tenant_isolation.py` — two real tenant databases,
  overlapping (locus 2) and disjoint (1, 3) loci, plus a locus no tenant carries. Runs the real
  insert per tenant and asserts each `germline_pn_wgs` is that tenant's own cohort (10 and 4, not
  14), `pc_*` on the shared locus counts only its own carriers, and tenant B — which has no
  somatic experiments — gets `somatic_pn_tn_* = 0` rather than A's cohort.
  Mutation-checked: dropping the semi-join fails on `{1,2,3,4} == {1,2}`; `ANY_VALUE`→`SUM` fails
  on `{20} == {10}`.
- **Unit render guards** in `test_pooled_sql_render.py` — no `UNION ALL`, no foreign tenant string,
  per-tenant target/sources, staging still shared.
- `test_queries.py` now creates a second real database so the tenant-scoped files `EXPLAIN` across
  database boundaries; the previous stub collapsed every tenant onto one DB, which is the blind
  spot that let this ship.
- `make test-static` clean, 463 unit and 15 integration (`USE_DOCKER_FIXTURES=true`) pass.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-1754
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Migration is manual and must happen in one window.** A compat view is not viable — a
  `UNION ALL` over tenant catalogs emits N rows per locus and cannot reconstruct the global `pn_*`,
  because those denominators *are* the bug. Order: pause `{NAMESPACE}-import` → deploy → backfill
  each tenant from `radiant.snv__staging_variant` + the (already correct) per-tenant frequency
  tables → deploy the portal → unpause → drop the old base tables.
- `max_active_tis_per_dagrun=1` is not cosmetic: both tasks use `submit_task_options`, so without
  it N concurrent full-catalog `INSERT OVERWRITE`s hit StarRocks at once.
- `compute_parts >> insert_snv_variant_part` survives `.partial(parameters=XComArg)` because
  `parameters` is a template field; there is now an explicit assertion for that edge.
- **Open-data staleness regression.** Previously any tenant's run refreshed the shared catalog for
  everyone; now only tenants in that batch pick up new annotations. The locus restriction narrows
  the blast radius but does not remove it — the rebuild DAG below is the fix.
- Follow-ups: `snv__consequence_filter_partitioned` has the identical leak (deliberately out of
  scope; converting it later lets us delete `render_pooled_sql` / `extract_all_tenants` outright);
  a `radiant-rebuild-tenant-variant-catalog` DAG for backfill, staleness and DR; and a tenant-aware
  `radiant/data_qa/` run.
