### PR TITLE
fix: SJRA-1756 set container resources for Radiant k8s tasks

### DIFF
--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -48,6 +48,19 @@ def _cnv_container_resources() -> k8s.V1ResourceRequirements:
     return _container_resources("CNV", cpu="1", memory="500Mi", memory_limit="1Gi")
 
 
+def _metadata_container_resources() -> k8s.V1ResourceRequirements:
+    """Committing partitions never touches row data: the partition filters align with the
+    tables' partition specs, so the Iceberg delete drops whole files as metadata rather
+    than rewriting them, and `add_files` reads one parquet footer at a time.
+
+    Peak therefore scales with the number of files, not the size of the VCFs -- and the
+    fan-in is what makes it non-trivial: this task is not mapped, so a single container
+    commits every file produced by every mapped extraction task in the part. Half a core
+    is enough because the footer reads are sequential and network-bound.
+    """
+    return _container_resources("METADATA", cpu="500m", memory="1Gi", memory_limit="2Gi")
+
+
 class RadiantTaskK8SOperator:
     @staticmethod
     def _get_k8s_context(radiant_namespace: str, container_resources: k8s.V1ResourceRequirements | None = None):
@@ -115,7 +128,9 @@ class ImportGermlineSNVVCF(RadiantTaskK8SOperator):
                 name="commit-partitions",
                 do_xcom_push=True,
             )
-            | ImportGermlineSNVVCF._get_k8s_context(radiant_namespace),
+            | ImportGermlineSNVVCF._get_k8s_context(
+                radiant_namespace, container_resources=_metadata_container_resources()
+            ),
         )
         def k8s_commit_partitions(table_partitions: dict[str, list[dict]]):
             from radiant.tasks.vcf.snv.germline.process import commit_partitions

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -3,14 +3,61 @@ import os
 from airflow.decorators import task
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from airflow.providers.cncf.kubernetes.secret import Secret
+from kubernetes.client import models as k8s
+
+
+def _container_resources(profile: str, cpu: str, memory: str, memory_limit: str) -> k8s.V1ResourceRequirements:
+    """Build the pod resources for a Radiant task.
+
+    Sizing a task at all is what makes it visible to the scheduler: with no request,
+    Karpenter sizes the node as if the pod were empty and lands it on the smallest
+    instance in the pool (a 3Gi-allocatable c6a.large in QA), where a heavy task is
+    OOMKilled with no memory limit to attribute the kill to.
+
+    Only memory is limited. A memory limit makes an over-budget task fail fast and
+    attributably instead of taking down whatever else shares the node, while a CPU
+    limit would merely throttle work we want to run at full speed (cyvcf2 reads with
+    ``vcf_threads=4`` and pyiceberg writes its parquet files in parallel).
+
+    Each profile is overridable without a deploy via
+    ``RADIANT_TASK_OPERATOR_<PROFILE>_{CPU,MEMORY,MEMORY_LIMIT}``.
+    """
+    return k8s.V1ResourceRequirements(
+        requests={
+            "cpu": os.getenv(f"RADIANT_TASK_OPERATOR_{profile}_CPU", cpu),
+            "memory": os.getenv(f"RADIANT_TASK_OPERATOR_{profile}_MEMORY", memory),
+        },
+        limits={"memory": os.getenv(f"RADIANT_TASK_OPERATOR_{profile}_MEMORY_LIMIT", memory_limit)},
+    )
+
+
+def _snv_container_resources() -> k8s.V1ResourceRequirements:
+    """SNV extraction keeps three TableAccumulator buffers alive at once (occurrence,
+    variant, consequence), each growing to PARQUET_FILE_SIZE_MB before it flushes, plus
+    a transient copy of the buffer on every flush -- so a trio WGS VCF needs several GB.
+    """
+    return _container_resources("SNV", cpu="1", memory="4Gi", memory_limit="6Gi")
+
+
+def _cnv_container_resources() -> k8s.V1ResourceRequirements:
+    """CNV emits far fewer records per sample than SNV, so it needs a fraction of the
+    memory. The limit leaves headroom because the CNV occurrence buffer is a plain list
+    with no flush threshold, materialised in one `pa.Table.from_pylist` at the end
+    (`radiant/tasks/vcf/cnv/germline/process.py`).
+    """
+    return _container_resources("CNV", cpu="1", memory="500Mi", memory_limit="1Gi")
 
 
 class RadiantTaskK8SOperator:
     @staticmethod
-    def _get_k8s_context(radiant_namespace: str):
+    def _get_k8s_context(radiant_namespace: str, container_resources: k8s.V1ResourceRequirements | None = None):
         iceberg_env_vars = {
             key: value for key, value in os.environ.items() if key.startswith("PYICEBERG_CATALOG__DEFAULT__")
         }
+        # Sizing is passed in rather than set by the caller alongside `task_id` and
+        # friends: callers merge as `dict(...) | _get_k8s_context(...)`, so this context
+        # wins on key collisions and would silently override a per-task value.
+        resources = {"container_resources": container_resources} if container_resources else {}
         return dict(
             namespace=os.getenv("RADIANT_TASK_OPERATOR_KUBERNETES_NAMESPACE"),
             image=os.getenv("RADIANT_TASK_OPERATOR_IMAGE"),
@@ -29,6 +76,7 @@ class RadiantTaskK8SOperator:
                 "LD_LIBRARY_PATH": os.getenv("RADIANT_TASK_OPERATOR_LD_LIBRARY_PATH"),
             }
             | iceberg_env_vars,
+            **resources,
         )
 
 
@@ -44,7 +92,7 @@ class ImportGermlineSNVVCF(RadiantTaskK8SOperator):
                 name="import-vcf-for-task",
                 do_xcom_push=True,
             )
-            | ImportGermlineSNVVCF._get_k8s_context(radiant_namespace)
+            | ImportGermlineSNVVCF._get_k8s_context(radiant_namespace, container_resources=_snv_container_resources())
         )
         def k8s_create_parquet_files(
             radiant_task: dict,
@@ -87,7 +135,7 @@ class ImportPart(RadiantTaskK8SOperator):
                 name="import-cnv-vcf",
                 do_xcom_push=True,
             )
-            | ImportPart._get_k8s_context(radiant_namespace)
+            | ImportPart._get_k8s_context(radiant_namespace, container_resources=_cnv_container_resources())
         )
         def import_cnv_vcf(tasks: list[dict]) -> None:
             import os
@@ -108,7 +156,7 @@ class ImportPart(RadiantTaskK8SOperator):
                 name="import-somatic-snv-vcf",
                 do_xcom_push=True,
             )
-            | ImportPart._get_k8s_context(radiant_namespace)
+            | ImportPart._get_k8s_context(radiant_namespace, container_resources=_snv_container_resources())
         )
         def get_import_somatic_snv_vcf(tasks: list[dict]) -> None:
             import os

--- a/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
@@ -5,6 +5,7 @@ from radiant.dags.operators.k8s import (
     RadiantTaskK8SOperator,
     _cnv_container_resources,
     _container_resources,
+    _metadata_container_resources,
     _snv_container_resources,
 )
 
@@ -57,11 +58,14 @@ def test_get_k8s_context_with_container_resources():
     assert context["container_resources"] is resources
 
 
-def test_snv_and_cnv_are_sized_separately():
-    """SNV holds three accumulator buffers at once; CNV needs a fraction of that."""
+def test_profiles_are_sized_separately():
+    """SNV holds three accumulator buffers at once; CNV needs a fraction of that; and
+    committing partitions is metadata-only, so it scales with file count, not VCF size.
+    """
     with patch.dict(os.environ, {}, clear=True):
         snv = _snv_container_resources()
         cnv = _cnv_container_resources()
+        metadata = _metadata_container_resources()
 
     assert snv.requests == {"cpu": "1", "memory": "4Gi"}
     # A CPU limit would throttle cyvcf2 and the parallel parquet writes.
@@ -69,6 +73,10 @@ def test_snv_and_cnv_are_sized_separately():
 
     assert cnv.requests == {"cpu": "1", "memory": "500Mi"}
     assert cnv.limits == {"memory": "1Gi"}
+
+    # Footer reads are sequential and network-bound, so half a core is enough.
+    assert metadata.requests == {"cpu": "500m", "memory": "1Gi"}
+    assert metadata.limits == {"memory": "2Gi"}
 
 
 def test_container_resources_profile_is_env_overridable():

--- a/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
@@ -1,7 +1,12 @@
 import os
 from unittest.mock import patch
 
-from radiant.dags.operators.k8s import RadiantTaskK8SOperator
+from radiant.dags.operators.k8s import (
+    RadiantTaskK8SOperator,
+    _cnv_container_resources,
+    _container_resources,
+    _snv_container_resources,
+)
 
 
 def test_get_k8s_context():
@@ -38,3 +43,53 @@ def test_get_k8s_context():
     assert env_vars["LD_LIBRARY_PATH"] == "/lib"
     assert env_vars["PYICEBERG_CATALOG__DEFAULT__FOO"] == "foo-value"
     assert env_vars["PYICEBERG_CATALOG__DEFAULT__BAR"] == "bar-value"
+
+    # Unsized tasks must not gain an empty `container_resources`, which would override
+    # any value the caller passes on the left of the `dict | dict` merge.
+    assert "container_resources" not in context
+
+
+def test_get_k8s_context_with_container_resources():
+    with patch.dict(os.environ, {}, clear=True):
+        resources = _snv_container_resources()
+        context = RadiantTaskK8SOperator._get_k8s_context("my-iceberg-namespace", container_resources=resources)
+
+    assert context["container_resources"] is resources
+
+
+def test_snv_and_cnv_are_sized_separately():
+    """SNV holds three accumulator buffers at once; CNV needs a fraction of that."""
+    with patch.dict(os.environ, {}, clear=True):
+        snv = _snv_container_resources()
+        cnv = _cnv_container_resources()
+
+    assert snv.requests == {"cpu": "1", "memory": "4Gi"}
+    # A CPU limit would throttle cyvcf2 and the parallel parquet writes.
+    assert snv.limits == {"memory": "6Gi"}
+
+    assert cnv.requests == {"cpu": "1", "memory": "500Mi"}
+    assert cnv.limits == {"memory": "1Gi"}
+
+
+def test_container_resources_profile_is_env_overridable():
+    overrides = {
+        "RADIANT_TASK_OPERATOR_SNV_CPU": "4",
+        "RADIANT_TASK_OPERATOR_SNV_MEMORY": "16Gi",
+        "RADIANT_TASK_OPERATOR_SNV_MEMORY_LIMIT": "24Gi",
+    }
+    with patch.dict(os.environ, overrides, clear=True):
+        snv = _snv_container_resources()
+        # A different profile must not pick up the SNV overrides.
+        cnv = _cnv_container_resources()
+
+    assert snv.requests == {"cpu": "4", "memory": "16Gi"}
+    assert snv.limits == {"memory": "24Gi"}
+    assert cnv.requests == {"cpu": "1", "memory": "500Mi"}
+
+
+def test_container_resources_uses_defaults_when_env_absent():
+    with patch.dict(os.environ, {}, clear=True):
+        resources = _container_resources("WHATEVER", cpu="2", memory="8Gi", memory_limit="8Gi")
+
+    assert resources.requests == {"cpu": "2", "memory": "8Gi"}
+    assert resources.limits == {"memory": "8Gi"}


### PR DESCRIPTION
## 📌 Context

`create_parquet_files_k8s` was OOMKilled in QA (`exit_code: 137`, `reason: OOMKilled`) on a
germline trio WGS VCF. The `AirflowException: Pod ... returned a failure` is a symptom; the cause is
in the pod spec:

```
resources: {'limits': None, 'requests': None}
```

**No Radiant k8s task declared any resources.** A repo-wide search for `container_resources` /
`V1ResourceRequirements` returned zero matches, so every `@task.kubernetes` pod ran with nothing set.
Karpenter sizes nodes from pod *requests*, and QA's `qlin-nodepool` constrains only instance
*category* (`c`, `r`, `m`) — there is no size cap — so a pod that requests nothing looks empty and
lands on the cheapest instance in the family: a **`c6a.large`, 3.7Gi capacity / 2.99Gi allocatable**,
bin-packed alongside `radiant-portal-ui`, `overprovisioning`, `fluent-bit` and the fsx/s3 CSI
daemonsets. With no limit, the cgroup ceiling was the whole node, so the kill was node exhaustion
rather than an attributable container OOM — the node itself went `NotReady` shortly after.

That is not a marginal miss. SNV extraction keeps **three** `TableAccumulator` buffers alive at once
(occurrence, variant, consequence), each growing to `PARQUET_FILE_SIZE_MB` (500MB) before it
flushes, plus a transient copy of the buffer per flush — a ~1.5GB floor before spikes. A germline
trio triples the occurrence rows (one row per experiment per variant) and widens the proband row by
18 fields.

This is **not** a code regression: `table_accumulator.py`, `germline/process.py` and
`iceberg/utils.py` are unchanged since `v1.0.11`, and direct deps are pinned. Which instance a pod
landed on, and who it shared it with, was luck.

## 📝 Changes

- **`_container_resources(profile, cpu, memory, memory_limit)`** — builds `V1ResourceRequirements`,
  with each profile overridable at DAG-parse time via
  `RADIANT_TASK_OPERATOR_<PROFILE>_{CPU,MEMORY,MEMORY_LIMIT}` so sizing can be retuned without a
  deploy. **Only memory is limited**: a memory limit makes an over-budget task fail fast and
  attributably instead of taking down its neighbours, while a CPU limit would merely throttle work
  we want at full speed (cyvcf2 reads with `vcf_threads=4`, pyiceberg writes parquet in parallel).
- **Three profiles, because the workloads differ:**
  - `_snv_container_resources()` — `cpu: 1`, `memory: 4Gi`, limit `6Gi`.
  - `_cnv_container_resources()` — `cpu: 1`, `memory: 500Mi`, limit `1Gi`. CNV emits far fewer
    records per sample.
  - `_metadata_container_resources()` — `cpu: 500m`, `memory: 1Gi`, limit `2Gi`, for
    `commit_partitions_k8s`. It never touches row data: the partition filters align with the tables'
    partition specs (`{part, task_id}` for occurrence, `{task_id}` for variant/consequence), so the
    Iceberg delete drops whole files as metadata instead of rewriting them, and `add_files` reads one
    parquet footer at a time (`parquet_files_to_data_files` is a sequential generator). Peak scales
    with **file count, not VCF size**, and half a core is enough because footer reads are sequential
    and network-bound.
- **`_get_k8s_context(radiant_namespace, container_resources=None)`** — threads sizing through, and
  omits the key entirely when unset.
- **Applied to the four Radiant task pods:** `create_parquet_files_k8s` and `import_somatic_snv_vcf` get the
  SNV profile (somatic uses the identical three-accumulator design); `import_cnv_vcf_k8s` gets CNV;
  `commit_partitions_k8s` gets METADATA. `InitIcebergTables` is deliberately left unsized — one-time
  DDL.

## ☑️ TO-DOs

- [ ] **Confirm 4Gi empirically.** Peak RSS was never measured — the failing container had no limit,
      so the node was the ceiling and nothing recorded a high-water mark. 4Gi is reasoned
      (~3–3.5GB estimated) with 6Gi as the margin, not verified. If it proves tight, raise
      `RADIANT_TASK_OPERATOR_SNV_MEMORY` — no code change needed.

## 🧪 Tests

- **New/updated unit tests** in `tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py`:
  the three profiles are sized separately with the expected values; memory is limited but CPU is not; env
  overrides apply per profile and **do not leak across profiles**; defaults hold when env is absent;
  and an unsized task must **not** gain an empty `container_resources` key (see reviewer note below).
- `make test-static` clean; **467 unit tests pass**.
- **Verified live in QA.** A `DagBag` render confirms the values reach the tasks — including
  `create_parquet_files_k8s`, where they land in `partial_kwargs` rather than as an attribute because
  it is a `DecoratedMappedOperator`. On-cluster, all seven running `import-vcf` pods now report
  `requests={cpu: 1, memory: 4Gi} limits={memory: 6Gi}`, and Karpenter responded by moving them off
  `c6a.large` onto `m5a.xlarge` / `m6a.xlarge` / `c6a.xlarge` (6.5–14.3Gi allocatable, i.e. 2.3–4.8×
  the headroom of the node that OOMed), preferring `m`-family — more memory per vCPU, the right
  shape for this workload.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-1756
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Why sizing is passed *into* `_get_k8s_context` instead of set beside `task_id`.** Callers merge
  as `dict(...) | _get_k8s_context(...)`, so the context is on the **right** and wins on key
  collisions. A `container_resources` placed in the per-task dict on the left would be silently
  discarded. Hence the `if container_resources` guard, and the test asserting the key is absent when
  unset — an unconditional `container_resources: None` would clobber any future per-task override.
- **QoS is `Burstable`, not `Guaranteed`**, since limit (6Gi) ≠ request (4Gi). Deliberate: it buys
  headroom for the flush spike, at the cost of these pods being evicted ahead of `Guaranteed` ones
  under node pressure. Setting `RADIANT_TASK_OPERATOR_SNV_MEMORY_LIMIT=4Gi` flips that choice with
  no code change.
- **CNV's limit is 1Gi, not 500Mi.** Its occurrence buffer is a plain `list` with *no* flush
  threshold, materialised in one `pa.Table.from_pylist` at the end
  (`radiant/tasks/vcf/cnv/germline/process.py`), which transiently holds both the list and the Arrow
  table. A hard 500Mi cap would likely OOM on that last step; the 500Mi *request* is still what gets
  reserved.
- **Why `commit_partitions_k8s` is sized at all**, given it is metadata-only: it is **not** mapped,
  so a single container commits every file produced by every mapped extraction task in the part (up
  to 100 experiments for WGS, 1000 for WXS), which is a few thousand `DataFile` records held until
  commit. Left unsized it stays invisible to Karpenter and can land on a 3Gi node or be evicted — and
  it is the one task in the DAG whose failure discards the entire run's work, since nothing is
  committed until it succeeds.
- **This multiplies at the pool level.** The `import_vcf` pool allows many concurrent pods (7 were
  running during verification). At 16 slots that is up to 64Gi of simultaneous reservation, so
  expect more Karpenter scale-out and higher cost. Worth revisiting the pool size separately.
- **Out of scope, flagged for follow-up:** the ECS path still takes sizing from the Fargate task
  definition outside this repo, so `IS_AWS=true` is unaffected. Separately, QA is also hitting
  `OSError ... CreateMultipartUpload ... curlCode: 28` on S3 writes — same undersized-node root cause
  (2 vCPU, sub-1Gbps baseline), but it exposes a real defect: the `max_retries = 20` loop at
  `radiant/tasks/iceberg/utils.py:73` catches only `CommitFailedException`, so the `OSError` from
  `write_files` is fatal and one transient timeout discards an entire parse.
