### PR TITLE
feat: SJRA-1751 make the parquet buffer flush threshold configurable

### DIFF
--- a/radiant/dags/operators/ecs.py
+++ b/radiant/dags/operators/ecs.py
@@ -5,6 +5,16 @@ from airflow.providers.amazon.aws.operators import ecs
 
 from radiant.dags import ECSEnv
 
+# Propagated to the SNV extraction tasks so a memory-constrained environment can shrink the
+# TableAccumulator flush threshold, which is what sets an extraction task's memory floor. An
+# empty value means "use the default" (see `resolve_parquet_file_size_mb`); the literal default
+# is deliberately not repeated here, since importing it would pull pyarrow/pyiceberg into the
+# Airflow interpreter, which does not have them.
+_PARQUET_FILE_SIZE_ENV = {
+    "name": "RADIANT_PARQUET_FILE_SIZE_MB",
+    "value": os.getenv("RADIANT_PARQUET_FILE_SIZE_MB", ""),
+}
+
 
 class RadiantTaskECSOperator:
     @staticmethod
@@ -51,6 +61,7 @@ class ImportSNVVCF(RadiantTaskECSOperator):
                                 {"name": "RADIANT_ICEBERG_NAMESPACE", "value": radiant_namespace},
                                 {"name": "PYICEBERG_CATALOG__DEFAULT__TYPE", "value": "glue"},
                                 {"name": "STARROCKS_BROKER_USE_INSTANCE_PROFILE", "value": "true"},
+                                _PARQUET_FILE_SIZE_ENV,
                             ],
                         }
                     ]
@@ -84,6 +95,7 @@ class ImportSNVVCF(RadiantTaskECSOperator):
                                 {"name": "RADIANT_ICEBERG_NAMESPACE", "value": radiant_namespace},
                                 {"name": "PYICEBERG_CATALOG__DEFAULT__TYPE", "value": "glue"},
                                 {"name": "STARROCKS_BROKER_USE_INSTANCE_PROFILE", "value": "true"},
+                                _PARQUET_FILE_SIZE_ENV,
                             ],
                         }
                     ]

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -35,6 +35,9 @@ def _snv_container_resources() -> k8s.V1ResourceRequirements:
     """SNV extraction keeps three TableAccumulator buffers alive at once (occurrence,
     variant, consequence), each growing to PARQUET_FILE_SIZE_MB before it flushes, plus
     a transient copy of the buffer on every flush -- so a trio WGS VCF needs several GB.
+
+    That floor holds however small the VCF is, so a constrained environment can lower it
+    with ``RADIANT_PARQUET_FILE_SIZE_MB`` instead of raising the memory here.
     """
     return _container_resources("SNV", cpu="1", memory="4Gi", memory_limit="6Gi")
 
@@ -88,6 +91,7 @@ class RadiantTaskK8SOperator:
                 "RADIANT_ICEBERG_NAMESPACE": radiant_namespace,
                 "PYTHONPATH": os.getenv("RADIANT_TASK_OPERATOR_PYTHONPATH"),
                 "LD_LIBRARY_PATH": os.getenv("RADIANT_TASK_OPERATOR_LD_LIBRARY_PATH"),
+                "RADIANT_PARQUET_FILE_SIZE_MB": os.getenv("RADIANT_PARQUET_FILE_SIZE_MB"),
             }
             | iceberg_env_vars,
             **resources,

--- a/radiant/tasks/iceberg/table_accumulator.py
+++ b/radiant/tasks/iceberg/table_accumulator.py
@@ -1,5 +1,6 @@
 import itertools
 import logging
+import os
 import uuid
 
 import pyarrow as pa
@@ -16,6 +17,26 @@ PARQUET_FILE_SIZE_MB = 500  # Keep this value slightly lower than size of
 # TableProperties.WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT,
 # otherwise there is a risk to write small parquet files.
 MAX_BUFFERED_ROWS = 10000
+
+
+def resolve_parquet_file_size_mb() -> int:
+    """Resolve the buffer flush threshold, overridable via ``RADIANT_PARQUET_FILE_SIZE_MB``.
+
+    The threshold sets the memory floor for an extraction task, independently of how small the
+    VCF is: a buffer flushes only once it reaches this size, ``merge_table`` briefly holds both
+    the old and the concatenated copy, and three buffers are live at once (occurrence, variant,
+    consequence). At the 500MB default that is several GB, which is more than a local
+    single-node cluster can give each of several mapped writers.
+
+    Lower it *only* for local/dev runs. The default is deliberately just under Iceberg's
+    ``WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT`` (see above), so reducing it in a real deployment
+    trades memory for a lot of small parquet files.
+
+    An empty value counts as unset: the KubernetesPodOperator propagates env vars it was given
+    as ``None``, and the container then sees an empty string rather than nothing at all.
+    """
+    raw = os.getenv("RADIANT_PARQUET_FILE_SIZE_MB")
+    return int(raw) if raw else PARQUET_FILE_SIZE_MB
 
 
 class TableAccumulator:
@@ -40,7 +61,7 @@ class TableAccumulator:
         table: Table,
         partition_filter: dict = None,
         max_buffered_rows: int = MAX_BUFFERED_ROWS,
-        parquet_file_size_mb: int = PARQUET_FILE_SIZE_MB,
+        parquet_file_size_mb: int | None = None,
     ):
         """
         Initialize the TableAccumulator.
@@ -49,7 +70,10 @@ class TableAccumulator:
             table (Table): The target Iceberg table instance.
             partition_filter (dict, optional): Partition key-value pairs to overwrite.
             max_buffered_rows (int): Maximum number of rows to buffer before merging.
-            parquet_file_size_mb (int): Parquet file size threshold in MB for writing.
+            parquet_file_size_mb (int, optional): Parquet file size threshold in MB for writing.
+                Defaults to :func:`resolve_parquet_file_size_mb`, i.e. ``RADIANT_PARQUET_FILE_SIZE_MB``
+                if set, otherwise ``PARQUET_FILE_SIZE_MB``. Resolved here rather than as a default
+                argument so the env var is read per instance instead of once at import.
         """
         self.table = table
         self.schema = self.remove_field_ids(table.schema().as_arrow())
@@ -58,7 +82,9 @@ class TableAccumulator:
         self.rows = []
         self.accumulated_pa_table = None
         self.max_buffered_rows = max_buffered_rows
-        self.parquet_file_size_mb = parquet_file_size_mb
+        self.parquet_file_size_mb = (
+            parquet_file_size_mb if parquet_file_size_mb is not None else resolve_parquet_file_size_mb()
+        )
 
     @staticmethod
     def remove_field_ids(schema: pa.Schema) -> pa.Schema:

--- a/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_radiant_task_k8s_operator.py
@@ -101,3 +101,19 @@ def test_container_resources_uses_defaults_when_env_absent():
 
     assert resources.requests == {"cpu": "2", "memory": "8Gi"}
     assert resources.limits == {"memory": "8Gi"}
+
+
+def test_parquet_file_size_override_reaches_the_pod():
+    """The override only helps if it is propagated; it is read inside the pod, not here."""
+    with patch.dict(os.environ, {"RADIANT_PARQUET_FILE_SIZE_MB": "64"}, clear=True):
+        context = RadiantTaskK8SOperator._get_k8s_context("my-iceberg-namespace")
+
+    assert context["env_vars"]["RADIANT_PARQUET_FILE_SIZE_MB"] == "64"
+
+
+def test_parquet_file_size_is_absent_when_not_overridden():
+    """Unset reaches the container as an empty string, which resolves back to the default."""
+    with patch.dict(os.environ, {}, clear=True):
+        context = RadiantTaskK8SOperator._get_k8s_context("my-iceberg-namespace")
+
+    assert context["env_vars"]["RADIANT_PARQUET_FILE_SIZE_MB"] is None

--- a/tests/unit/iceberg/test_table_accumulator.py
+++ b/tests/unit/iceberg/test_table_accumulator.py
@@ -1,0 +1,55 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from radiant.tasks.iceberg.table_accumulator import (
+    PARQUET_FILE_SIZE_MB,
+    TableAccumulator,
+    resolve_parquet_file_size_mb,
+)
+
+
+@pytest.fixture
+def iceberg_table():
+    """A table whose Arrow schema conversion is stubbed; only the threshold matters here."""
+    table = MagicMock()
+    with patch.object(TableAccumulator, "remove_field_ids", return_value=MagicMock()):
+        yield table
+
+
+def test_default_is_the_module_constant(monkeypatch):
+    monkeypatch.delenv("RADIANT_PARQUET_FILE_SIZE_MB", raising=False)
+    assert resolve_parquet_file_size_mb() == PARQUET_FILE_SIZE_MB == 500
+
+
+def test_env_var_overrides_the_default(monkeypatch):
+    monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", "64")
+    assert resolve_parquet_file_size_mb() == 64
+
+
+def test_empty_env_var_falls_back_to_the_default(monkeypatch):
+    """KubernetesPodOperator turns an env var it was given as None into an empty string.
+
+    Without this, an unset override would reach the container as "" and raise ValueError.
+    """
+    monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", "")
+    assert resolve_parquet_file_size_mb() == PARQUET_FILE_SIZE_MB
+
+
+def test_accumulator_picks_up_the_env_var(monkeypatch, iceberg_table):
+    monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", "64")
+
+    # Resolved per instance, not bound once as a default argument at import time.
+    assert TableAccumulator(iceberg_table).parquet_file_size_mb == 64
+
+
+def test_explicit_argument_wins_over_the_env_var(monkeypatch, iceberg_table):
+    monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", "64")
+
+    assert TableAccumulator(iceberg_table, parquet_file_size_mb=128).parquet_file_size_mb == 128
+
+
+def test_accumulator_defaults_without_the_env_var(monkeypatch, iceberg_table):
+    monkeypatch.delenv("RADIANT_PARQUET_FILE_SIZE_MB", raising=False)
+
+    assert TableAccumulator(iceberg_table).parquet_file_size_mb == PARQUET_FILE_SIZE_MB


### PR DESCRIPTION
## 📌 Context

`PARQUET_FILE_SIZE_MB = 500` was hardcoded, and it — not the input size — sets an extraction task's memory floor. A buffer flushes only at 500MB, `merge_table`'s `pa.concat_tables` briefly holds both the old and concatenated copy (~1GiB for a *single* buffer), and three buffers are live at once. So every writer needed 2–2.5GiB even for a 21M test VCF, which a single-node dev cluster can't give to several mapped writers at once — a 1Gi limit OOMKilled (exit 137).

## 📝 Changes

- `resolve_parquet_file_size_mb()` reads `RADIANT_PARQUET_FILE_SIZE_MB`, resolved per `TableAccumulator` instance rather than bound as a default argument at import.
- Propagated to task pods: `_get_k8s_context` `env_vars` (K8s) and `_PARQUET_FILE_SIZE_ENV` on the two SNV writers (ECS). Not on `commit_partitions` or CNV — neither uses `TableAccumulator`.
- Default stays **500**.

## ☑️ TO-DOs

- [ ] None.

## 🧪 Tests

- `make test-unit`: **486 passed**. `ruff check radiant/`: clean.
- 8 new tests: default, override, empty-value fallback, per-instance resolution, explicit-arg precedence, and that the var actually reaches the pod spec.
- Verified end to end on local minikube: with `RADIANT_PARQUET_FILE_SIZE_MB=64` the SNV writers run under a 1Gi limit / 512Mi request, down from 4Gi.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- SJRA-1751
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **An empty value counts as unset.** `KubernetesPodOperator` turns an env var passed as `None` into an empty string in the container, so `int(os.getenv(...))` would raise `ValueError` on every pod when the override is absent. Hence `int(raw) if raw else PARQUET_FILE_SIZE_MB`, pinned by a test.
- **`ecs.py` doesn't import the default** — it uses `os.getenv(..., "")`. Importing the constant would pull pyarrow/pyiceberg into the Airflow interpreter, which doesn't have them.
- **Don't lower the default in a real deployment**: 500 is deliberately just under Iceberg's `WRITE_TARGET_FILE_SIZE_BYTES_DEFAULT`, so reducing it trades memory for many small parquet files.


