### PR TITLE
fix: SJRA-1751 test and fix on tumor only snv variants

### DIFF
--- a/radiant/dags/sql/clinical/seeds.sql
+++ b/radiant/dags/sql/clinical/seeds.sql
@@ -70,7 +70,8 @@ INSERT INTO {{ params.clinical_patient }} (id, submitter_patient_id, submitter_p
     (58, 'MRN-283830', 'mrn', 'UCSF', 'female', '1994-06-26', 'alive', 'Simon', 'Côté', 'CÔT9406263607', 'radiant'),
     (59, 'MRN-283831', 'mrn', 'UCSF', 'male', '1984-02-09', 'alive', 'Camille', 'Bélanger', 'BÉL8402099104', 'radiant'),
     (60, 'MRN-283832', 'mrn', 'UCSF', 'female', '1979-07-01', 'alive', 'Gabriel', 'Fortin', 'FOR7907010876', 'radiant'),
-    (61, 'MRN-283833', 'mrn', 'UCSF', 'female', '1971-07-25', 'alive', 'Camille', 'Bergeron', 'BER7107256143', 'radiant');
+    (61, 'MRN-283833', 'mrn', 'UCSF', 'female', '1971-07-25', 'alive', 'Camille', 'Bergeron', 'BER7107256143', 'radiant'),
+    (62, 'MRN-283834', 'mrn', 'CQGC', 'male', '1968-11-14', 'alive', 'Olivier', 'Tremblay', 'TRE6811149217', 'radiant');
 
 -- Cases
 TRUNCATE {{ params.clinical_project }} CASCADE;
@@ -108,7 +109,8 @@ INSERT INTO {{ params.clinical_case }} (id, proband_id, project_id, analysis_cat
     (19, 55, 2, 2, 'revoke', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'germline', 'postnatal', 'MONDO', 'unsolved', 'Ethan Reid', 'CHUSJ', '2:19', 'radiant'),
     (20, 58, 2, 2, 'revoke', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'germline', 'postnatal', 'MONDO', 'unsolved', 'Leonie Laplante', 'CHUSJ', '2:20', 'radiant'),
     (21, 60, 2, 2, 'incomplete', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'germline', 'postnatal', 'MONDO', 'unsolved', 'Henri Chabot', 'CHUSJ', '2:21', 'radiant'),
-    (22, 3, 1, 1, 'in_progress', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'somatic', 'postnatal', 'MONDO', 'unsolved', 'Felix Laflamme', 'CHUSJ', '1:22', 'radiant');
+    (22, 3, 1, 1, 'in_progress', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'somatic', 'postnatal', 'MONDO', 'unsolved', 'Felix Laflamme', 'CHUSJ', '1:22', 'radiant'),
+    (23, 62, 1, 1, 'in_progress', 'MONDO:0700092', 'CQGC', 'Administrative comment', '2021-09-12 13:08:00', '2021-09-12 13:08:00', 'routine', 'somatic', 'postnatal', 'MONDO', 'unsolved', 'Felix Laflamme', 'CHUSJ', '1:23', 'radiant');
 
 TRUNCATE {{ params.clinical_family }} CASCADE;
 INSERT INTO {{ params.clinical_family }} (id, case_id, family_member_id, relationship_to_proband_code, affected_status_code, tenant_code) VALUES
@@ -769,7 +771,9 @@ INSERT INTO {{ params.clinical_sample }} (id, type_code, parent_sample_id, tissu
     (121, 'blood', NULL, NULL, 'normal', 'B-990.2', 61, 'CQGC', 'radiant'),
     (122, 'blood', NULL, NULL, 'normal', 'B-990.3', 59, 'CQGC', 'radiant'),
     (123, 'blood', NULL, NULL, 'tumoral', 'B-990.3', 3, 'CQGC', 'radiant'),
-    (124, 'blood', NULL, NULL, 'normal', 'B-990.3', 3, 'CQGC', 'radiant');
+    (124, 'blood', NULL, NULL, 'normal', 'B-990.3', 3, 'CQGC', 'radiant'),
+    -- Tumor sample with no matched normal: the case below is analysed tumor-only.
+    (125, 'blood', NULL, NULL, 'tumoral', 'B-990.4', 62, 'CQGC', 'radiant');
 
 -- Sequencing Experiment
 TRUNCATE {{ params.clinical_sequencing_experiment }} CASCADE;
@@ -836,7 +840,8 @@ INSERT INTO {{ params.clinical_sequencing_experiment }} (id, sample_id, status_c
     (60, 60, 'incomplete', 'S14858', 'CQGC', 1676, 'A00516_0228', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant'),
     (61, 61, 'incomplete', 'S14859', 'CQGC', 1677, 'A00516_0229', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant'),
     (62, 123, 'incomplete', 'TCR002361_SRX1091647-T', 'CQGC', 1677, 'TCR002361_SRX1091647-Tumor', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant'),
-    (63, 124, 'incomplete', 'TCR002361_SRX1091646-N', 'CQGC', 1677, 'TCR002361_SRX1091646-Normal', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant');
+    (63, 124, 'incomplete', 'TCR002361_SRX1091646-N', 'CQGC', 1677, 'TCR002361_SRX1091646-Normal', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant'),
+    (64, 125, 'incomplete', 'TCRBOA6_SRX1166091-T', 'CQGC', 1677, 'TCRBOA6_SRX1166091-Tumor', '2021-08-31', NULL, '2021-10-12 13:08:00', '2021-10-12 13:08:00', 'wgs', 'short_read', 'illumina', 'radiant');
 
 
 TRUNCATE {{ params.clinical_case_has_sequencing_experiment }} CASCADE;
@@ -903,7 +908,8 @@ INSERT INTO {{ params.clinical_case_has_sequencing_experiment }} (case_id, seque
     (21, 60),
     (21, 61),
     (22, 62),
-    (22, 63);
+    (22, 63),
+    (23, 64);
 
 TRUNCATE {{ params.clinical_task }} CASCADE;
 INSERT INTO {{ params.clinical_task }} (id, task_type_code, pipeline_name, pipeline_version, genome_build, created_on, tenant_code) VALUES
@@ -973,7 +979,13 @@ INSERT INTO {{ params.clinical_task }} (id, task_type_code, pipeline_name, pipel
     (64, 'exomiser', NULL, '14.0.0', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
     (65, 'radiant_germline_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
     (66, 'exomiser', NULL, '14.0.0', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
-    (67, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant');
+    (67, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
+    -- Tumor-only analysis of the SAME tumor sample as task 67, which is tumor-normal. A task is
+    -- tumor-only iff it has exactly one 'tumoral' aliquot and no 'normal' one, so the distinction
+    -- is per-task, not per-case: case 22 carries both.
+    (68, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
+    -- Tumor-only analysis of case 23, whose tumor sample has no matched normal at all.
+    (69, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant');
 
 TRUNCATE {{ params.clinical_task_context }} CASCADE;
 INSERT INTO {{ params.clinical_task_context }} (task_id, case_id, sequencing_experiment_id) VALUES
@@ -1048,7 +1060,10 @@ INSERT INTO {{ params.clinical_task_context }} (task_id, case_id, sequencing_exp
     (65, 8, 22),
     (66, 8, 22),
     (67, 22, 62),
-    (67, 22, 63)
+    (67, 22, 63),
+    -- Task 68 spans only the tumoral experiment 62 -> tumor-only.
+    (68, 22, 62),
+    (69, 23, 64)
 ;
 
 
@@ -1307,7 +1322,11 @@ INSERT INTO {{ params.clinical_document }} (id, name, data_category_code, data_t
     (255, 'FI0005566.S14029.vcf.gz', 'genomic', 'snv', 'vcf', 307243253, '{{ params.vcf_bucket_prefix }}/sarek/preprocessing/', '5d41402abc4b2a76b9719d911017c836', 'radiant'),
     (256, 'FI0005566.S14029.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 2422210, '{{ params.vcf_bucket_prefix }}/sarek/preprocessing/', '5d41402abc4b2a76b9719d911017c837', 'radiant'),
     (257, 'variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz', 'genomic', 'snv', 'vcf', 34095067, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz', '103f65eeff69dae290c90d2a4ad3fea2-3', 'radiant'),
-    (258, 'variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 933443, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz.tbi', '5d7f43f74fd1ea4af83b87e727799ec2', 'radiant');
+    (258, 'variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 933443, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T_vs_SRX1091646-N.snv.vep.vcf.gz.tbi', '5d7f43f74fd1ea4af83b87e727799ec2', 'radiant'),
+    (259, 'variants.SRX1091647-T.snv.vep.vcf.gz', 'genomic', 'snv', 'vcf', 21903112, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T.snv.vep.vcf.gz', '39056b126bc06b21446c9f6912bc259e', 'radiant'),
+    (260, 'variants.SRX1091647-T.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 612884, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T.snv.vep.vcf.gz.tbi', '97cfc0224aa7e916bfddd070c7522dc7', 'radiant'),
+    (261, 'variants.SRX1166091-T.snv.vep.vcf.gz', 'genomic', 'snv', 'vcf', 23417650, '{{ params.vcf_bucket_prefix }}/variants.SRX1166091-T.snv.vep.vcf.gz', 'adc19953d1b08acdf57f20be42dbcdf3', 'radiant'),
+    (262, 'variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 641327, '{{ params.vcf_bucket_prefix }}/variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'ce6da3c5c64ee1debb468acac4999080', 'radiant');
 
 TRUNCATE {{ params.clinical_task_has_document }} CASCADE;
 INSERT INTO {{ params.clinical_task_has_document }} (task_id, document_id, type) VALUES
@@ -1566,7 +1585,11 @@ INSERT INTO {{ params.clinical_task_has_document }} (task_id, document_id, type)
     (65, 236, 'output'),
     (66, 246, 'output'),
     (67, 257, 'output'),
-    (67, 258, 'output');
+    (67, 258, 'output'),
+    (68, 259, 'output'),
+    (68, 260, 'output'),
+    (69, 261, 'output'),
+    (69, 262, 'output');
 
 -- Reset sequences
 ALTER TABLE {{ params.clinical_analysis_catalog }} ALTER COLUMN id RESTART WITH 1000;

--- a/radiant/dags/sql/radiant/snv_variant_insert.sql
+++ b/radiant/dags/sql/radiant/snv_variant_insert.sql
@@ -14,9 +14,11 @@ somatic_pn AS (
     FROM {{ mapping.starrocks_somatic_snv_variant_frequency }}
 ),
 tenant_loci AS (
-    SELECT locus_id FROM {{ mapping.starrocks_germline_snv_variant_frequency }}
-    UNION
-    SELECT locus_id FROM {{ mapping.starrocks_somatic_snv_variant_frequency }}
+    SELECT DISTINCT locus_id FROM (
+        SELECT locus_id FROM {{ mapping.starrocks_germline_snv_variant_frequency }}
+        UNION ALL
+        SELECT locus_id FROM {{ mapping.starrocks_somatic_snv_variant_frequency }}
+    ) u
 )
 SELECT
     v.locus_id,

--- a/radiant/tasks/iceberg/table_accumulator.py
+++ b/radiant/tasks/iceberg/table_accumulator.py
@@ -36,7 +36,9 @@ def resolve_parquet_file_size_mb() -> int:
     as ``None``, and the container then sees an empty string rather than nothing at all.
     """
     raw = os.getenv("RADIANT_PARQUET_FILE_SIZE_MB")
-    return int(raw) if raw else PARQUET_FILE_SIZE_MB
+    if not raw:
+        return PARQUET_FILE_SIZE_MB
+    return int(raw.strip().strip("\"'"))
 
 
 class TableAccumulator:

--- a/tests/integration/dags/sql/test_sequencing_experiment_select_delta.py
+++ b/tests/integration/dags/sql/test_sequencing_experiment_select_delta.py
@@ -91,7 +91,55 @@ def test_sequencing_experiment_empty(
 
     assert results is not None, "Results should not be None"
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 12
+    assert len(result_df) == 14
+
+
+def test_sequencing_experiment_delta_carries_tumor_only_tasks(
+    postgres_clinical_seeds, starrocks_session, sequencing_experiment_tables, sequencing_delta_columns
+):
+    """Somatic tasks with a single tumoral aliquot reach the delta, in both shapes that exist.
+
+    Nothing upstream flags which analysis is which — a task is tumor-only iff it has exactly one
+    'tumoral' aliquot and no 'normal' one. So the view must emit one row per (case, seq, task) and
+    leave the aliquot count to say it. The seeds cover all three shapes:
+
+    - task 67: tumor-normal, case 22, experiments 62 (tumoral) + 63 (normal)
+    - task 68: tumor-only on the SAME tumor sample as 67 (experiment 62) — so case 22 is
+      simultaneously both, which a per-case discriminator could not express
+    - task 69: tumor-only on its own case 23 / experiment 64, a tumor sample with no normal at all
+
+    Tasks 68 and 69 belong to different patients, so the tumor-only cohort has two members and its
+    frequency denominators are not degenerate.
+    """
+    with starrocks_session.cursor() as cursor:
+        cursor.execute("TRUNCATE TABLE staging_sequencing_experiment;")
+        cursor.execute("SELECT * FROM staging_sequencing_experiment_delta;")
+        results = cursor.fetchall()
+
+    somatic = pd.DataFrame(results, columns=sequencing_delta_columns).query("analysis_type == 'somatic'")
+
+    assert {int(task_id): sorted(rows["histology_type"]) for task_id, rows in somatic.groupby("task_id")} == {
+        67: ["normal", "tumoral"],
+        68: ["tumoral"],
+        69: ["tumoral"],
+    }
+
+    # Each tumor-only task points at its own single-sample VCF, never the paired one.
+    tumor_only = {
+        int(row["task_id"]): (int(row["seq_id"]), row["aliquot"], row["patient_id"], row["vcf_filepath"])
+        for _, row in somatic.query("task_id in [68, 69]").iterrows()
+    }
+    assert tumor_only[68][:2] == (62, "TCR002361_SRX1091647-T")
+    assert tumor_only[68][3].endswith("variants.SRX1091647-T.snv.vep.vcf.gz")
+    assert tumor_only[69][:2] == (64, "TCRBOA6_SRX1166091-T")
+    assert tumor_only[69][3].endswith("variants.SRX1166091-T.snv.vep.vcf.gz")
+
+    # Task 68 shares experiment 62 with the tumor-normal task; task 69 is a distinct patient.
+    assert 62 in set(somatic.query("task_id == 67")["seq_id"])
+    assert tumor_only[68][2] != tumor_only[69][2]
+
+    # Every somatic experiment here is wgs, so the tumor-only cohort lands in the wgs buckets.
+    assert set(somatic["experimental_strategy"]) == {"wgs"}
 
 
 def test_sequencing_experiment_no_delta(
@@ -206,7 +254,7 @@ def test_sequencing_experiment_existing_wgs_task_partition(
         results = cursor.fetchall()
 
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 11
+    assert len(result_df) == 13
 
 
 def test_sequencing_experiment_with_recently_updated_task(
@@ -250,7 +298,7 @@ def test_sequencing_experiment_with_recently_updated_task(
         results = cursor.fetchall()
 
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 11
+    assert len(result_df) == 13
 
     with (
         psycopg2.connect(
@@ -276,4 +324,4 @@ def test_sequencing_experiment_with_recently_updated_task(
 
     # Should capture the updated experiment
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 12
+    assert len(result_df) == 14

--- a/tests/unit/dags/test_pooled_sql_render.py
+++ b/tests/unit/dags/test_pooled_sql_render.py
@@ -64,8 +64,10 @@ def test_snv_variant_reads_only_the_tenant_frequencies():
     assert "INSERT OVERWRITE chop_tenant.snv__variant\n" in sql
     assert "chop_tenant.germline__snv__variant_frequency" in sql
     assert "chop_tenant.somatic__snv__variant_frequency" in sql
-    # A cross-tenant UNION ALL is what made every frequency a pooled number.
-    assert "UNION ALL" not in sql
+    # A cross-tenant union is what made every frequency a pooled number. The one union left combines
+    # this tenant's own germline and somatic loci, so it must stay at exactly two selects — and
+    # `UNION ALL` rather than `UNION`, which StarRocks mis-plans on the right of a LEFT SEMI JOIN.
+    _assert_balanced_unions(sql, n_selects=2)
     # The catalog only holds the loci this tenant carries.
     assert "LEFT SEMI JOIN tenant_loci" in sql
     # The annotation source is open data, so it stays shared.

--- a/tests/unit/iceberg/test_table_accumulator.py
+++ b/tests/unit/iceberg/test_table_accumulator.py
@@ -36,6 +36,16 @@ def test_empty_env_var_falls_back_to_the_default(monkeypatch):
     assert resolve_parquet_file_size_mb() == PARQUET_FILE_SIZE_MB
 
 
+@pytest.mark.parametrize("raw", ["'64'", '"64"', " '64' "])
+def test_quoted_env_var_is_accepted(monkeypatch, raw):
+    """The value is deployed quoted so that a DAG rendering templates natively evals it back to a
+    string; Kubernetes rejects the pod outright when `EnvVar.value` is a number. DAGs that render
+    non-natively hand the quotes straight to the container, so both forms have to resolve here.
+    """
+    monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", raw)
+    assert resolve_parquet_file_size_mb() == 64
+
+
 def test_accumulator_picks_up_the_env_var(monkeypatch, iceberg_table):
     monkeypatch.setenv("RADIANT_PARQUET_FILE_SIZE_MB", "64")
 


### PR DESCRIPTION
## 📌 Context

Validating the tumor-only frequencies from #212 against real sandbox data turned up two defects, neither tumor-only specific.

**`snv_variant_insert.sql` was silently dropping ~85% of the catalog.** `tenant_loci` used a deduplicating `UNION` on the right side of a `LEFT SEMI JOIN`, which StarRocks mis-plans — no error, just a wrong answer. On the sandbox the insert produced 86,109 rows instead of 345,020. Germline was hit hardest (~296k loci missing); tumor-only showed 870 carriers instead of 3,518. The `UNION` predates this ticket, so the catalog has been incomplete for a while.

**`RADIANT_PARQUET_FILE_SIZE_MB` broke every K8s pod task in `import_part`.** `env_vars` is a templated field and that DAG sets `render_template_as_native_obj=True`, so Jinja's native rendering runs `literal_eval` on the value: `"64"` becomes the int `64`, and Kubernetes rejects the whole pod with a 400 because `EnvVar.value` must be a string. Deploying the value quoted keeps it a string through native rendering; DAGs that render non-natively (`import_snv_vcf`) hand the quotes to the container verbatim, so they are stripped on read.

## 📝 Changes

- **`snv_variant_insert.sql`**: `tenant_loci` now uses `UNION ALL` wrapped in `SELECT DISTINCT`. Verified on the sandbox: 345,020 rows, all 8,175 somatic loci, all 3,518 tumor-only carriers.
- **`table_accumulator.py`**: `resolve_parquet_file_size_mb` strips surrounding quotes.
- **`seeds.sql`**: two tumor-only tasks — task 68 on case 22's *existing* tumor sample (so one sample carries both a tumor-normal and a tumor-only analysis) and case 23 / task 69 as a standalone tumor-only case on a second patient. The tumor-only cohort now has two members, so `pf_to_*` can take an intermediate value.

## ☑️ TO-DOs

- [ ] Re-run `insert_snv_variant` / `insert_snv_variant_part` in each environment after deploy — both are `INSERT OVERWRITE`, but the catalogs currently hold under-counted content and will not self-correct until the tasks run again.

## 🧪 Tests

- `ruff check radiant/`: clean. `make test-unit`: **489 passed**. `USE_DOCKER_FIXTURES=true make test-integration`: **20 passed**.
- **Verified against the source VCFs** with an independent cyvcf2 reimplementation of the filter chain (`len(ALT) <= 1`, supported chromosome, `FILTER=PASS`, `tumor_ad_alt > 2`, tumor carries an alt). Exact match on every count:

  | | VCF | pipeline |
  |---|---:|---:|
  | task 67 (tumor-normal) | 4,830 | 4,830 |
  | task 68 (tumor-only, same tumor sample) | 2,113 | 2,113 |
  | task 69 (tumor-only, second patient) | 2,026 | 2,026 |
  | case 22: 67 ∩ 68 | 173 | 173 |
  | two tumor-only patients: 68 ∩ 69 | 621 | 621 |

  The 173 shared loci were also matched by `locus` in `snv__variant`: all 173 present, all flagged in both cohorts with `pc_tn = pc_to = 1`. No `pf` exceeds 1 and `pc > pn` never occurs.
- `snv__variant_partitioned` vs `snv__variant` over all 345,020 rows: zero column shift, confirming the positional `v.*` copy stays aligned.
- New: tumor-only delta test asserting all three task shapes reach `staging_sequencing_experiment_delta`; parametrised quoted-value test for the parquet threshold.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- SJRA-1751
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **The semi-join fix is not tumor-only work.** Germline lost more loci than somatic did. Anyone reading `snv__variant` has been seeing an incomplete catalog.
- **The existing integration test would not have caught it** — `test_snv_variant_tenant_isolation.py` seeds three loci and StarRocks only picks the bad plan at volume. `test_pooled_sql_render.py` now pins the SQL *shape* instead (`_assert_balanced_unions(sql, n_selects=2)`), replacing an `assert "UNION ALL" not in sql` that was guarding against the cross-tenant pooling SJRA-1754 already removed.
- `snv_consequence_filter_insert_part.sql` and `snv_variant_part_insert_part.sql` already use `UNION ALL`; `snv_variant_insert.sql` was the only affected file.
- The quoting convention for `RADIANT_PARQUET_FILE_SIZE_MB` lives in the deployment config, so the next numeric env var added to `_get_k8s_context` will hit the same 400.
- The sandbox runs StarRocks **4.0.13**, while CLAUDE.md documents 3.4.2 — worth reconciling, since planner behaviour is exactly what differs between majors.
