### PR TITLE
fix: SJRA-1766 stop StarRocks trigger from blocking the triggerer event loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ The following are examples and should be adjusted to your environment:
 - `Login`: `root`
 - `Password`: (leave empty)
 
+#### Socket timeouts (recommended for deployed environments)
+
+Add socket timeouts to the connection's `Extra` field:
+
+```json
+{"connect_timeout": 10, "read_timeout": 60, "write_timeout": 60}
+```
+
+`StarRocksTaskCompleteTrigger` polls long-running StarRocks tasks from the triggerer. It already bounds each
+poll with `asyncio.wait_for`, so a dead socket can neither block the triggerer's event loop nor stall the
+poll loop. But the worker thread behind a timed-out poll stays blocked in `recv()` until the socket itself
+errors out, holding a slot in the default thread pool — only a driver-level `read_timeout` releases it. This
+matters when the FE's IP changes or a pod is rescheduled, leaving half-open connections behind.
+
+Verify the extras against the `apache-airflow-providers-mysql` version in your image (`6.5.2` for the
+K8s/MWAA builds) before relying on them: the hook forwards only whitelisted extras to the driver, so an
+unsupported key can break `get_conn()` outright. A `Test` on the connection in the Airflow UI is enough to
+confirm.
+
 
 ## Artifacts
 

--- a/radiant/tasks/starrocks/operator.py
+++ b/radiant/tasks/starrocks/operator.py
@@ -26,17 +26,29 @@ class SubmitTaskOptions:
     Data class to hold options for submitting a task.
 
     Attributes:
-        max_query_timeout (int): Maximum query timeout in milliseconds.
+        max_query_timeout (int): StarRocks `query_timeout`, in seconds.
         poll_interval (int): Interval in seconds to poll for task completion.
         enable_spill (bool): Flag to enable or disable spilling.
         spill_mode (str): Mode of spilling, e.g., 'auto'.
+        defer_timeout (int): Deadline in seconds for the whole deferral, enforced by the scheduler rather
+            than the triggerer, so a wedged triggerer fails the task instead of leaving it deferred forever.
+            Defaults to `max_query_timeout` plus `DEFER_TIMEOUT_MARGIN` — StarRocks aborts the query at
+            `query_timeout`, so the task cannot legitimately outlive that.
     """
+
+    DEFER_TIMEOUT_MARGIN = 600
 
     max_query_timeout: int = 10000
     poll_interval: int = 30
     enable_spill: bool = True
     spill_mode: str = "auto"
     extra_args: dict[str, Any] = None
+    defer_timeout: int | None = None
+
+    def get_defer_timeout(self) -> int:
+        if self.defer_timeout is not None:
+            return self.defer_timeout
+        return self.max_query_timeout + self.DEFER_TIMEOUT_MARGIN
 
 
 class RadiantStarRocksBaseOperator(BaseSQLOperator):
@@ -130,14 +142,16 @@ class RadiantStarRocksBaseOperator(BaseSQLOperator):
         )
         self.get_db_hook().run(sql=submit_sql, autocommit=True, parameters=parameters)
         if self.submit_task_options:
-            # Defer until StarRocks task completes
+            # Defer until StarRocks task completes. `timeout` is the scheduler-side backstop: without it a
+            # triggerer that dies or wedges leaves the task deferred indefinitely.
             self.defer(
                 trigger=StarRocksTaskCompleteTrigger(
                     conn_id=self.conn_id,
                     task_name=task_name,
-                    sleep_time=30,
+                    sleep_time=self.submit_task_options.poll_interval,
                 ),
                 method_name=method_name,
+                timeout=timedelta(seconds=self.submit_task_options.get_defer_timeout()),
             )
 
 

--- a/radiant/tasks/starrocks/trigger.py
+++ b/radiant/tasks/starrocks/trigger.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import math
 from typing import Any
 
 from airflow.hooks.base import BaseHook
@@ -7,16 +8,26 @@ from airflow.triggers.base import BaseTrigger, TriggerEvent
 
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_QUERY_TIMEOUT = 60
+
+# StarRocks creates the `task_runs` row asynchronously after `SUBMIT TASK` returns, so the first polls can
+# legitimately find nothing. Keep the grace window time-based rather than attempt-based, otherwise a short
+# `poll_interval` silently shrinks it.
+_NOT_FOUND_GRACE_SECONDS = 120
+
 
 class StarRocksTaskCompleteTrigger(BaseTrigger):
-    _MISSED_MAX_COUNT = 5
+    _MAX_QUERY_ERRORS = 5
 
-    def __init__(self, conn_id, task_name, sleep_time):
+    def __init__(self, conn_id, task_name, sleep_time, query_timeout: int = DEFAULT_QUERY_TIMEOUT):
         super().__init__()
         self.conn_id = conn_id
         self.task_name = task_name
         self._sleep_time = sleep_time
-        self._missed_count = 0
+        self._query_timeout = query_timeout
+        self._max_not_found = max(self._MAX_QUERY_ERRORS, math.ceil(_NOT_FOUND_GRACE_SECONDS / max(sleep_time, 1)))
+        self._query_error_count = 0
+        self._not_found_count = 0
 
     def serialize(self) -> tuple[str, dict[str, Any]]:
         return (
@@ -25,36 +36,51 @@ class StarRocksTaskCompleteTrigger(BaseTrigger):
                 "conn_id": self.conn_id,
                 "task_name": self.task_name,
                 "sleep_time": self._sleep_time,
+                "query_timeout": self._query_timeout,
             },
         )
 
-    def _get_task_completed(self, cursor):
-        try:
-            cursor.execute(
-                f"""
-                SELECT state, error_message
-                FROM information_schema.task_runs
-                WHERE task_name = '{self.task_name}'
-                ORDER BY CREATE_TIME DESC
-                LIMIT 1
-                """
-            )
-            result = cursor.fetchone()
-        except Exception as e:
-            LOGGER.info(f"Retrying after receiving: [{type(e)}] {e}")
-            self._missed_count += 1
-            if self._missed_count >= self._MISSED_MAX_COUNT:
-                return TriggerEvent({"error_message": f"Caught {type(e)} caused {self.task_name} to fail"})
-            return None
+    def _fetch_last_run(self) -> tuple | None:
+        """Read the latest task run state for `self.task_name`.
 
+        Blocking: opens a short-lived connection, queries, then closes it. Runs in a worker thread, never on
+        the triggerer event loop. A fresh connection per poll re-resolves DNS and sidesteps half-open sockets
+        left behind by an FE restart or a pod being rescheduled.
+        """
+        connection = BaseHook.get_connection(self.conn_id)
+        hook = connection.get_hook(hook_params={})
+        conn = hook.get_conn()
+        try:
+            with conn.cursor() as cursor:
+                cursor.execute(
+                    f"""
+                    SELECT state, error_message
+                    FROM information_schema.task_runs
+                    WHERE task_name = '{self.task_name}'
+                    ORDER BY CREATE_TIME DESC
+                    LIMIT 1
+                    """
+                )
+                return cursor.fetchone()
+        finally:
+            try:
+                conn.close()
+            except Exception as e:  # noqa: BLE001 - closing must never mask the query outcome
+                LOGGER.debug(f"Ignoring error while closing connection: [{type(e)}] {e}")
+
+    def _evaluate_state(self, result: tuple | None) -> TriggerEvent | None:
+        """Map a `task_runs` row to a terminal event, or None to keep polling."""
         if not result:
-            LOGGER.info("Expected variable `result` is None, retrying...")
-            self._missed_count += 1
-            if self._missed_count >= self._MISSED_MAX_COUNT:
+            self._not_found_count += 1
+            LOGGER.info(
+                f"No task run found for {self.task_name} ({self._not_found_count}/{self._max_not_found}), retrying..."
+            )
+            if self._not_found_count >= self._max_not_found:
                 return TriggerEvent({"status": "error", "error_message": f"task {self.task_name} not found"})
             return None
 
-        self._missed_count = 0
+        self._query_error_count = 0
+        self._not_found_count = 0
 
         if result[0] == "SUCCESS":
             return TriggerEvent({"status": "success"})
@@ -62,14 +88,39 @@ class StarRocksTaskCompleteTrigger(BaseTrigger):
             return TriggerEvent({"status": "error", "state": result[0], "error_message": result[1]})
         return None
 
-    async def run(self):
-        connection = BaseHook.get_connection(self.conn_id)
-        hook = connection.get_hook(hook_params={})
-        conn = hook.get_conn()
-        cursor = conn.cursor()
+    async def _poll_once(self) -> TriggerEvent | None:
+        """Poll StarRocks once without ever blocking the triggerer event loop.
 
-        result = self._get_task_completed(cursor)
+        `wait_for` bounds a hung socket so the loop can retry with a fresh connection. Note the abandoned
+        thread stays blocked on `recv()` and holds a default-executor slot until the socket errors out — set
+        `read_timeout`/`connect_timeout` in the `starrocks_conn` extra to bound that too (see README).
+        """
+        try:
+            result = await asyncio.wait_for(asyncio.to_thread(self._fetch_last_run), timeout=self._query_timeout)
+        except TimeoutError:
+            return self._on_query_error(f"query timed out after {self._query_timeout}s")
+        except Exception as e:  # noqa: BLE001 - any driver error is retryable
+            return self._on_query_error(f"[{type(e)}] {e}")
+
+        return self._evaluate_state(result)
+
+    def _on_query_error(self, message: str) -> TriggerEvent | None:
+        self._query_error_count += 1
+        LOGGER.info(
+            f"Retrying after receiving ({self._query_error_count}/{self._MAX_QUERY_ERRORS}): {message}",
+        )
+        if self._query_error_count >= self._MAX_QUERY_ERRORS:
+            return TriggerEvent(
+                {
+                    "status": "error",
+                    "error_message": f"Polling {self.task_name} failed {self._MAX_QUERY_ERRORS} times: {message}",
+                }
+            )
+        return None
+
+    async def run(self):
+        result = await self._poll_once()
         while result is None:
             await asyncio.sleep(self._sleep_time)
-            result = self._get_task_completed(cursor)
+            result = await self._poll_once()
         yield result

--- a/tests/unit/starrocks/test_operator.py
+++ b/tests/unit/starrocks/test_operator.py
@@ -1,7 +1,9 @@
 import re
 from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
+from airflow.exceptions import TaskDeferred
 
 from radiant.tasks.starrocks.operator import (
     RadiantStarRocksBaseOperator,
@@ -10,6 +12,7 @@ from radiant.tasks.starrocks.operator import (
     SubmitTaskOptions,
     SwapPartition,
 )
+from radiant.tasks.starrocks.trigger import StarRocksTaskCompleteTrigger
 
 # Pin the shared database so mapping assertions don't depend on the process environment.
 _SHARED_CONF = {"RADIANT_TABLES_DATABASE": "radiant"}
@@ -129,6 +132,34 @@ def test_mapped_render_injects_mapping_and_tenant_code():
     assert "chop_tenant.germline__snv__occurrence" in op.sql
     assert "radiant.snv__staging_variant" in op.sql
     assert "'chop'" in op.sql
+
+
+def _deferred(submit_task_options):
+    op = RadiantStarRocksOperator(task_id="t", sql="SELECT 1", submit_task_options=submit_task_options)
+    with patch.object(op, "get_db_hook", return_value=MagicMock()), pytest.raises(TaskDeferred) as exc:
+        op.submit_query(sql="SELECT 1", method_name="_is_complete")
+    return exc.value
+
+
+# Regression: poll_interval used to be dropped on the floor — submit_query hardcoded sleep_time=30.
+def test_submit_query_uses_configured_poll_interval():
+    deferred = _deferred(SubmitTaskOptions(max_query_timeout=3600, poll_interval=10))
+
+    assert isinstance(deferred.trigger, StarRocksTaskCompleteTrigger)
+    assert deferred.trigger.serialize()[1]["sleep_time"] == 10
+
+
+# Regression: no defer timeout meant a wedged or restarted triggerer left the task deferred forever.
+def test_submit_query_sets_defer_timeout_from_query_timeout():
+    deferred = _deferred(SubmitTaskOptions(max_query_timeout=3600, poll_interval=10))
+
+    assert deferred.timeout.total_seconds() == 3600 + SubmitTaskOptions.DEFER_TIMEOUT_MARGIN
+
+
+def test_submit_query_honours_explicit_defer_timeout():
+    deferred = _deferred(SubmitTaskOptions(max_query_timeout=3600, poll_interval=10, defer_timeout=120))
+
+    assert deferred.timeout.total_seconds() == 120
 
 
 def test_mapped_render_partition_swap_resolves_table_per_tenant():

--- a/tests/unit/starrocks/test_trigger.py
+++ b/tests/unit/starrocks/test_trigger.py
@@ -8,57 +8,89 @@ from pymysql import ProgrammingError
 from radiant.tasks.starrocks.trigger import StarRocksTaskCompleteTrigger
 
 
+class _StarRocksMock:
+    """Handles on the mocked connection chain, so tests can assert reconnect/close behaviour."""
+
+    def __init__(self, get_connection, connection, conn, cursor):
+        self.get_connection = get_connection
+        self.connection = connection
+        self.conn = conn
+        self.cursor = cursor
+
+    @property
+    def poll_count(self) -> int:
+        """How many times the trigger opened a fresh connection."""
+        return self.get_connection.call_count
+
+
 @pytest.fixture
-def mock_connection():
+def starrocks():
     with patch("radiant.tasks.starrocks.trigger.BaseHook.get_connection") as mock_get_connection:
         mock_cursor = MagicMock()
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
         mock_connection = MagicMock()
-        mock_connection.get_hook.return_value.get_conn.return_value.cursor.return_value = mock_cursor
+        mock_connection.get_hook.return_value.get_conn.return_value = mock_conn
         mock_get_connection.return_value = mock_connection
-        yield mock_cursor
+        yield _StarRocksMock(mock_get_connection, mock_connection, mock_conn, mock_cursor)
 
 
-@pytest.fixture
-def context():
-    return {}
+@pytest.fixture(autouse=True)
+def no_wait():
+    """Skip the inter-poll backoff so tests exercise the loop, not the wall clock."""
+
+    async def _noop(_delay):
+        return None
+
+    with patch("radiant.tasks.starrocks.trigger.asyncio.sleep", _noop):
+        yield
 
 
-def test_get_task_completed_success(mock_connection):
-    mock_connection.fetchone.return_value = ("SUCCESS", None)
+def _trigger(sleep_time=1, **kwargs):
+    return StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=sleep_time, **kwargs)
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
-    result = trigger._get_task_completed(mock_connection)
+
+def _run(trigger):
+    async def run_trigger():
+        return [event async for event in trigger.run()]
+
+    return asyncio.run(run_trigger())
+
+
+def test_evaluate_state_success():
+    result = _trigger()._evaluate_state(("SUCCESS", None))
 
     assert isinstance(result, TriggerEvent)
     assert result.payload.get("status") == "success"
 
 
-def test_get_task_completed_failed(mock_connection):
-    mock_connection.fetchone.return_value = ("FAILED", "fake_out_of_memory_error")
-
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
-    result = trigger._get_task_completed(mock_connection)
+def test_evaluate_state_failed():
+    result = _trigger()._evaluate_state(("FAILED", "fake_out_of_memory_error"))
 
     assert isinstance(result, TriggerEvent)
+    assert result.payload.get("status") == "error"
     assert result.payload.get("error_message") == "fake_out_of_memory_error"
     assert result.payload.get("state") == "FAILED"
 
 
-def test_get_task_completed_running(mock_connection):
-    mock_connection.fetchone.return_value = ("RUNNING", None)
-
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
-    result = trigger._get_task_completed(mock_connection)
-
-    assert result is None
+@pytest.mark.parametrize("state", ["RUNNING", "PENDING"])
+def test_evaluate_state_pending_keeps_polling(state):
+    assert _trigger()._evaluate_state((state, None)) is None
 
 
-def test_get_task_completed_none(mock_connection):
-    mock_connection.fetchone.return_value = None
+def test_evaluate_state_unknown():
+    result = _trigger()._evaluate_state(("FOOBAR", None))
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
+    assert isinstance(result, TriggerEvent)
+    assert result.payload.get("error_message") is None
+    assert result.payload.get("state") == "FOOBAR"
 
-    result = [trigger._get_task_completed(mock_connection) for _ in range(5)]
+
+def test_evaluate_state_not_found_exhausts_grace():
+    # sleep_time=30 -> ceil(120/30) = 4, floored to _MAX_QUERY_ERRORS (5).
+    trigger = _trigger(sleep_time=30)
+
+    result = [trigger._evaluate_state(None) for _ in range(5)]
 
     assert result[:4] == [None, None, None, None]
     assert isinstance(result[4], TriggerEvent)
@@ -66,79 +98,134 @@ def test_get_task_completed_none(mock_connection):
     assert result[4].payload.get("error_message") == "task test_task not found"
 
 
-def test_get_task_completed_unknown(mock_connection):
-    mock_connection.fetchone.return_value = ("FOOBAR", None)
+def test_not_found_grace_does_not_shrink_with_short_poll_interval():
+    # A 10s poll interval must still allow ~120s of "row not visible yet", not 5 attempts (50s).
+    trigger = _trigger(sleep_time=10)
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
-    result = trigger._get_task_completed(mock_connection)
-
-    assert isinstance(result, TriggerEvent)
-    assert result.payload.get("error_message") is None
-    assert result.payload.get("state") == "FOOBAR"
+    assert trigger._max_not_found == 12
+    assert [trigger._evaluate_state(None) for _ in range(11)] == [None] * 11
+    assert isinstance(trigger._evaluate_state(None), TriggerEvent)
 
 
-def test_run_trigger_until_success(mock_connection):
-    mock_connection.fetchone.side_effect = [("RUNNING", None), ("SUCCESS", None)]
+def test_evaluate_state_resets_counters_after_transient_miss():
+    trigger = _trigger(sleep_time=30)
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=1)
+    assert trigger._evaluate_state(None) is None
+    assert trigger._evaluate_state(("RUNNING", None)) is None
+    assert trigger._not_found_count == 0
 
-    async def run_trigger():
-        result = [event async for event in trigger.run()]
-        return result
 
-    result = asyncio.run(run_trigger())
+def test_run_trigger_until_success(starrocks):
+    starrocks.cursor.fetchone.side_effect = [("RUNNING", None), ("SUCCESS", None)]
+
+    result = _run(_trigger())
 
     assert len(result) == 1
-    assert isinstance(result[0], TriggerEvent)
     assert result[0].payload.get("status") == "success"
 
 
-def test_run_trigger_until_failure(mock_connection):
-    mock_connection.fetchone.side_effect = [
+def test_run_trigger_until_failure(starrocks):
+    starrocks.cursor.fetchone.side_effect = [
         ("RUNNING", None),
         ("FAILED", "fake_out_of_memory_error"),
     ]
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=1)
-
-    async def run_trigger():
-        result = [event async for event in trigger.run()]
-        return result
-
-    result = asyncio.run(run_trigger())
+    result = _run(_trigger())
 
     assert len(result) == 1
-    assert isinstance(result[0], TriggerEvent)
     assert result[0].payload.get("error_message") == "fake_out_of_memory_error"
     assert result[0].payload.get("state") == "FAILED"
 
 
-def test_run_trigger_until_unknown(mock_connection):
-    mock_connection.fetchone.side_effect = [None, None, None, None, None]
+def test_run_trigger_until_unknown(starrocks):
+    starrocks.cursor.fetchone.side_effect = [None] * 5
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=1)
-
-    async def run_trigger():
-        result = [event async for event in trigger.run()]
-        return result
-
-    result = asyncio.run(run_trigger())
+    result = _run(_trigger(sleep_time=30))
 
     assert len(result) == 1
-    assert isinstance(result[0], TriggerEvent)
     assert result[0].payload.get("status") == "error"
     assert result[0].payload.get("error_message") == "task test_task not found"
 
 
-def test_get_task_complete_programming_error(mock_connection):
-    mock_connection.execute.side_effect = ProgrammingError()
+def test_run_reconnects_on_every_poll(starrocks):
+    starrocks.cursor.fetchone.side_effect = [("RUNNING", None), ("RUNNING", None), ("SUCCESS", None)]
 
-    trigger = StarRocksTaskCompleteTrigger(conn_id="test_conn", task_name="test_task", sleep_time=5)
+    _run(_trigger())
 
-    result = [trigger._get_task_completed(mock_connection) for _ in range(5)]
+    # A stale connection can no longer wedge the loop: each poll dials StarRocks again and hangs up after.
+    assert starrocks.poll_count == 3
+    assert starrocks.conn.close.call_count == 3
 
-    assert isinstance(result[-1], TriggerEvent)
-    assert (
-        result[-1].payload.get("error_message")
-        == "Caught <class 'pymysql.err.ProgrammingError'> caused test_task to fail"
-    )
+
+def test_run_closes_connection_even_when_query_fails(starrocks):
+    starrocks.cursor.execute.side_effect = [ProgrammingError(), None]
+    starrocks.cursor.fetchone.return_value = ("SUCCESS", None)
+
+    result = _run(_trigger())
+
+    assert result[0].payload.get("status") == "success"
+    assert starrocks.conn.close.call_count == 2
+
+
+def test_run_recovers_from_query_error(starrocks):
+    starrocks.cursor.execute.side_effect = [ProgrammingError(), None]
+    starrocks.cursor.fetchone.return_value = ("SUCCESS", None)
+
+    trigger = _trigger()
+    result = _run(trigger)
+
+    assert result[0].payload.get("status") == "success"
+    assert trigger._query_error_count == 0
+
+
+def test_run_fails_after_repeated_query_errors(starrocks):
+    starrocks.cursor.execute.side_effect = ProgrammingError()
+
+    result = _run(_trigger())
+
+    assert len(result) == 1
+    assert result[0].payload.get("status") == "error"
+    assert "failed 5 times" in result[0].payload.get("error_message")
+    assert "ProgrammingError" in result[0].payload.get("error_message")
+
+
+def test_run_recovers_from_hung_query():
+    """A hung socket must be bounded by the query timeout instead of blocking the event loop forever."""
+    calls = {"n": 0}
+
+    async def fetch():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            await asyncio.Event().wait()  # never set; stands in for a blocked recv()
+        return ("SUCCESS", None)
+
+    # `new=` (not side_effect): patch would otherwise build an AsyncMock for the async `to_thread` and the
+    # inner coroutine would come back un-awaited.
+    trigger = _trigger(query_timeout=0.05)
+    with patch("radiant.tasks.starrocks.trigger.asyncio.to_thread", new=lambda _fn: fetch()):
+        result = _run(trigger)
+
+    assert len(result) == 1
+    assert result[0].payload.get("status") == "success"
+    assert calls["n"] == 2
+
+
+def test_run_fails_after_repeated_hung_queries():
+    async def never_returns():
+        await asyncio.Event().wait()
+
+    trigger = _trigger(query_timeout=0.01)
+    with patch("radiant.tasks.starrocks.trigger.asyncio.to_thread", new=lambda _fn: never_returns()):
+        result = _run(trigger)
+
+    assert result[0].payload.get("status") == "error"
+    assert "query timed out" in result[0].payload.get("error_message")
+
+
+def test_serialize_round_trips_query_timeout():
+    classpath, kwargs = _trigger(sleep_time=7, query_timeout=42).serialize()
+
+    assert classpath == "radiant.tasks.starrocks.trigger.StarRocksTaskCompleteTrigger"
+    assert kwargs == {"conn_id": "test_conn", "task_name": "test_task", "sleep_time": 7, "query_timeout": 42}
+    # Reassignment to another triggerer rebuilds the trigger from these kwargs.
+    assert StarRocksTaskCompleteTrigger(**kwargs)._query_timeout == 42


### PR DESCRIPTION
## Problem

An ETL run in QA got stuck forever on `[StarRocks] Insert SNV Variants`, even though the StarRocks task itself had finished successfully. Other unrelated deferred tasks on the same triggerer were stuck too.

## Cause

`StarRocksTaskCompleteTrigger` polled StarRocks with plain blocking database calls placed directly inside the triggerer's async event loop, reusing a single connection opened once at the start.

So when that connection went dead (pod rescheduled, FE IP changed), the "is the task done yet?" query never returned and never errored — no socket timeout. The trigger waited forever, and because it was blocking the shared event loop, it froze every other deferred task on that triggerer pod as well.

## Fix

- Each poll now opens a **fresh** connection, runs in a worker thread with a 60s cap, and closes it. A hung poll can no longer block the event loop, and the loop retries instead of waiting forever.
- After 5 consecutive failed polls the task fails with the real error, instead of hanging silently.
- `defer()` now has a hard deadline (`max_query_timeout` + 10 min), so the scheduler kills a stuck deferral even if a triggerer is unresponsive.
- Two bugs found on the way: `poll_interval` was ignored (`sleep_time` was hardcoded to 30s), and error events were missing `status`, so the task log said `"Unknown error"` instead of the actual exception.
- README documents the recommended `starrocks_conn` socket timeouts.

## Tests

`ruff` clean, 501 unit tests and 20 integration tests pass. New tests cover recovery from a hung poll, reconnecting on every poll, closing the connection on the error path, and the `poll_interval` / defer-timeout plumbing.