### PR TITLE
feat: SJRA-1772 discovery and task model for somatic tumor-only CNV

### DIFF
--- a/radiant/dags/sql/clinical/seeds.sql
+++ b/radiant/dags/sql/clinical/seeds.sql
@@ -985,7 +985,11 @@ INSERT INTO {{ params.clinical_task }} (id, task_type_code, pipeline_name, pipel
     -- is per-task, not per-case: case 22 carries both.
     (68, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
     -- Tumor-only analysis of case 23, whose tumor sample has no matched normal at all.
-    (69, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant');
+    (69, 'radiant_somatic_annotation', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant'),
+    -- The calling step behind task 69: this is where the somatic CNV VCF comes from. Somatic CNV is
+    -- discovered by task type + document data type (`tumor_only_variant_calling` + `scnv`), never by
+    -- filename, exactly as germline CNV is by `alignment_germline_variant_calling` + `gcnv`.
+    (70, 'tumor_only_variant_calling', 'Dragen', '4.4.4', 'GRch38', '2021-10-12 13:08:00', 'radiant');
 
 TRUNCATE {{ params.clinical_task_context }} CASCADE;
 INSERT INTO {{ params.clinical_task_context }} (task_id, case_id, sequencing_experiment_id) VALUES
@@ -1063,7 +1067,9 @@ INSERT INTO {{ params.clinical_task_context }} (task_id, case_id, sequencing_exp
     (67, 22, 63),
     -- Task 68 spans only the tumoral experiment 62 -> tumor-only.
     (68, 22, 62),
-    (69, 23, 64)
+    (69, 23, 64),
+    -- Task 70 calls the same single tumoral experiment 64 that task 69 annotates.
+    (70, 23, 64)
 ;
 
 
@@ -1326,7 +1332,13 @@ INSERT INTO {{ params.clinical_document }} (id, name, data_category_code, data_t
     (259, 'variants.SRX1091647-T.snv.vep.vcf.gz', 'genomic', 'snv', 'vcf', 21903112, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T.snv.vep.vcf.gz', '39056b126bc06b21446c9f6912bc259e', 'radiant'),
     (260, 'variants.SRX1091647-T.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 612884, '{{ params.vcf_bucket_prefix }}/variants.SRX1091647-T.snv.vep.vcf.gz.tbi', '97cfc0224aa7e916bfddd070c7522dc7', 'radiant'),
     (261, 'variants.SRX1166091-T.snv.vep.vcf.gz', 'genomic', 'snv', 'vcf', 23417650, '{{ params.vcf_bucket_prefix }}/variants.SRX1166091-T.snv.vep.vcf.gz', 'adc19953d1b08acdf57f20be42dbcdf3', 'radiant'),
-    (262, 'variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 641327, '{{ params.vcf_bucket_prefix }}/variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'ce6da3c5c64ee1debb468acac4999080', 'radiant');
+    (262, 'variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'genomic', 'snv', 'tbi', 641327, '{{ params.vcf_bucket_prefix }}/variants.SRX1166091-T.snv.vep.vcf.gz.tbi', 'ce6da3c5c64ee1debb468acac4999080', 'radiant'),
+    -- Outputs of the tumor-only *calling* task 70. A calling step emits both the somatic CNV VCF and
+    -- a raw, un-annotated somatic SNV VCF: document 265 is that raw file, and it must never reach
+    -- `vcf_filepath`, which only ever holds the annotated VCF of a `radiant_somatic_annotation` task.
+    (263, 'TCRBOA6_SRX1166091-T.cnv.vcf.gz', 'genomic', 'scnv', 'vcf', 1204512, '{{ params.vcf_bucket_prefix }}/TCRBOA6_SRX1166091-T.cnv.vcf.gz', 'b4e1f0a2c7d95836ae2f1c0d4b7a9e51', 'radiant'),
+    (264, 'TCRBOA6_SRX1166091-T.cnv.vcf.gz.tbi', 'genomic', 'scnv', 'tbi', 18432, '{{ params.vcf_bucket_prefix }}/TCRBOA6_SRX1166091-T.cnv.vcf.gz.tbi', 'd0c6a3f92b17e845cf30ab29e6d15473', 'radiant'),
+    (265, 'TCRBOA6_SRX1166091-T.snv.vcf.gz', 'genomic', 'ssnv', 'vcf', 19874233, '{{ params.vcf_bucket_prefix }}/TCRBOA6_SRX1166091-T.snv.vcf.gz', 'f27a5b910ce3d648b0a71f2c85d9e304', 'radiant');
 
 TRUNCATE {{ params.clinical_task_has_document }} CASCADE;
 INSERT INTO {{ params.clinical_task_has_document }} (task_id, document_id, type) VALUES
@@ -1589,7 +1601,10 @@ INSERT INTO {{ params.clinical_task_has_document }} (task_id, document_id, type)
     (68, 259, 'output'),
     (68, 260, 'output'),
     (69, 261, 'output'),
-    (69, 262, 'output');
+    (69, 262, 'output'),
+    (70, 263, 'output'),
+    (70, 264, 'output'),
+    (70, 265, 'output');
 
 -- Reset sequences
 ALTER TABLE {{ params.clinical_analysis_catalog }} ALTER COLUMN id RESTART WITH 1000;

--- a/radiant/dags/sql/radiant/init/staging_external_sequencing_experiment_create_table.sql
+++ b/radiant/dags/sql/radiant/init/staging_external_sequencing_experiment_create_table.sql
@@ -51,7 +51,7 @@ sequencing_experiments AS (
 	    se.tenant_code,
         COALESCE(se.priority_code, 'routine') AS request_priority,
 	    ANY_VALUE(CASE WHEN d.format_code = 'vcf' AND d.data_type_code IN ('snv', 'ssnv') THEN d.url ELSE NULL END) AS vcf_filepath,
-	    ANY_VALUE(CASE WHEN d.format_code = 'vcf' AND d.data_type_code='gcnv' THEN d.url ELSE NULL END) AS cnv_vcf_filepath,
+	    ANY_VALUE(CASE WHEN d.format_code = 'vcf' AND d.data_type_code IN ('gcnv', 'scnv') THEN d.url ELSE NULL END) AS cnv_vcf_filepath,
 	    ANY_VALUE(CASE WHEN d.format_code = 'tsv' THEN d.url ELSE NULL END) AS exomiser_filepath,
         se.created_on AS created_at,
         IF(tctx.case_id IS NOT NULL, c.updated_on, se.updated_on) AS updated_at
@@ -62,9 +62,12 @@ sequencing_experiments AS (
 	LEFT JOIN {{ mapping.clinical_task }} t ON t.id = tctx.task_id
 	LEFT JOIN {{ mapping.clinical_task_has_document }} thd ON thd.task_id = t.id AND thd.type = 'output'
 	LEFT JOIN {{ mapping.clinical_document }} d ON d.id = thd.document_id
+	-- The data-type gate on the two *calling* steps is what keeps a raw, un-annotated VCF out of
+	-- `vcf_filepath`, which must only ever hold the annotated file from a `radiant_*_annotation` task.
 	WHERE (
 		(d.format_code = 'vcf' AND t.task_type_code IN ('radiant_germline_annotation', 'radiant_somatic_annotation'))
-		OR (d.format_code = 'vcf' AND t.task_type_code = 'alignment_germline_variant_calling')
+		OR (d.format_code = 'vcf' AND d.data_type_code = 'gcnv' AND t.task_type_code = 'alignment_germline_variant_calling')
+		OR (d.format_code = 'vcf' AND d.data_type_code = 'scnv' AND t.task_type_code = 'tumor_only_variant_calling')
 		OR (d.url LIKE '%variants.tsv' AND t.task_type_code = 'exomiser')
 	)
 	GROUP BY

--- a/radiant/tasks/vcf/experiment.py
+++ b/radiant/tasks/vcf/experiment.py
@@ -6,6 +6,7 @@ RADIANT_GERMLINE_ANNOTATION_TASK = "radiant_germline_annotation"
 ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK = "alignment_germline_variant_calling"
 EXOMISER_TASK = "exomiser"
 RADIANT_SOMATIC_ANNOTATION_TASK = "radiant_somatic_annotation"
+TUMOR_ONLY_VARIANT_CALLING_TASK = "tumor_only_variant_calling"
 
 
 class Experiment(BaseModel):
@@ -96,11 +97,34 @@ class RadiantSomaticAnnotationTask(BaseTask):
         raise ValueError("No tumor sample found in rows for `radiant_somatic_annotation` task.")
 
 
+class TumorOnlyVariantCallingTask(BaseTask):
+    task_type: str = TUMOR_ONLY_VARIANT_CALLING_TASK
+    cnv_vcf_filepath: str | None = None
+
+    @staticmethod
+    def gather_additional_args(rows: list[dict]) -> dict:
+        # The task type asserts tumor-only; these checks hold the file to it. A second row means a
+        # tumor-normal task mislabelled upstream, and a non-tumoral histology means a normal sample
+        # whose depths would otherwise be written as tumor values. Tumor-normal CNV is out of scope,
+        # so fail loudly rather than half-succeed.
+        if len(rows) > 1:
+            raise ValueError("`tumor_only_variant_calling` task expects a single row per task.")
+        if rows[0].get("histology_type") != "tumoral":
+            raise ValueError(
+                f"`tumor_only_variant_calling` task [{rows[0].get('task_id')}] expects a tumoral sample, "
+                f"got histology_type: {rows[0].get('histology_type')}."
+            )
+        return {
+            "cnv_vcf_filepath": rows[0].get("cnv_vcf_filepath"),
+        }
+
+
 _TASK_TYPES = {
     RADIANT_GERMLINE_ANNOTATION_TASK: RadiantGermlineAnnotationTask,
     ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK: AlignmentGermlineVariantCallingTask,
     EXOMISER_TASK: ExomiserTask,
     RADIANT_SOMATIC_ANNOTATION_TASK: RadiantSomaticAnnotationTask,
+    TUMOR_ONLY_VARIANT_CALLING_TASK: TumorOnlyVariantCallingTask,
 }
 
 

--- a/tests/integration/dags/sql/test_sequencing_experiment_select_delta.py
+++ b/tests/integration/dags/sql/test_sequencing_experiment_select_delta.py
@@ -91,7 +91,7 @@ def test_sequencing_experiment_empty(
 
     assert results is not None, "Results should not be None"
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 14
+    assert len(result_df) == 15
 
 
 def test_sequencing_experiment_delta_carries_tumor_only_tasks(
@@ -117,8 +117,10 @@ def test_sequencing_experiment_delta_carries_tumor_only_tasks(
         results = cursor.fetchall()
 
     somatic = pd.DataFrame(results, columns=sequencing_delta_columns).query("analysis_type == 'somatic'")
+    # Task 70 is the tumor-only *calling* step behind task 69, covered by its own test below.
+    annotations = somatic.query("task_type == 'radiant_somatic_annotation'")
 
-    assert {int(task_id): sorted(rows["histology_type"]) for task_id, rows in somatic.groupby("task_id")} == {
+    assert {int(task_id): sorted(rows["histology_type"]) for task_id, rows in annotations.groupby("task_id")} == {
         67: ["normal", "tumoral"],
         68: ["tumoral"],
         69: ["tumoral"],
@@ -140,6 +142,42 @@ def test_sequencing_experiment_delta_carries_tumor_only_tasks(
 
     # Every somatic experiment here is wgs, so the tumor-only cohort lands in the wgs buckets.
     assert set(somatic["experimental_strategy"]) == {"wgs"}
+
+
+def test_sequencing_experiment_delta_gates_somatic_cnv_documents(
+    postgres_clinical_seeds, starrocks_session, sequencing_experiment_tables, sequencing_delta_columns
+):
+    """A somatic CNV VCF is discovered by task type + document data type, never by filename.
+
+    Task 70 is the `tumor_only_variant_calling` step behind the tumor-only annotation task 69, and it
+    registers three output documents: the `scnv` CNV VCF, its index, and a raw un-annotated `ssnv`
+    SNV VCF. Only the CNV VCF may surface — the raw SNV file must not reach `vcf_filepath`, which
+    only ever holds the annotated VCF of a `radiant_somatic_annotation` task. Without the
+    `data_type_code = 'scnv'` gate in the view's WHERE clause, it would, giving somatic SNV a second
+    ingestion route it must not have.
+    """
+    with starrocks_session.cursor() as cursor:
+        cursor.execute("TRUNCATE TABLE staging_sequencing_experiment;")
+        cursor.execute("SELECT * FROM staging_sequencing_experiment_delta;")
+        results = cursor.fetchall()
+
+    delta = pd.DataFrame(results, columns=sequencing_delta_columns)
+    calling = delta.query("task_id == 70")
+
+    # One row: the task's single tumoral experiment, carrying the CNV VCF and nothing else.
+    assert len(calling) == 1
+    row = calling.iloc[0]
+    assert row["task_type"] == "tumor_only_variant_calling"
+    assert (row["seq_id"], row["aliquot"], row["histology_type"]) == (64, "TCRBOA6_SRX1166091-T", "tumoral")
+    assert row["cnv_vcf_filepath"].endswith("TCRBOA6_SRX1166091-T.cnv.vcf.gz")
+    # pd.isna, not `is None`: pandas renders a SQL NULL as either None or NaN depending on what else
+    # the column holds, and a leak would show up as a URL string either way.
+    assert pd.isna(row["vcf_filepath"]), "the raw un-annotated ssnv VCF leaked into vcf_filepath"
+
+    # The annotation task on the same experiment still points at its own annotated VCF.
+    annotation = delta.query("task_id == 69").iloc[0]
+    assert annotation["vcf_filepath"].endswith("variants.SRX1166091-T.snv.vep.vcf.gz")
+    assert pd.isna(annotation["cnv_vcf_filepath"])
 
 
 def test_sequencing_experiment_no_delta(
@@ -254,7 +292,7 @@ def test_sequencing_experiment_existing_wgs_task_partition(
         results = cursor.fetchall()
 
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 13
+    assert len(result_df) == 14
 
 
 def test_sequencing_experiment_with_recently_updated_task(
@@ -298,7 +336,7 @@ def test_sequencing_experiment_with_recently_updated_task(
         results = cursor.fetchall()
 
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 13
+    assert len(result_df) == 14
 
     with (
         psycopg2.connect(
@@ -324,4 +362,4 @@ def test_sequencing_experiment_with_recently_updated_task(
 
     # Should capture the updated experiment
     result_df = pd.DataFrame(results, columns=sequencing_delta_columns)
-    assert len(result_df) == 14
+    assert len(result_df) == 15

--- a/tests/unit/vcf/somatic/test_somatic_cnv_experiments.py
+++ b/tests/unit/vcf/somatic/test_somatic_cnv_experiments.py
@@ -1,0 +1,89 @@
+import pytest
+
+from radiant.tasks.vcf.experiment import (
+    TUMOR_ONLY_VARIANT_CALLING_TASK,
+    TumorOnlyVariantCallingTask,
+    build_task_from_dict,
+    build_task_from_rows,
+)
+
+
+def _base_row() -> dict:
+    return {
+        "task_id": 70,
+        "part": 0,
+        "task_type": TUMOR_ONLY_VARIANT_CALLING_TASK,
+        "analysis_type": "somatic",
+        "seq_id": 64,
+        "patient_id": 62,
+        "aliquot": "TCRBOA6_SRX1166091-T",
+        "tenant_code": "tenant1",
+        "family_role": "proband",
+        "affected_status": "affected",
+        "sex": "female",
+        "experimental_strategy": "wgs",
+        "request_priority": "routine",
+        "histology_type": "tumoral",
+        "cnv_vcf_filepath": "/path/to/tumor_only.cnv.vcf.gz",
+        "deleted": False,
+    }
+
+
+def test_tumor_only_variant_calling_task_single_tumoral_row_ok():
+    task = build_task_from_rows([_base_row()])
+
+    assert isinstance(task, TumorOnlyVariantCallingTask)
+    assert task.task_type == TUMOR_ONLY_VARIANT_CALLING_TASK
+    assert task.cnv_vcf_filepath == "/path/to/tumor_only.cnv.vcf.gz"
+    assert len(task.experiments) == 1
+    assert task.experiments[0].histology_type == "tumoral"
+
+
+def test_tumor_only_variant_calling_task_multiple_rows_raises():
+    """More than one aliquot on the task means a tumor-normal analysis mislabelled upstream."""
+    row1 = _base_row()
+    row2 = _base_row() | {"seq_id": 65, "aliquot": "TCRBOA6_SRX1166091-N"}
+
+    with pytest.raises(ValueError) as excinfo:
+        build_task_from_rows([row1, row2])
+
+    assert "tumor_only_variant_calling" in str(excinfo.value)
+
+
+def test_tumor_only_variant_calling_task_non_tumoral_row_raises():
+    """A normal-only task would otherwise write normal depths as tumor values."""
+    row = _base_row() | {"histology_type": "normal"}
+
+    with pytest.raises(ValueError) as excinfo:
+        build_task_from_rows([row])
+
+    assert "tumoral" in str(excinfo.value)
+    assert "normal" in str(excinfo.value)
+
+
+def test_tumor_only_variant_calling_task_missing_histology_type_raises():
+    row = _base_row()
+    del row["histology_type"]
+
+    with pytest.raises(ValueError):
+        build_task_from_rows([row])
+
+
+def test_tumor_only_variant_calling_task_without_cnv_filepath_builds():
+    """The staging view's `scnv` gate should always supply the URL, but a missing one must not abort
+    the whole partition: every task in the part is built by the same `tasks_output_processor` call."""
+    row = _base_row() | {"cnv_vcf_filepath": None}
+
+    task = build_task_from_rows([row])
+
+    assert task.cnv_vcf_filepath is None
+
+
+def test_tumor_only_variant_calling_task_round_trips_through_dict():
+    """`import_part` hands tasks to the extraction DAGs as `model_dump()` payloads over XCom."""
+    task = build_task_from_rows([_base_row()])
+
+    rebuilt = build_task_from_dict(task.model_dump())
+
+    assert isinstance(rebuilt, TumorOnlyVariantCallingTask)
+    assert rebuilt == task


### PR DESCRIPTION
## 📌 Context

First subtask of SJRA-1770 (§8 item 1 of `design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md`): make a somatic tumor-only CNV VCF **discoverable** and give it a task model. Nothing consumes it yet — extraction (SJRA-1773), tables (SJRA-1774), load SQL (SJRA-1775) and orchestration (SJRA-1776) follow.

CNV VCFs are found by task type + document data type, never by filename. Germline CNV is `alignment_germline_variant_calling` + `gcnv`; somatic tumor-only is now `tumor_only_variant_calling` + `scnv`, reusing the existing `cnv_vcf_filepath` column. Both dictionary codes already exist in the clinical model, so there is **no clinical-model change** — but no `task` row used `tumor_only_variant_calling` yet, so the seeds are net-new.

## 📝 Changes

- **`staging_external_sequencing_experiment_create_table.sql`**: the `scnv` document lands in `cnv_vcf_filepath`; a new gated `WHERE` clause exposes `tumor_only_variant_calling` + `scnv`; germline's clause gets the same `data_type_code = 'gcnv'` gate it never had. The gate is the point — a *calling* step also emits a raw, un-annotated SNV VCF, and ungated that file would land in `vcf_filepath`, which must only ever hold the annotated VCF from a `radiant_*_annotation` task. That would give somatic SNV a second ingestion route it must not have.
- **`radiant/tasks/vcf/experiment.py`**: `TUMOR_ONLY_VARIANT_CALLING_TASK`, a `TumorOnlyVariantCallingTask` model and its `_TASK_TYPES` entry. Two validations per §3: exactly one experiment on the task (more means a mislabelled tumor-normal task, out of scope), and `histology_type == 'tumoral'` (stops a normal-only task writing normal depths as tumor values).
- **`seeds.sql`**: task 70, the `tumor_only_variant_calling` step behind the existing tumor-only annotation task 69 (case 23 / experiment 64). It registers three documents: the `scnv` CNV VCF, its index, and a raw `ssnv` SNV VCF that exercises the gate.

## ☑️ TO-DOs

- [ ] **Drop the view before deploying.** It is created with `CREATE VIEW IF NOT EXISTS`, so re-running `init-starrocks-base-tables` will *not* pick this up: run `DROP VIEW staging_external_sequencing_experiment;` in each environment first, then re-run that DAG.
- [ ] **Do not release ahead of SJRA-1773/1776.** `import_part` stamps `ingested_at` on every task in a part, and per SJRA-1187 the delta only re-offers a row when `updated_at >= ingested_at`. Tumor-only CNV tasks reaching production before extraction exists would be marked ingested with their VCF never read, and would not be offered again.

## 🧪 Tests

- `ruff check radiant/`: clean. `make test-unit`: **507 passed**. `USE_DOCKER_FIXTURES=true make test-integration`: **21 passed**.
- New `tests/unit/vcf/somatic/test_somatic_cnv_experiments.py` — 6 cases: single tumoral row builds, two rows raise, non-tumoral raises, missing `histology_type` raises, absent URL builds as `None`, and a `model_dump()` round-trip through `build_task_from_dict` (how `import_part` hands tasks over XCom).
- New `test_sequencing_experiment_delta_gates_somatic_cnv_documents` — task 70 appears once with its `.cnv.vcf.gz` URL and a **NULL `vcf_filepath`**, proving the decoy `ssnv` document did not leak; task 69 still points at its own annotated VCF.
- Delta row counts bumped by the one added row (14→15, 13→14). The existing tumor-only assertion is now scoped to `radiant_somatic_annotation`, since task 70 is somatic too but is covered by its own test.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- SJRA-1772
- SJRA-1770
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Tightening germline's `WHERE` is the only change that touches existing behaviour.** It is behaviour-preserving on the current seeds — the only `format_code='vcf'` document on a germline calling task is the `gcnv` one (crams are `cram`/`crai`, gVCFs are `gvcf`) — and all counts held. Worth a sanity check against real clinical data before deploy.
- **`cnv_vcf_filepath` is `str | None` here, where germline types it `str`.** `tasks_output_processor` builds every task of a partition in one comprehension, so a required field would turn one missing URL into a failed delta fetch for the whole part.
- §3's third validation — the VCF declaring exactly one sample, captured before `set_samples` narrows `vcf.samples` — is a *file* check and lands with the extractor in SJRA-1773.