### PR TITLE
feat: SJRA-1773 somatic CNV extraction

### DIFF
--- a/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
+++ b/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
@@ -49,7 +49,7 @@ loaded by the machinery germline CNV already uses. No frequencies of our own, no
 - **Tables** — `somatic_cnv_occurrence` (Iceberg, shared, partitioned by `tenant_code`) and
   `somatic__cnv__occurrence` (StarRocks, per-tenant). Two mapping-dict entries do most of the wiring. (§5)
 - **Column set** — mirror germline, plus the DRAGEN 4.2.4 ASCN fields (`cn, cnf, cnq, mcn, mcnf, mcnq, maf,
-  sd, as`), all nullable and often empty. `filter` stays `VARCHAR(255)` like every other occurrence
+  sd, ascn_as`), all nullable and often empty. `filter` stays `VARCHAR(255)` like every other occurrence
   table. (§5)
 - **`type` comes from the DRAGEN ID** — `GAIN`, `LOSS`, `CNLOH`, `GAINLOH`. Measured: there is no usable
   copy-number fallback, since `CN`/`MCN` are absent or per-record and `SM` distributions overlap. A knowing
@@ -476,7 +476,7 @@ Where somatic differs, and what the two measured files say:
 | `type` | `GAIN` / `LOSS` / `CNLOH` / `GAINLOH`, from the DRAGEN ID (§4) | all four occur in production; the ID is the only reliable source |
 | `alternate` | `<DUP>` / `<DEL>` / `<LOH>` — both LOH spellings normalised (§4) | 4.2 writes `<DEL>,<DUP>`, 4.4 writes `<LOH>` |
 | `cnv_id` | keyed on `type`, not `alternate` | requires the widened UDF below |
-| `cn, cnf, cnq, mcn, mcnf, mcnq, maf, sd, as` | added, all nullable | ASCN fields: absent in 3.10.8, per-record in 4.2.4. `MAF=0` is the direct LOH marker |
+| `cn, cnf, cnq, mcn, mcnf, mcnq, maf, sd, ascn_as` | added, all nullable | ASCN fields: absent in 3.10.8, per-record in 4.2.4. `MAF=0` is the direct LOH marker. DRAGEN's FORMAT `AS` is stored as **`ascn_as`**: `as` is reserved in both Python and StarRocks/MySQL and would need quoting in every DDL, load-SQL and dbt call site |
 | `cipos` / `ciend` | kept, nullable | 3.10.8 declares but never populates them; 4.2.4 does not declare them at all |
 | `filter` | `VARCHAR(255)`, as in every other occurrence table | 22% of file A's rows are multi-valued, semicolon-joined |
 

--- a/radiant/tasks/vcf/cnv/somatic/occurrence.py
+++ b/radiant/tasks/vcf/cnv/somatic/occurrence.py
@@ -1,0 +1,257 @@
+import logging
+import math
+from collections.abc import Callable
+from typing import Any
+
+from cyvcf2 import Variant
+from pyiceberg.schema import NestedField, Schema
+from pyiceberg.types import BooleanType, FloatType, IntegerType, ListType, StringType
+
+from radiant.tasks.vcf.vcf_utils import calls_without_phased
+
+logger = logging.getLogger("airflow.task")
+
+SCHEMA: Schema = Schema(
+    NestedField(600, "part", IntegerType(), required=True),
+    NestedField(601, "seq_id", IntegerType(), required=True),
+    NestedField(602, "tenant_code", StringType(), required=True),
+    NestedField(603, "task_id", IntegerType(), required=True),
+    NestedField(604, "aliquot", StringType(), required=True),
+    NestedField(605, "chromosome", StringType(), required=True),
+    NestedField(606, "alternate", StringType(), required=True),
+    NestedField(607, "start", IntegerType(), required=True),
+    NestedField(608, "end", IntegerType(), required=True),
+    NestedField(609, "type", StringType(), required=True),
+    NestedField(610, "length", IntegerType(), required=True),
+    NestedField(611, "name", StringType(), required=True),
+    NestedField(612, "quality", FloatType(), required=False),
+    NestedField(613, "calls", ListType(700, IntegerType()), required=False),
+    NestedField(614, "filter", StringType(), required=False),
+    NestedField(615, "bc", IntegerType(), required=False),
+    NestedField(616, "pe", ListType(701, IntegerType()), required=False),
+    NestedField(617, "sm", FloatType(), required=False),
+    NestedField(618, "svtype", StringType(), required=False),
+    NestedField(619, "svlen", IntegerType(), required=False),
+    NestedField(620, "reflen", IntegerType(), required=False),
+    NestedField(621, "ciend", ListType(702, IntegerType()), required=False),
+    NestedField(622, "cipos", ListType(703, IntegerType()), required=False),
+    NestedField(623, "phased", BooleanType(), required=False),
+    # DRAGEN 4.2.4 allele-specific copy number (ASCN) fields. Absent altogether on 3.10.8 and
+    # declared-but-omitted per record on 4.2.4, hence all nullable and read defensively below.
+    NestedField(624, "cn", IntegerType(), required=False),
+    NestedField(625, "cnf", FloatType(), required=False),
+    NestedField(626, "cnq", FloatType(), required=False),
+    NestedField(627, "mcn", IntegerType(), required=False),
+    NestedField(628, "mcnf", FloatType(), required=False),
+    NestedField(629, "mcnq", FloatType(), required=False),
+    NestedField(630, "maf", FloatType(), required=False),
+    NestedField(631, "sd", FloatType(), required=False),
+    # DRAGEN spells this FORMAT field `AS`, which is a reserved word in both Python and
+    # StarRocks/MySQL; storing it under a prefixed name keeps every downstream call site unquoted.
+    NestedField(632, "ascn_as", IntegerType(), required=False),
+)
+
+GAIN = "GAIN"
+LOSS = "LOSS"
+CNLOH = "CNLOH"
+GAINLOH = "GAINLOH"
+
+CNV_TYPES = (GAIN, LOSS, CNLOH, GAINLOH)
+LOH_TYPES = (CNLOH, GAINLOH)
+
+ALT_DUP = "<DUP>"
+ALT_DEL = "<DEL>"
+ALT_LOH = "<LOH>"
+
+# What the stored `alternate` is, per resolved type. Deriving it from `type` rather than from the raw
+# ALT is what makes the two DRAGEN spellings of an LOH event produce the same row: VCF 4.2 writes
+# `<DEL>,<DUP>` and VCF 4.4 writes `<LOH>` for the same segment.
+ALTERNATE_BY_TYPE = {
+    GAIN: ALT_DUP,
+    LOSS: ALT_DEL,
+    CNLOH: ALT_LOH,
+    GAINLOH: ALT_LOH,
+}
+
+# `type` implied by the ALT alone, used only when the DRAGEN ID is unparseable. LOH is deliberately
+# absent: two ALTs (4.2) or `<LOH>` (4.4) say the event *is* LOH but not which kind.
+_TYPE_BY_ALT = {
+    (ALT_DUP,): GAIN,
+    (ALT_DEL,): LOSS,
+}
+_LOH_ALTS = ((ALT_LOH,), (ALT_DEL, ALT_DUP), (ALT_DUP, ALT_DEL))
+
+# htslib's "missing integer" bit pattern, which cyvcf2 surfaces verbatim.
+_INT32_MISSING = -(2**31)
+
+
+def resolve_cnv_type(record: Variant) -> str | None:
+    """Resolves the CNV type of a record, or `None` when the record must be skipped.
+
+    The DRAGEN ID (`DRAGEN:<TYPE>:<chr>:<start>-<end>`) is the primary and, in practice, the only
+    source: `CN`/`MCN` are either not emitted at all (DRAGEN 3.10.8) or omitted from the LOH record's
+    own FORMAT (4.2.4), and ALT cannot express `CNLOH` versus `GAINLOH`. This is a knowing coupling to
+    a vendor convention -- the VCF spec treats ID as optional -- accepted because nothing else in the
+    file can classify LOH.
+
+    An unrecognised ALT is skipped before the ID is even read: a type is only meaningful for an ALT we
+    understand, and `cnv_id` is a `NOT NULL` key column downstream, so a record we cannot classify must
+    never be persisted rather than degrade to an `UNKNOWN` row that fails the whole StarRocks load.
+
+    Args:
+        record (Variant): A `cyvcf2.Variant` object representing the CNV segment.
+
+    Returns:
+        str | None: One of `CNV_TYPES`, or `None` when the record should be skipped.
+
+    Raises:
+        ValueError: The ALT says the segment is LOH but the ID does not say which kind.
+    """
+    alts = tuple(record.ALT)
+    is_loh_alt = alts in _LOH_ALTS
+    if not is_loh_alt and alts not in _TYPE_BY_ALT:
+        return None
+
+    id_type = None
+    name = record.ID or ""
+    parts = name.split(":")
+    if len(parts) > 1 and parts[1] in CNV_TYPES:
+        id_type = parts[1]
+
+    if id_type is not None:
+        alt_implied = ALT_LOH if is_loh_alt else alts[0]
+        if ALTERNATE_BY_TYPE[id_type] != alt_implied:
+            logger.warning(
+                f"CNV record {record.CHROM}:{record.POS} has ID [{name}] typed {id_type} but ALT {list(alts)}; "
+                f"trusting the ID."
+            )
+        return id_type
+
+    if is_loh_alt:
+        # Both LOH spellings say only that heterozygosity was lost, never whether the copy number
+        # changed with it. Guessing would silently mislabel copy-neutral segments as gains.
+        raise ValueError(
+            f"CNV record {record.CHROM}:{record.POS} has an LOH ALT {list(alts)} but no parseable "
+            f"DRAGEN type in its ID [{name}]: cannot tell {CNLOH} from {GAINLOH}."
+        )
+
+    return _TYPE_BY_ALT[alts]
+
+
+def _format_value(record: Variant, key: str, cast: Callable[[Any], Any], sample_idx: int) -> Any:
+    """Reads one FORMAT value for a sample, tolerating both ways DRAGEN can leave it out.
+
+    `cyvcf2` distinguishes the two: a field declared in the header but absent from this record yields
+    `None`, while a field the header never declares raises `KeyError` (`Variant.format` resolves the
+    field's type through the header first). The ASCN fields hit both cases -- 3.10.8 declares none of
+    them, 4.2.4 declares them all and still omits `CN`/`MCN` from its LOH rows.
+
+    The cast is explicit so the value matches the Iceberg column even if a DRAGEN release declares the
+    field with a different type than we assume.
+    """
+    try:
+        values = record.format(key)
+    except KeyError:
+        return None
+    if values is None:
+        return None
+
+    value = values[sample_idx][0]
+    if value is None:
+        return None
+
+    # A third way to be empty: the field is in the record but written `.` for this sample. htslib
+    # hands that back as a sentinel rather than a null -- NaN for a float, INT32_MIN for an integer --
+    # which would otherwise be stored as a real measurement.
+    numeric = float(value)
+    if math.isnan(numeric) or numeric == _INT32_MISSING:
+        return None
+
+    return cast(value)
+
+
+def _format_list_value(record: Variant, key: str, sample_idx: int) -> list | None:
+    """Same tolerance as `_format_value`, for a FORMAT field with several values per sample."""
+    try:
+        values = record.format(key)
+    except KeyError:
+        return None
+    return None if values is None else values[sample_idx].tolist()
+
+
+def process_occurrence(
+    record: Variant,
+    part: int,
+    seq_id: int,
+    tenant_code: str,
+    task_id: int,
+    aliquot: str,
+    sample_idx: int,
+    cnv_type: str,
+) -> dict:
+    """Processes a somatic CNV occurrence and extracts relevant information for the tumor sample.
+
+    Args:
+        record (Variant): A `cyvcf2.Variant` object representing the CNV segment to process.
+        part (int): The partition the task belongs to.
+        seq_id (int): The sequencing experiment id.
+        tenant_code (str): The tenant the experiment belongs to.
+        task_id (int): The task that produced the file.
+        aliquot (str): The aliquot of the sample being processed.
+        sample_idx (int): The index of the sample in the VCF record.
+        cnv_type (str): The type resolved by `resolve_cnv_type`, passed in so an unclassifiable
+            record can be skipped before a row is ever built.
+
+    Returns:
+        dict: A dictionary containing the processed occurrence data.
+    """
+    rlen = record.INFO.get("REFLEN")
+    start = record.POS
+    end = record.end
+    calls = calls_without_phased(record, sample_idx)
+
+    # `SVLEN` is declared `Number=.` and carries one value per ALT allele, so an LOH record reads
+    # `SVLEN=-220050,220050` -- a tuple against a scalar column. The alleles describe the same
+    # segment, so the first value is the segment length.
+    svlen = record.INFO.get("SVLEN", None)
+    if isinstance(svlen, tuple | list):
+        svlen = svlen[0] if svlen else None
+
+    occurrence = {
+        "part": part,
+        "seq_id": seq_id,
+        "tenant_code": tenant_code,
+        "task_id": task_id,
+        "aliquot": aliquot,
+        "chromosome": record.CHROM.replace("chr", ""),
+        "alternate": ALTERNATE_BY_TYPE[cnv_type],
+        "start": start,
+        "end": end,
+        "type": cnv_type,
+        "length": end - start,
+        "name": record.ID,
+        "quality": float(record.QUAL) if record.QUAL is not None else None,
+        "filter": record.FILTER or "PASS",
+        "reflen": rlen,
+        "svlen": svlen,
+        # VCF 4.4 may drop `SVTYPE` entirely; every record in these files is a CNV segment.
+        "svtype": record.INFO.get("SVTYPE", "CNV"),
+        "ciend": record.INFO.get("CIEND", None),
+        "cipos": record.INFO.get("CIPOS", None),
+        "bc": _format_value(record, "BC", int, sample_idx),
+        "pe": _format_list_value(record, "PE", sample_idx),
+        "sm": _format_value(record, "SM", float, sample_idx),
+        "calls": calls,
+        "phased": record.gt_phases[sample_idx],
+        "cn": _format_value(record, "CN", int, sample_idx),
+        "cnf": _format_value(record, "CNF", float, sample_idx),
+        "cnq": _format_value(record, "CNQ", float, sample_idx),
+        "mcn": _format_value(record, "MCN", int, sample_idx),
+        "mcnf": _format_value(record, "MCNF", float, sample_idx),
+        "mcnq": _format_value(record, "MCNQ", float, sample_idx),
+        "maf": _format_value(record, "MAF", float, sample_idx),
+        "sd": _format_value(record, "SD", float, sample_idx),
+        "ascn_as": _format_value(record, "AS", int, sample_idx),
+    }
+
+    return occurrence

--- a/radiant/tasks/vcf/cnv/somatic/process.py
+++ b/radiant/tasks/vcf/cnv/somatic/process.py
@@ -1,0 +1,174 @@
+import logging
+import sys
+import tempfile
+
+import pyarrow as pa
+from cyvcf2 import VCF
+from pyiceberg.catalog import load_catalog
+
+from radiant.tasks.tracing.trace import get_tracer
+from radiant.tasks.utils import download_s3_file
+from radiant.tasks.vcf.cnv.somatic.occurrence import process_occurrence, resolve_cnv_type
+from radiant.tasks.vcf.experiment import (
+    TUMOR_ONLY_VARIANT_CALLING_TASK,
+    BaseTask,
+    TumorOnlyVariantCallingTask,
+)
+
+logger = logging.getLogger("airflow.task")
+tracer = get_tracer(__name__)
+
+
+def validate_task_is_tumor_only(task: BaseTask, vcf_file_samples: list[str]) -> None:
+    """Holds the file to what the task type claims.
+
+    `tumor_only_variant_calling` asserts a single tumoral sample, but only
+    `gather_additional_args` enforces that, and only on the `build_task_from_rows` path -- the K8s and
+    ECS containers reach this module through `model_validate` on a dict, which skips it. So the checks
+    are repeated here, where the file itself is available.
+
+    The sample count is the only one that catches a genuinely tumor-normal file mislabelled upstream.
+    Tumor-normal CNV is out of scope, so all three fail loudly rather than half-succeed by writing a
+    normal sample's depths as tumor values.
+    """
+    if len(task.experiments) != 1:
+        raise ValueError(
+            f"Task {task.task_id} is `{TUMOR_ONLY_VARIANT_CALLING_TASK}` but carries "
+            f"{len(task.experiments)} experiments ({[exp.aliquot for exp in task.experiments]}); "
+            f"expected exactly one tumoral sample."
+        )
+
+    experiment = task.experiments[0]
+    if experiment.histology_type != "tumoral":
+        raise ValueError(
+            f"Task {task.task_id} is `{TUMOR_ONLY_VARIANT_CALLING_TASK}` but its experiment "
+            f"{experiment.aliquot} has histology_type '{experiment.histology_type}', expected 'tumoral'."
+        )
+
+    if len(vcf_file_samples) != 1:
+        raise ValueError(
+            f"Task {task.task_id} is `{TUMOR_ONLY_VARIANT_CALLING_TASK}` but its VCF "
+            f"{task.cnv_vcf_filepath} declares {len(vcf_file_samples)} samples: {vcf_file_samples} -- "
+            f"likely a tumor-normal file mislabelled upstream."
+        )
+
+
+# Required decoration because cyvcf2 doesn't fail when it encounters an error, it just prints to stderr.
+# Airflow will treat the task as successful if the error is not captured properly.
+# @capture_libc_stderr_and_check_errors(error_patterns=["[E::"])
+def process_tasks(
+    tasks: list[BaseTask],
+    catalog_name="default",
+    namespace="radiant",
+    vcf_threads=None,
+    catalog_properties=None,
+):
+    with tracer.start_as_current_span("process_tasks"):
+        occurrences_partition_commit = []
+
+        occurrences_table_name = f"{namespace}.somatic_cnv_occurrence"
+        if not tasks:
+            # Overwriting with an empty buffer would wipe the table; refuse the no-op.
+            logger.warning(f"No somatic CNV tasks to process; skipping overwrite of {occurrences_table_name}")
+            return {occurrences_table_name: occurrences_partition_commit}
+
+        catalog = (
+            load_catalog(catalog_name, **catalog_properties) if catalog_properties else load_catalog(catalog_name)
+        )
+
+        occurrence_table = catalog.load_table(occurrences_table_name)
+        occurrence_buffer = []
+        for task in tasks:
+            if not task.cnv_vcf_filepath:
+                logger.info(f"No somatic CNV VCF filepath for task [{task.task_id}] skipping")
+                continue
+
+            vcf = VCF(task.cnv_vcf_filepath, strict_gt=True, threads=vcf_threads)
+            # The full sample list has to be captured before narrowing: `set_samples` rewrites both
+            # `vcf.samples` and `vcf.raw_header` to the subset, so this is the only chance to see that
+            # a one-aliquot task was handed a tumor-normal file.
+            vcf_file_samples = list(vcf.samples)
+            validate_task_is_tumor_only(task, vcf_file_samples)
+
+            vcf.set_samples([exp.aliquot for exp in task.experiments])
+            if not vcf.samples:
+                raise ValueError(
+                    f"Task {task.task_id} has no matching samples in the somatic CNV VCF file "
+                    f"{task.cnv_vcf_filepath}; its samples are {vcf_file_samples}."
+                )
+
+            logger.info(
+                f"Starting processing somatic CNV VCF for task {task.task_id} with file {task.cnv_vcf_filepath}"
+            )
+            for exp in task.experiments:
+                logger.info(f"Process aliquot: {exp.aliquot} (seq_id: {exp.seq_id})")
+                sample_idx = vcf.samples.index(exp.aliquot)
+                with tracer.start_as_current_span(f"vcf_task_{task.task_id}_{exp.seq_id}"):
+                    for record in vcf:
+                        if not record.ALT:
+                            # Reference segments (`DRAGEN:REF:...`, ALT `.`) carry no event.
+                            logger.debug(f"Skipping record with no ALT: {record.CHROM}:{record.POS}-{record.end}")
+                            continue
+
+                        # An ALT the mapping does not recognise would produce a NULL `cnv_id` against a
+                        # NOT NULL key column and fail the whole StarRocks load, not just its own row.
+                        cnv_type = resolve_cnv_type(record)
+                        if cnv_type is None:
+                            logger.warning(
+                                f"Skipping unclassifiable CNV record {record.CHROM}:{record.POS}-{record.end} "
+                                f"[{record.ID}] with ALT {record.ALT}"
+                            )
+                            continue
+
+                        occurrence = process_occurrence(
+                            record,
+                            task.part,
+                            exp.seq_id,
+                            exp.tenant_code,
+                            task.task_id,
+                            exp.aliquot,
+                            sample_idx,
+                            cnv_type,
+                        )
+                        occurrence_buffer.append(occurrence)
+            vcf.close()
+        df = pa.Table.from_pylist(occurrence_buffer, schema=occurrence_table.schema().as_arrow())
+        occurrence_table.overwrite(df)
+        logger.info(f"✅ Table {occurrences_table_name} overwritten")
+
+        return {occurrences_table_name: occurrences_partition_commit}
+
+
+def import_somatic_cnv_vcf(tasks: list[dict], namespace: str) -> None:
+    """Extracts every somatic tumor-only CNV VCF of a part into the somatic CNV occurrence table.
+
+    A failed download propagates, unlike germline CNV, which logs and skips it (SJRA-1784). A skip is
+    invisible downstream: the task still succeeds, so `update_sequencing_experiments` marks the
+    experiment ingested and the incremental delta never offers it again. Failing costs a retry of the
+    part; skipping costs the data permanently.
+    """
+    logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler(sys.stdout)])
+    logger = logging.getLogger(__name__)
+
+    updated_tasks = []
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for task in tasks:
+            if task.get("task_type") != TUMOR_ONLY_VARIANT_CALLING_TASK:
+                continue
+
+            if not task.get("cnv_vcf_filepath"):
+                # The staging view's `scnv` gate should always supply the URL; a missing one is a
+                # tumor-only task with nothing to extract, not a failure.
+                logger.info(f"No somatic CNV VCF filepath for task [{task.get('task_id')}] skipping")
+                continue
+
+            logger.info(f"Downloading somatic CNV VCF from {task['cnv_vcf_filepath']} to a temporary directory")
+            cnv_vcf_local = download_s3_file(task["cnv_vcf_filepath"], tmpdir, randomize_filename=True)
+            logger.info(f"Downloaded somatic CNV VCF to {cnv_vcf_local}")
+            task["cnv_vcf_filepath"] = cnv_vcf_local
+
+            task = TumorOnlyVariantCallingTask.model_validate(task)
+            updated_tasks.append(task)
+
+        logger.info("Starting somatic CNV VCF processing for all tasks")
+        process_tasks(updated_tasks, namespace=namespace, vcf_threads=4)

--- a/tests/resources/test_somatic_cnv.vcf
+++ b/tests/resources/test_somatic_cnv.vcf
@@ -1,0 +1,45 @@
+##fileformat=VCFv4.2
+##ALT=<ID=CNV,Description="Copy number variant region">
+##ALT=<ID=DEL,Description="Deletion relative to the reference">
+##ALT=<ID=DUP,Description="Region of elevated copy number relative to the reference">
+##ALT=<ID=LOH,Description="Loss of heterozygosity">
+##contig=<ID=chr1,length=248956422>
+##contig=<ID=chr2,length=242193529>
+##contig=<ID=chrX,length=156040895>
+##reference=file:///ephemeral/reference/index
+##INFO=<ID=REFLEN,Number=1,Type=Integer,Description="Number of REF positions included in this record">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END">
+##INFO=<ID=HET,Number=0,Type=Flag,Description="Segment is heterogeneous">
+##FILTER=<ID=cnvQual,Description="CNV with quality below threshold">
+##FILTER=<ID=cnvLength,Description="CNV with length below 10000">
+##FILTER=<ID=binCount,Description="CNV with low bin count">
+##FILTER=<ID=segmentMean,Description="CNV with copy ratio within +/- 0.2 of 1.0">
+##FILTER=<ID=cnvBinSupportRatio,Description="CNV with low supporting number of bins with respect to event length">
+##FILTER=<ID=cnvCopyRatio,Description="CNV with copy ratio within +/- 0.2 of 1.0">
+##FILTER=<ID=LoDFail,Description="CNV below the limit of detection">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=SM,Number=1,Type=Float,Description="Linear copy ratio of the segment mean">
+##FORMAT=<ID=SD,Number=1,Type=Float,Description="Standard deviation of the segment mean">
+##FORMAT=<ID=BC,Number=1,Type=Integer,Description="Number of bins in the region">
+##FORMAT=<ID=PE,Number=2,Type=Integer,Description="Number of improperly paired end reads at start and stop breakpoints">
+##FORMAT=<ID=CN,Number=1,Type=Integer,Description="Estimated copy number">
+##FORMAT=<ID=CNF,Number=1,Type=Float,Description="Floating point copy number estimate">
+##FORMAT=<ID=CNQ,Number=1,Type=Float,Description="Phred-scaled quality of the copy number call">
+##FORMAT=<ID=MCN,Number=1,Type=Integer,Description="Estimated minor haplotype copy number">
+##FORMAT=<ID=MCNF,Number=1,Type=Float,Description="Floating point minor haplotype copy number estimate">
+##FORMAT=<ID=MCNQ,Number=1,Type=Float,Description="Phred-scaled quality of the minor haplotype copy number call">
+##FORMAT=<ID=MAF,Number=1,Type=Float,Description="MAP estimate of minor allele frequency">
+##FORMAT=<ID=AS,Number=1,Type=Integer,Description="Number of allele-specific sites used in the segment">
+##DRAGENVersion=<ID=dragen,Version="SW: 07.021.732.4.2.4, HW: 07.021.732">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TCRBOA6-T
+chr1	450730	DRAGEN:LOSS:chr1:450731-7249626	N	<DEL>	128	cnvCopyRatio;LoDFail	SVTYPE=CNV;SVLEN=-6798896;END=7249626;REFLEN=6798896	GT:SM:SD:BC:PE:CN:CNF:CNQ:MCN:MCNF:MCNQ:MAF:AS	0/1:1.04404:702.9:1979:25,7:1:1.02:44.1:0:0.01:60.3:0.02:1979
+chr1	6667699	DRAGEN:CNLOH:chr1:6667700-6887749	N	<DEL>,<DUP>	3	cnvQual;segmentMean	SVTYPE=CNV;SVLEN=-220050,220050;END=6887749;REFLEN=220050;HET	GT:SM:SD:MAF:BC:AS:PE	1/2:1.018696:702.9:0:20:1:4,0
+chr1	124941718	DRAGEN:GAIN:chr1:124941719-124975661	N	<DUP>	36	PASS	SVTYPE=CNV;SVLEN=33943;END=124975661;REFLEN=33943;CIPOS=-150,150;CIEND=-200,200	GT:SM:SD:BC:PE:CN:CNF:CNQ:MCN:MCNF:MCNQ:MAF:AS	0/1:1.43012:120.5:20:5,30:3:3.12:180.4:1:1.04:95.2:0.34:12
+chr2	31000000	DRAGEN:GAINLOH:chr2:31000001-31500000	N	<LOH>	41	PASS	SVTYPE=CNV;SVLEN=500000;END=31500000;REFLEN=500000	GT:SM:SD:MAF:BC:AS:PE	1/2:1.512:88.4:0:64:9:12,3
+chr2	80000000	DRAGEN:LOSS:chr2:80000001-80400000	N	<DEL>	52	PASS	SVTYPE=CNV;SVLEN=-400000;END=80400000;REFLEN=400000	GT:SM:SD:BC:PE:CN:CNF:CNQ:MCN:MCNF:MCNQ:MAF:AS	0/1:0.51:.:48:8,2:.:.:.:.:.:.:.:.
+chrX	9000000	DRAGEN:REF:chrX:9000001-9100000	N	.	21	PASS	SVTYPE=CNV;END=9100000;REFLEN=100000	GT:SM:SD:BC:PE	0/0:1.001:12.4:10:0,0
+chrX	154548409	DRAGEN:GAIN:chrX:154548410-154554958	N	<CNV>	65	cnvLength	SVTYPE=CNV;SVLEN=6549;END=154554958;REFLEN=6549	GT:SM:SD:BC:PE	1/1:2.01527:41.2:5:28,4

--- a/tests/resources/test_somatic_cnv_no_ascn.vcf
+++ b/tests/resources/test_somatic_cnv_no_ascn.vcf
@@ -1,0 +1,24 @@
+##fileformat=VCFv4.2
+##ALT=<ID=CNV,Description="Copy number variant region">
+##ALT=<ID=DEL,Description="Deletion relative to the reference">
+##ALT=<ID=DUP,Description="Region of elevated copy number relative to the reference">
+##contig=<ID=chr1,length=248956422>
+##reference=file:///ephemeral/reference/index
+##INFO=<ID=REFLEN,Number=1,Type=Integer,Description="Number of REF positions included in this record">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##INFO=<ID=CIPOS,Number=2,Type=Integer,Description="Confidence interval around POS">
+##INFO=<ID=CIEND,Number=2,Type=Integer,Description="Confidence interval around END">
+##FILTER=<ID=cnvQual,Description="CNV with quality below 10">
+##FILTER=<ID=cnvBinSupportRatio,Description="CNV with low supporting number of bins with respect to event length">
+##FILTER=<ID=cnvCopyRatio,Description="CNV with copy ratio within +/- 0.2 of 1.0">
+##FILTER=<ID=LoDFail,Description="CNV below the limit of detection">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=SM,Number=1,Type=Float,Description="Linear copy ratio of the segment mean">
+##FORMAT=<ID=BC,Number=1,Type=Integer,Description="Number of bins in the region">
+##FORMAT=<ID=PE,Number=2,Type=Integer,Description="Number of improperly paired end reads at start and stop breakpoints">
+##DRAGENVersion=<ID=dragen,Version="SW: 05.021.510.3.10.8, HW: 05.021.510">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TCRBOA7-T
+chr1	450730	DRAGEN:LOSS:chr1:450731-7249626	N	<DEL>	128	cnvCopyRatio;LoDFail	SVTYPE=CNV;SVLEN=-6798896;END=7249626;REFLEN=6798896	GT:SM:BC:PE	0/1:1.04404:1979:25,7
+chr1	124941718	DRAGEN:GAIN:chr1:124941719-124975661	N	<DUP>	36	PASS	END=124975661;REFLEN=33943	GT:SM:BC:PE	0/1:1.43012:20:5,30

--- a/tests/unit/vcf/somatic/test_somatic_cnv_occurrences.py
+++ b/tests/unit/vcf/somatic/test_somatic_cnv_occurrences.py
@@ -1,0 +1,208 @@
+from types import SimpleNamespace
+
+import pytest
+
+from radiant.tasks.vcf.cnv.somatic.occurrence import process_occurrence, resolve_cnv_type
+from tests.unit.vcf.vcf_test_utils import vcf
+
+SOMATIC_CNV_VCF = "test_somatic_cnv.vcf"
+SOMATIC_CNV_NO_ASCN_VCF = "test_somatic_cnv_no_ascn.vcf"
+
+ASCN_FIELDS = ("cn", "cnf", "cnq", "mcn", "mcnf", "mcnq", "maf", "sd", "ascn_as")
+
+
+def records_by_id(vcf_filename: str) -> dict[str, object]:
+    """Indexes a fixture's records by their DRAGEN ID, so tests don't depend on row order."""
+    with vcf(vcf_filename) as vcf_file:
+        return {record.ID: record for record in vcf_file}
+
+
+def occurrence(record, **overrides) -> dict:
+    args = {
+        "part": 1,
+        "seq_id": 64,
+        "tenant_code": "tenant1",
+        "task_id": 70,
+        "aliquot": "TCRBOA6-T",
+        "sample_idx": 0,
+        "cnv_type": resolve_cnv_type(record),
+    } | overrides
+    return process_occurrence(record, **args)
+
+
+def fake_record(alts: list[str], name: str | None = "DRAGEN:GAIN:chr1:1-2") -> SimpleNamespace:
+    """`resolve_cnv_type` only reads ALT, ID and the coordinates it logs, so a stub is enough."""
+    return SimpleNamespace(ALT=alts, ID=name, CHROM="chr1", POS=100)
+
+
+@pytest.fixture(scope="module")
+def cnv_records() -> dict:
+    return records_by_id(SOMATIC_CNV_VCF)
+
+
+@pytest.fixture(scope="module")
+def no_ascn_records() -> dict:
+    return records_by_id(SOMATIC_CNV_NO_ASCN_VCF)
+
+
+@pytest.mark.parametrize(
+    "record_id,expected_type",
+    [
+        ("DRAGEN:GAIN:chr1:124941719-124975661", "GAIN"),
+        ("DRAGEN:LOSS:chr1:450731-7249626", "LOSS"),
+        ("DRAGEN:CNLOH:chr1:6667700-6887749", "CNLOH"),
+        ("DRAGEN:GAINLOH:chr2:31000001-31500000", "GAINLOH"),
+    ],
+)
+def test_resolve_cnv_type_from_dragen_id(cnv_records, record_id, expected_type):
+    """All four types come off the ID; ALT cannot express the two LOH ones at all."""
+    assert resolve_cnv_type(cnv_records[record_id]) == expected_type
+
+
+def test_resolve_cnv_type_skips_reference_segment(cnv_records):
+    assert resolve_cnv_type(cnv_records["DRAGEN:REF:chrX:9000001-9100000"]) is None
+
+
+def test_resolve_cnv_type_skips_unrecognised_alt_even_with_parseable_id(cnv_records):
+    """A `<CNV>` ALT would produce a NULL `cnv_id` against a NOT NULL key column and fail the whole
+    StarRocks load, so the ALT guard runs ahead of the ID."""
+    assert resolve_cnv_type(cnv_records["DRAGEN:GAIN:chrX:154548410-154554958"]) is None
+
+
+@pytest.mark.parametrize("alts,expected_type", [(["<DUP>"], "GAIN"), (["<DEL>"], "LOSS")])
+def test_resolve_cnv_type_falls_back_to_alt(alts, expected_type):
+    """Without a parseable ID, ALT still settles the non-LOH cases."""
+    assert resolve_cnv_type(fake_record(alts, name=".")) == expected_type
+    assert resolve_cnv_type(fake_record(alts, name=None)) == expected_type
+
+
+@pytest.mark.parametrize("alts", [["<LOH>"], ["<DEL>", "<DUP>"]])
+def test_resolve_cnv_type_raises_on_loh_without_parseable_id(alts):
+    """Both LOH spellings say heterozygosity was lost, never whether copy number changed with it."""
+    with pytest.raises(ValueError, match="CNLOH"):
+        resolve_cnv_type(fake_record(alts, name="segment_42"))
+
+
+@pytest.mark.parametrize(
+    "alts,name,expected_type",
+    [
+        (["<DEL>"], "DRAGEN:GAIN:chr1:1-2", "GAIN"),
+        # A caller that splits multi-allelic records would hand us one LOH haplotype at a time.
+        (["<DUP>"], "DRAGEN:CNLOH:chr1:1-2", "CNLOH"),
+        (["<DEL>", "<DUP>"], "DRAGEN:GAIN:chr1:1-2", "GAIN"),
+    ],
+)
+def test_resolve_cnv_type_trusts_the_id_over_a_disagreeing_alt(caplog, alts, name, expected_type):
+    assert resolve_cnv_type(fake_record(alts, name=name)) == expected_type
+    assert "trusting the ID" in caplog.text
+
+
+def test_process_occurrence_gain(cnv_records):
+    occ = occurrence(cnv_records["DRAGEN:GAIN:chr1:124941719-124975661"])
+
+    assert occ["part"] == 1
+    assert occ["seq_id"] == 64
+    assert occ["tenant_code"] == "tenant1"
+    assert occ["task_id"] == 70
+    assert occ["aliquot"] == "TCRBOA6-T"
+    assert occ["chromosome"] == "1"
+    assert occ["type"] == "GAIN"
+    assert occ["alternate"] == "<DUP>"
+    assert occ["start"] == 124941718
+    assert occ["end"] == 124975661
+    assert occ["length"] == 33943
+    assert occ["reflen"] == 33943
+    assert occ["svlen"] == 33943
+    assert occ["svtype"] == "CNV"
+    assert occ["name"] == "DRAGEN:GAIN:chr1:124941719-124975661"
+    assert occ["quality"] == pytest.approx(36.0)
+    assert occ["filter"] == "PASS"
+    assert occ["calls"] == [0, 1]
+    assert not occ["phased"]
+    assert occ["bc"] == 20
+    assert occ["pe"] == [5, 30]
+    assert occ["sm"] == pytest.approx(1.43012, rel=1e-5)
+    assert tuple(occ["cipos"]) == (-150, 150)
+    assert tuple(occ["ciend"]) == (-200, 200)
+    # The full DRAGEN 4.2.4 ASCN block, present on this record.
+    assert occ["cn"] == 3
+    assert occ["cnf"] == pytest.approx(3.12, rel=1e-5)
+    assert occ["cnq"] == pytest.approx(180.4, rel=1e-5)
+    assert occ["mcn"] == 1
+    assert occ["mcnf"] == pytest.approx(1.04, rel=1e-5)
+    assert occ["mcnq"] == pytest.approx(95.2, rel=1e-5)
+    assert occ["maf"] == pytest.approx(0.34, rel=1e-5)
+    assert occ["sd"] == pytest.approx(120.5, rel=1e-5)
+    assert occ["ascn_as"] == 12
+
+
+def test_process_occurrence_keeps_multi_valued_filter(cnv_records):
+    """22% of the measured file's rows carry two filters, semicolon-joined."""
+    occ = occurrence(cnv_records["DRAGEN:LOSS:chr1:450731-7249626"])
+
+    assert occ["type"] == "LOSS"
+    assert occ["alternate"] == "<DEL>"
+    assert occ["filter"] == "cnvCopyRatio;LoDFail"
+    assert occ["svlen"] == -6798896
+    assert occ["length"] == 6798896
+
+
+def test_process_occurrence_legacy_loh(cnv_records):
+    """VCF 4.2 spells an LOH event as multi-allelic `<DEL>,<DUP>`, which brings three traps at once:
+    a per-allele `SVLEN`, a `1/2` genotype, and `CN`/`MCN` missing from the record's own FORMAT."""
+    occ = occurrence(cnv_records["DRAGEN:CNLOH:chr1:6667700-6887749"])
+
+    assert occ["type"] == "CNLOH"
+    assert occ["alternate"] == "<LOH>"
+    # Not the `(-220050, 220050)` tuple `INFO.get` returns for a per-allele value.
+    assert occ["svlen"] == -220050
+    assert occ["length"] == 220050
+    assert occ["calls"] == [1, 2]
+    assert occ["cn"] is None
+    assert occ["mcn"] is None
+    assert occ["cnf"] is None
+    assert occ["mcnf"] is None
+    # `MAF=0` is the direct LOH marker, and must survive as 0.0 rather than being read as missing.
+    assert occ["maf"] == pytest.approx(0.0)
+    assert occ["ascn_as"] == 1
+
+
+def test_both_loh_spellings_produce_the_same_row_shape(cnv_records):
+    """The point of keying on `type` rather than ALT: an upstream DRAGEN flag changes the spelling of
+    an LOH event, and must not change the row we store."""
+    legacy = occurrence(cnv_records["DRAGEN:CNLOH:chr1:6667700-6887749"])
+    current = occurrence(cnv_records["DRAGEN:GAINLOH:chr2:31000001-31500000"])
+
+    assert legacy["alternate"] == current["alternate"] == "<LOH>"
+    assert legacy["type"] == "CNLOH"
+    assert current["type"] == "GAINLOH"
+
+
+def test_process_occurrence_with_dot_valued_ascn_fields(cnv_records):
+    """A field written `.` for the sample is a third way to be empty, and the one that does not
+    announce itself: htslib returns NaN or INT32_MIN, which would be stored as a measurement."""
+    occ = occurrence(cnv_records["DRAGEN:LOSS:chr2:80000001-80400000"])
+
+    assert all(occ[field] is None for field in ASCN_FIELDS)
+    assert occ["sm"] == pytest.approx(0.51, rel=1e-5)
+    assert occ["bc"] == 48
+
+
+def test_process_occurrence_without_ascn_fields(no_ascn_records):
+    """DRAGEN 3.10.8 declares no ASCN field at all, so reading one raises `KeyError` in cyvcf2 rather
+    than returning None -- the whole reason for the defensive read."""
+    occ = occurrence(no_ascn_records["DRAGEN:LOSS:chr1:450731-7249626"], aliquot="TCRBOA7-T")
+
+    assert occ["type"] == "LOSS"
+    assert all(occ[field] is None for field in ASCN_FIELDS)
+    assert occ["bc"] == 1979
+    assert occ["pe"] == [25, 7]
+    assert occ["sm"] == pytest.approx(1.04404, rel=1e-5)
+
+
+def test_process_occurrence_defaults_svtype_when_absent(no_ascn_records):
+    """VCF 4.4 may omit `SVTYPE`; every record in these files is a CNV segment."""
+    occ = occurrence(no_ascn_records["DRAGEN:GAIN:chr1:124941719-124975661"], aliquot="TCRBOA7-T")
+
+    assert occ["svtype"] == "CNV"
+    assert occ["svlen"] is None

--- a/tests/unit/vcf/somatic/test_somatic_cnv_process.py
+++ b/tests/unit/vcf/somatic/test_somatic_cnv_process.py
@@ -1,0 +1,163 @@
+from unittest.mock import patch
+
+import pytest
+
+from radiant.tasks.utils import S3DownloadError
+from radiant.tasks.vcf.cnv.somatic import process as cnv_process
+from radiant.tasks.vcf.experiment import (
+    ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK,
+    TUMOR_ONLY_VARIANT_CALLING_TASK,
+    Experiment,
+    TumorOnlyVariantCallingTask,
+)
+from tests.unit.vcf.vcf_test_utils import RESOURCES_DIR
+
+
+def _experiment(seq_id: int = 64, aliquot: str = "TCRBOA6-T", histology_type: str = "tumoral") -> Experiment:
+    return Experiment(
+        seq_id=seq_id,
+        patient_id=62,
+        aliquot=aliquot,
+        tenant_code="tenant1",
+        family_role="proband",
+        affected_status="affected",
+        sex="female",
+        experimental_strategy="wgs",
+        request_priority="routine",
+        histology_type=histology_type,
+    )
+
+
+def _task(experiments: list[Experiment] | None = None) -> TumorOnlyVariantCallingTask:
+    return TumorOnlyVariantCallingTask(
+        task_id=70,
+        part=0,
+        analysis_type="somatic",
+        deleted=False,
+        experiments=experiments if experiments is not None else [_experiment()],
+        cnv_vcf_filepath="/tmp/tumor_only.cnv.vcf.gz",
+    )
+
+
+def _task_dict(task_id: int, filepath: str | None, task_type: str = TUMOR_ONLY_VARIANT_CALLING_TASK) -> dict:
+    return {
+        "task_id": task_id,
+        "task_type": task_type,
+        "cnv_vcf_filepath": filepath,
+    }
+
+
+def test_validate_task_is_tumor_only_accepts_single_tumoral_sample():
+    cnv_process.validate_task_is_tumor_only(_task(), ["TCRBOA6-T"])
+
+
+def test_validate_task_is_tumor_only_rejects_two_experiments():
+    """Two aliquots on the task means a tumor-normal analysis mislabelled upstream."""
+    task = _task([_experiment(), _experiment(seq_id=65, aliquot="TCRBOA6-N", histology_type="normal")])
+
+    with pytest.raises(ValueError, match="2 experiments"):
+        cnv_process.validate_task_is_tumor_only(task, ["TCRBOA6-T"])
+
+
+def test_validate_task_is_tumor_only_rejects_non_tumoral_experiment():
+    """A normal-only task would otherwise write normal depths as tumor values."""
+    task = _task([_experiment(histology_type="normal")])
+
+    with pytest.raises(ValueError, match="histology_type 'normal'"):
+        cnv_process.validate_task_is_tumor_only(task, ["TCRBOA6-T"])
+
+
+def test_validate_task_is_tumor_only_rejects_multi_sample_vcf():
+    """The only check that catches a genuinely tumor-normal *file*: the task looks tumor-only because
+    its normal experiment never registered upstream, but the VCF still carries both samples."""
+    with pytest.raises(ValueError, match="declares 2 samples"):
+        cnv_process.validate_task_is_tumor_only(_task(), ["TCRBOA6-T", "TCRBOA6-N"])
+
+
+def test_process_tasks_refuses_to_overwrite_with_an_empty_buffer():
+    """No tasks must not wipe the table, and must not need a catalog to decide that."""
+    with patch.object(cnv_process, "load_catalog") as mock_load_catalog:
+        res = cnv_process.process_tasks([], namespace="radiant")
+
+    mock_load_catalog.assert_not_called()
+    assert res == {"radiant.somatic_cnv_occurrence": []}
+
+
+def test_process_tasks_buffers_only_classifiable_records():
+    """The reference segment (ALT `.`) and the `<CNV>` segment must never reach the table: both would
+    produce a NULL `cnv_id` against a NOT NULL key column and fail the whole StarRocks load."""
+    task = _task()
+    task = task.model_copy(update={"cnv_vcf_filepath": str(RESOURCES_DIR / "test_somatic_cnv.vcf")})
+
+    with (
+        patch.object(cnv_process, "load_catalog"),
+        patch.object(cnv_process, "pa") as mock_pa,
+    ):
+        cnv_process.process_tasks([task], namespace="radiant")
+
+    buffered = mock_pa.Table.from_pylist.call_args.args[0]
+    assert [(occ["type"], occ["alternate"]) for occ in buffered] == [
+        ("LOSS", "<DEL>"),
+        ("CNLOH", "<LOH>"),
+        ("GAIN", "<DUP>"),
+        ("GAINLOH", "<LOH>"),
+        ("LOSS", "<DEL>"),
+    ]
+    assert {occ["seq_id"] for occ in buffered} == {64}
+    assert {occ["tenant_code"] for occ in buffered} == {"tenant1"}
+    assert {occ["task_id"] for occ in buffered} == {70}
+
+
+def test_import_somatic_cnv_vcf_processes_only_tumor_only_tasks():
+    tasks = [
+        _task_dict(1, "s3://bucket/germline.cnv.vcf.gz", task_type=ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK),
+        _task_dict(2, "s3://bucket/tumor_only.cnv.vcf.gz"),
+    ]
+
+    with (
+        patch.object(cnv_process, "download_s3_file", return_value="/tmp/local.cnv.vcf.gz"),
+        patch.object(cnv_process.TumorOnlyVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+    ):
+        cnv_process.import_somatic_cnv_vcf(tasks, namespace="radiant")
+
+    processed = mock_process.call_args.args[0]
+    assert [t["task_id"] for t in processed] == [2]
+    assert processed[0]["cnv_vcf_filepath"] == "/tmp/local.cnv.vcf.gz"
+
+
+def test_import_somatic_cnv_vcf_skips_task_without_filepath():
+    """`cnv_vcf_filepath` is nullable on the model, and a missing URL is nothing to extract -- not a
+    reason to abort the other tasks of the part."""
+    tasks = [_task_dict(1, None), _task_dict(2, "s3://bucket/tumor_only.cnv.vcf.gz")]
+
+    with (
+        patch.object(cnv_process, "download_s3_file", return_value="/tmp/local.cnv.vcf.gz"),
+        patch.object(cnv_process.TumorOnlyVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+    ):
+        cnv_process.import_somatic_cnv_vcf(tasks, namespace="radiant")
+
+    processed = mock_process.call_args.args[0]
+    assert [t["task_id"] for t in processed] == [2]
+
+
+def test_import_somatic_cnv_vcf_propagates_download_failure():
+    """Unlike germline CNV (SJRA-1784), a failed download must not be swallowed: the task would
+    succeed, the experiment would be marked ingested, and the delta would never offer it again."""
+    tasks = [_task_dict(1, "s3://bucket/bad.cnv.vcf.gz"), _task_dict(2, "s3://bucket/good.cnv.vcf.gz")]
+
+    def fake_download(s3_path, _tmpdir, randomize_filename=False):
+        if s3_path == "s3://bucket/bad.cnv.vcf.gz":
+            raise S3DownloadError(f"Failed to download S3 file {s3_path}")
+        return "/tmp/good.cnv.vcf.gz"
+
+    with (
+        patch.object(cnv_process, "download_s3_file", side_effect=fake_download),
+        patch.object(cnv_process.TumorOnlyVariantCallingTask, "model_validate", side_effect=lambda t: t),
+        patch.object(cnv_process, "process_tasks") as mock_process,
+        pytest.raises(S3DownloadError),
+    ):
+        cnv_process.import_somatic_cnv_vcf(tasks, namespace="radiant")
+
+    mock_process.assert_not_called()


### PR DESCRIPTION
## 📌 Context

Item 2 of the [SJRA-1770](https://d3b.atlassian.net/browse/SJRA-1770) breakdown: the extraction module for somatic tumor-only CNV. SJRA-1772 (discovery view + task model) already landed, so this adds the code that turns a DRAGEN somatic tumor-only CNV VCF into rows for the `somatic_cnv_occurrence` Iceberg table.

Extraction only. The Iceberg/StarRocks tables (SJRA-1774), load SQL (SJRA-1775), DAG and ECS wiring (SJRA-1776), the widened `cnv_id` UDF (SJRA-1777) and data QA + seeds (SJRA-1778) come separately — **nothing calls this module yet**.

## 📝 Changes

- `radiant/tasks/vcf/cnv/somatic/occurrence.py` — Iceberg schema (field IDs 600–632 / list element IDs 700–703, clear of germline CNV's), `resolve_cnv_type()` and `process_occurrence()`.
- `radiant/tasks/vcf/cnv/somatic/process.py` — `process_tasks()` in the same single-container batch shape as germline CNV, `validate_task_is_tumor_only()`, and the `import_somatic_cnv_vcf()` entrypoint SJRA-1776 will call.
- Mirrors germline CNV, except where the measured files say it must not (design §4):
  - **`type` comes off the DRAGEN ID** (`GAIN`/`LOSS`/`CNLOH`/`GAINLOH`), ALT only as a fallback. ALT cannot express the two LOH types, and `CN`/`MCN` are not available to derive them.
  - **`alternate` is derived from the resolved `type`**, so 4.2's `<DEL>,<DUP>` and 4.4's `<LOH>` produce the same row for the same event — this is what lets `cnv_id` key on `type`.
  - **`SVLEN` takes element 0**: it carries one value per ALT allele on LOH rows, so germline's bare `INFO.get("SVLEN")` would hand a tuple to a scalar column.
  - **ASCN fields (`cn, cnf, cnq, mcn, mcnf, mcnq, maf, sd, ascn_as`)** added, all nullable and read defensively.
  - **Unclassifiable records are skipped, never written as `UNKNOWN`** — reference segments (ALT `.`) and unrecognised ALTs (`<CNV>`) would produce a NULL `cnv_id` against a NOT NULL key column and fail the whole StarRocks load, not just their own row.
- Design §5 amended: DRAGEN's FORMAT `AS` is stored as **`ascn_as`** — `as` is reserved in Python and StarRocks/MySQL and would need quoting at every downstream call site.

## ☑️ TO-DOs

- [ ] Nothing blocking. Follow-ups are the remaining SJRA-1770 sub-tasks (1774–1778).

## 🧪 Tests

- `tests/resources/test_somatic_cnv.vcf` — DRAGEN 4.2.4-shaped fixture: GAIN, LOSS with a multi-valued `FILTER`, a legacy `<DEL>,<DUP>` CNLOH row, a 4.4 `<LOH>` GAINLOH row, a `.`-valued ASCN row, a `.`-ALT reference segment and a `<CNV>` row.
- `tests/resources/test_somatic_cnv_no_ascn.vcf` — DRAGEN 3.10.8-shaped fixture declaring no ASCN field at all.
- `tests/unit/vcf/somatic/test_somatic_cnv_occurrences.py`, `test_somatic_cnv_process.py` — 27 tests covering type resolution, the LOH normalisation, the record-skipping rules, the tumor-only validations and the download-failure behaviour.
- `make test-unit` → 536 passed. `USE_DOCKER_FIXTURES=true make test-integration` → 21 passed (no new integration coverage: the Iceberg table arrives with SJRA-1774). `ruff check radiant/` clean.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1773](https://d3b.atlassian.net/browse/SJRA-1773)
- [SJRA-1770](https://d3b.atlassian.net/browse/SJRA-1770)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Two behaviours verified against cyvcf2/htslib rather than assumed, both of which shaped the code.** `Variant.format()` *raises `KeyError`* for a FORMAT field the header never declares, so germline's `is not None` guard would throw outright on a 3.10.8 file. And a field written `.` for the sample comes back as a sentinel — `nan` for floats, `-2147483648` for integers — which without a guard would store `-2147483648` as a real copy number. Both are covered by fixtures.
- **A failed download raises here, unlike germline CNV, which skips it** (SJRA-1784). A skip is invisible downstream: the task still succeeds, the experiment is marked ingested, and per SJRA-1187 the delta never offers it again. Deliberate divergence, not an oversight — SJRA-1784 should bring germline to the same behaviour.
- **`validate_task_is_tumor_only()` repeats checks the task model already makes.** `gather_additional_args` only runs on the `build_task_from_rows` path; the K8s/ECS containers reach this module via `model_validate` on a dict, which skips them. The VCF sample count is the only check that catches a genuinely tumor-normal file mislabelled upstream, and it needs the file.
- The coupling to DRAGEN's ID convention is knowing, not accidental — the VCF spec treats ID as optional. It is forced: nothing else in these files can classify LOH (design §4).

[SJRA-1770]: https://d3b.atlassian.net/browse/SJRA-1770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SJRA-1773]: https://d3b.atlassian.net/browse/SJRA-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ