### PR TITLE
feat: SJRA-1776 orchestrate somatic CNV in import_part

### DIFF
--- a/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
+++ b/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
@@ -511,6 +511,16 @@ New module `radiant/tasks/vcf/cnv/somatic/{occurrence,process}.py`, mirroring
 (1 cpu / 500Mi / 1Gi limit) should apply unchanged — a tumor-only CNV file is single-sample and
 segment-level, so it is far smaller than the SNV files that profile was sized against.
 
+**Done in SJRA-1776**, as described. Two notes from implementing it:
+
+- The Dockerfile needed no change after all: `Dockerfile.radiant.operator` ends in
+  `COPY scripts/ecs/ /opt/radiant/`, a wholesale directory copy, so the new script is picked up by
+  existing lines.
+- The new container must go **inside the `vcf_imports` list literal**, not be appended after it. On
+  the ECS path, `vcf_imports >> cleanup.expand(params=stored_tasks)` reads the list as it exists at
+  that line, and `cleanup` deletes the very `stored_tasks` S3 JSON the container reads — so an op
+  wired in outside the literal would race a deletion of its own input.
+
 ---
 
 ## 7. Load and annotations — *decided: structural + keep gnomAD-SV*
@@ -596,8 +606,14 @@ count is the cost, not any single item. The reasoning for each lives in the refe
    against the target table, which a bare `EXPLAIN <select>` does not. Registering the UDF needed the
    StarRocks test container moved from `allin1-ubuntu:3.4.2` to `4.0.13`: the `v2.0.0` jar is Java 17 and
    3.4.2 runs a Java 11 runtime.
-5. **[SJRA-1776](https://d3b.atlassian.net/browse/SJRA-1776) — Orchestration.** `import_part.py`, `operators/{k8s,ecs}.py`,
-   `scripts/ecs/import_somatic_cnv_vcf.py` and the Dockerfile copy path.
+5. **[SJRA-1776](https://d3b.atlassian.net/browse/SJRA-1776) — Orchestration.** `import_part.py`,
+   `operators/{k8s,ecs}.py`, `scripts/ecs/import_somatic_cnv_vcf.py` and the Dockerfile copy path.
+   *Done.* The Dockerfile turned out to need nothing (§6). The `somatic_cnv_occurrence` group is
+   chained serially after `germline_cnv_occurrence` in Phase 3 rather than run in parallel with it,
+   so the StarRocks insert concurrency stays capped as it is elsewhere in the DAG; that chaining is
+   what makes `trigger_rule=NONE_FAILED` on `sanity_check_somatic_cnvs` load-bearing — a
+   germline-only part skips the germline insert upstream, and an `ALL_SUCCESS` root would be skipped
+   with it. Exactly the germline-SNV → somatic-SNV idiom already used in Phase 4.
 6. **[SJRA-1777](https://d3b.atlassian.net/browse/SJRA-1777) — `cnv_id` UDF.** Widen to a 3-bit type field (§5) and backfill germline
    `cnv_id`s. **Ordering, now that SJRA-1775 has moved the call sites to `type`: this must ship first.** The
    released UDF only understands `<DUP>`/`<DEL>` and returns NULL for anything else, against a `NOT NULL`

--- a/radiant/dags/import_part.py
+++ b/radiant/dags/import_part.py
@@ -25,6 +25,7 @@ from radiant.tasks.vcf.experiment import (
     ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK,
     RADIANT_GERMLINE_ANNOTATION_TASK,
     RADIANT_SOMATIC_ANNOTATION_TASK,
+    TUMOR_ONLY_VARIANT_CALLING_TASK,
     build_task_from_rows,
 )
 
@@ -155,11 +156,16 @@ def import_part():
             radiant_namespace=namespace_task,
             ecs_env=ecs_env,
         )
+        import_somatic_cnv_vcf = operators.ImportPart.get_import_somatic_cnv_vcf(
+            radiant_namespace=namespace_task,
+            ecs_env=ecs_env,
+        )
 
         cleanup = operators.ImportPart.get_cleanup(ecs_env=ecs_env)
 
     else:
         import_cnv_vcf = operators.ImportPart.get_import_cnv_vcf(namespace_task)
+        import_somatic_cnv_vcf = operators.ImportPart.get_import_somatic_cnv_vcf(namespace_task)
 
     @task(task_id="build_tenant_params", task_display_name="[PyOp] Per-tenant Params")
     def prepare_tenant_scoped_params(tasks) -> list[dict[str, Any]]:
@@ -228,7 +234,7 @@ def import_part():
 
         @task.short_circuit(
             task_id="sanity_check_cnvs",
-            task_display_name="[PyOp] Sanity Check CNVs",
+            task_display_name="[PyOp] Sanity Check Germline CNVs",
             ignore_downstream_trigger_rules=False,
         )
         def sanity_check_cnvs(tasks: Any) -> Any:
@@ -239,7 +245,7 @@ def import_part():
         insert_germline_cnv_occurrences = RadiantStarRocksPartitionSwapOperator.partial(
             task_id="insert_germline_cnv_occurrences",
             table="{{ mapping.starrocks_germline_cnv_occurrence }}",
-            task_display_name="[StarRocks] Insert CNV Occurrences Part",
+            task_display_name="[StarRocks] Insert Germline CNV Occurrences Part",
             map_index_template="{{ task.tenant_code }}",
             swap_partition=SwapPartition(
                 partition="{{ params.part }}",
@@ -251,6 +257,37 @@ def import_part():
         ).expand_kwargs(tenant_params)
 
         sanity_check_cnvs(tasks) >> insert_germline_cnv_occurrences
+
+    with TaskGroup(group_id="somatic_cnv_occurrence") as tg_somatic_cnv_occurrence_per_tenant:
+
+        @task.short_circuit(
+            task_id="sanity_check_somatic_cnvs",
+            task_display_name="[PyOp] Sanity Check Somatic CNVs",
+            ignore_downstream_trigger_rules=False,
+            trigger_rule=TriggerRule.NONE_FAILED,  # If we have germline only, we don't want to skip somatic
+        )
+        def sanity_check_somatic_cnvs(tasks: Any) -> Any:
+            # No `not deleted` clause, unlike the SNV checks: a part holding only deleted tumor-only tasks
+            # must still run the swap, because that is what purges their rows from the partition.
+            has_somatic_cnv = any(t.get("task_type") == TUMOR_ONLY_VARIANT_CALLING_TASK for t in tasks)
+            return has_somatic_cnv
+
+        # max_active_tis_per_dagrun=1: process tenants one at a time within a dagrun
+        insert_somatic_cnv_occurrences = RadiantStarRocksPartitionSwapOperator.partial(
+            task_id="insert_somatic_cnv_occurrences",
+            table="{{ mapping.starrocks_somatic_cnv_occurrence }}",
+            task_display_name="[StarRocks] Insert Somatic CNV Occurrences Part",
+            map_index_template="{{ task.tenant_code }}",
+            swap_partition=SwapPartition(
+                partition="{{ params.part }}",
+                copy_partition_sql="./sql/radiant/somatic_cnv_occurrence_copy_partition.sql",
+            ),
+            submit_task_options=std_submit_task_opts,
+            insert_partition_sql="./sql/radiant/somatic_cnv_occurrence_insert_partition_delta.sql",
+            max_active_tis_per_dagrun=1,
+        ).expand_kwargs(tenant_params)
+
+        sanity_check_somatic_cnvs(tasks) >> insert_somatic_cnv_occurrences
 
     # Single, shared load: all tenants' exomiser files land in one staging table, each row tagged with
     # tenant_code (set during the broker load) so the per-tenant insert_exomiser can route them later.
@@ -578,9 +615,12 @@ def import_part():
     )
 
     # Parallel VCF Imports
+    # Every ECS member must be listed here: `cleanup` below deletes the `stored_tasks` S3 file those
+    # containers read, and it only waits on the imports this list holds.
     vcf_imports = [
         import_snv_vcf,
         import_cnv_vcf.expand(params=stored_tasks) if IS_AWS else import_cnv_vcf(tasks=tasks),
+        import_somatic_cnv_vcf.expand(params=stored_tasks) if IS_AWS else import_somatic_cnv_vcf(tasks=tasks),
     ]
     if IS_AWS:
         vcf_imports >> cleanup.expand(params=stored_tasks)
@@ -599,6 +639,7 @@ def import_part():
         >> load_exomiser
         >> refresh_iceberg_tables
         >> tg_germline_cnv_occurrence_per_tenant
+        >> tg_somatic_cnv_occurrence_per_tenant
         >> insert_hashes
         >> overwrite_snv_tmp_variants
         >> insert_exomiser_per_tenant

--- a/radiant/dags/operators/ecs.py
+++ b/radiant/dags/operators/ecs.py
@@ -201,6 +201,36 @@ class ImportPart(RadiantTaskECSOperator):
         )
 
     @staticmethod
+    def get_import_somatic_cnv_vcf(radiant_namespace: str, ecs_env: ECSEnv):
+        return ecs.EcsRunTaskOperator.partial(
+            **dict(
+                task_id="import_somatic_cnv_vcf_ecs",
+                task_display_name="[ECS] Import Somatic CNV VCF",
+                overrides={
+                    "containerOverrides": [
+                        {
+                            "name": "radiant-operator-qa-etl-container",
+                            "command": [
+                                "python /opt/radiant/import_somatic_cnv_vcf.py --tasks '{{ params.stored_tasks }}'"
+                            ],
+                            "environment": [
+                                {"name": "PYTHONPATH", "value": "/opt/radiant"},
+                                {"name": "LD_LIBRARY_PATH", "value": "/usr/local/lib:$LD_LIBRARY_PATH"},
+                                {"name": "RADIANT_ICEBERG_NAMESPACE", "value": radiant_namespace},
+                                {"name": "PYICEBERG_CATALOG__DEFAULT__TYPE", "value": "glue"},
+                            ],
+                        }
+                    ]
+                },
+            )
+            | ImportSNVVCF._get_ecs_context(
+                ecs_cluster=ecs_env.ECS_CLUSTER,
+                ecs_subnets=ecs_env.ECS_SUBNETS,
+                ecs_security_groups=ecs_env.ECS_SECURITY_GROUPS,
+            )
+        )
+
+    @staticmethod
     def get_cleanup(ecs_env: ECSEnv):
         return ecs.EcsRunTaskOperator.partial(
             **dict(

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -190,6 +190,29 @@ class ImportPart(RadiantTaskK8SOperator):
 
         return import_cnv_vcf
 
+    @staticmethod
+    def get_import_somatic_cnv_vcf(radiant_namespace: str):
+        @task.kubernetes(
+            **dict(
+                task_id="import_somatic_cnv_vcf_k8s",
+                task_display_name="[K8s] Import Somatic CNV VCF",
+                name="import-somatic-cnv-vcf",
+                do_xcom_push=True,
+            )
+            # Same profile as germline CNV: a tumor-only CNV file is single-sample and segment-level
+            # (~304 segments for a WES sample), so it is no heavier than the germline one.
+            | ImportPart._get_k8s_context(radiant_namespace, container_resources=_cnv_container_resources())
+        )
+        def import_somatic_cnv_vcf(tasks: list[dict]) -> None:
+            import os
+
+            from radiant.tasks.vcf.cnv.somatic.process import import_somatic_cnv_vcf as _import_somatic_cnv_vcf
+
+            namespace = os.getenv("RADIANT_ICEBERG_NAMESPACE")
+            _import_somatic_cnv_vcf(tasks=tasks, namespace=namespace)
+
+        return import_somatic_cnv_vcf
+
 
 class InitIcebergTables(RadiantTaskK8SOperator):
     @staticmethod

--- a/scripts/ecs/import_somatic_cnv_vcf.py
+++ b/scripts/ecs/import_somatic_cnv_vcf.py
@@ -1,0 +1,39 @@
+import argparse
+import logging
+import os
+import sys
+
+from radiant.tasks.utils import download_json_from_s3
+from radiant.tasks.vcf.cnv.somatic.process import import_somatic_cnv_vcf
+
+logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler(sys.stdout)])
+logger = logging.getLogger(__name__)
+
+
+def main(tasks: list[dict]):
+    namespace = os.environ["RADIANT_ICEBERG_NAMESPACE"]
+    import_somatic_cnv_vcf(tasks, namespace)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Tasks from an S3 JSON file")
+
+    parser.add_argument(
+        "--tasks",
+        required=True,
+        help="S3 path to a JSON file containing the table partitions",
+    )
+    args = parser.parse_args()
+    logger.info(f"Received argument --tasks={args.tasks}")
+
+    # Distinct from the germline script's /tmp/tasks.json: the two run as separate ECS tasks with their
+    # own filesystems, but this keeps them independent if both are ever run inside one container.
+    local_tmp_path = "/tmp/somatic_tasks.json"
+
+    try:
+        tasks = download_json_from_s3(args.tasks, local_tmp_path, logger)
+        logger.info(f"Downloaded tasks: {tasks}")
+        main(tasks)
+    except Exception as e:
+        logger.exception(f"Error while processing tasks: {e}")
+        sys.exit(1)

--- a/tests/unit/dags/test_import_part.py
+++ b/tests/unit/dags/test_import_part.py
@@ -1,4 +1,5 @@
 import pytest
+from airflow.utils.trigger_rule import TriggerRule
 
 from radiant.dags import NAMESPACE
 from radiant.dags.import_part import (
@@ -190,12 +191,15 @@ def test_dag_contains_all_tasks(dag_bag):
         "extract_task_ids",
         "checkpoint_after_setup",
         "import_cnv_vcf_k8s",
+        "import_somatic_cnv_vcf_k8s",
         "import_snv_vcf",
         "checkpoint_after_vcf_imports",
         "load_exomiser_files",
         "refresh_iceberg_tables",
         "germline_cnv_occurrence.sanity_check_cnvs",
         "germline_cnv_occurrence.insert_germline_cnv_occurrences",
+        "somatic_cnv_occurrence.sanity_check_somatic_cnvs",
+        "somatic_cnv_occurrence.insert_somatic_cnv_occurrences",
         "insert_variant_hashes",
         "overwrite_snv_tmp_variant",
         "insert_exomiser",
@@ -232,6 +236,20 @@ def test_dag_task_dependencies_are_valid(dag_bag):
     namespace_task = dag.get_task("get_iceberg_namespace")
     import_cnv_vcf_k8s_task = dag.get_task("import_cnv_vcf_k8s")
     assert namespace_task in import_cnv_vcf_k8s_task.get_flat_relatives(upstream=True)
+    import_somatic_cnv_vcf_k8s_task = dag.get_task("import_somatic_cnv_vcf_k8s")
+    assert namespace_task in import_somatic_cnv_vcf_k8s_task.get_flat_relatives(upstream=True)
+
+    # The somatic CNV group is chained after the germline one, so its short-circuit carries
+    # `trigger_rule=NONE_FAILED` to survive a germline-only part skipping the germline insert.
+    assert (
+        "somatic_cnv_occurrence.sanity_check_somatic_cnvs"
+        in dag.get_task("germline_cnv_occurrence.insert_germline_cnv_occurrences").downstream_task_ids
+    )
+    assert dag.get_task("somatic_cnv_occurrence.sanity_check_somatic_cnvs").trigger_rule == TriggerRule.NONE_FAILED
+
+    # What keeps `insert_variant_hashes` (NONE_FAILED_MIN_ONE_SUCCESS) alive when both CNV groups skip:
+    # `parameters` is a template field, so the `extract_task_ids` XComArg is a real, successful upstream.
+    assert "insert_variant_hashes" in dag.get_task("extract_task_ids").downstream_task_ids
 
     # `compute_parts` is only referenced through `.partial(parameters=...)`; the edge exists because
     # `parameters` is a template field, so `MappedOperator` applies the XComArg relationship.


### PR DESCRIPTION
## 📌 Context

Somatic CNV (tumor-only) ingestion is built out as sub-tasks of SJRA-1770. Every layer below
orchestration has landed — task model (SJRA-1772), extraction (SJRA-1773), Iceberg table + mappings
(SJRA-1774), StarRocks load SQL (SJRA-1775) — but nothing calls any of it.

This is the missing wiring: a second batch extraction container alongside the germline CNV one, and a
StarRocks load TaskGroup mirroring `germline_cnv_occurrence`. After this, a `tumor_only_variant_calling`
task discovered by the incremental delta actually flows VCF → Iceberg → StarRocks
`somatic__cnv__occurrence`.

## 📝 Changes

- **`scripts/ecs/import_somatic_cnv_vcf.py`** (new) — mirror of `import_cnv_vcf.py`, calling
  `import_somatic_cnv_vcf`, downloading to a distinct `/tmp/somatic_tasks.json`. No Dockerfile change
  needed: `Dockerfile.radiant.operator` ends in `COPY scripts/ecs/ /opt/radiant/`, a wholesale copy.
- **`operators/k8s.py`** — `ImportPart.get_import_somatic_cnv_vcf`, reusing `_cnv_container_resources()`
  (1 cpu / 500Mi / 1Gi) unchanged: a tumor-only CNV file is single-sample and segment-level (~304
  segments for a WES sample).
- **`operators/ecs.py`** — the ECS twin, `.partial()` so the DAG expands it over `stored_tasks`.
- **`import_part.py`** — new `somatic_cnv_occurrence` TaskGroup (`sanity_check_somatic_cnvs`
  short-circuit + `RadiantStarRocksPartitionSwapOperator...expand_kwargs(tenant_params)`), the container
  added to `vcf_imports`, and the group chained into Phase 3 after germline CNV. Also disambiguated the
  two germline CNV *display* names (no `task_id` changes, so no history/XCom loss).
- **`design/SJRA-1770-*.md`** — marked §6 / work-item 5 done, per the convention SJRA-1775 established.

Explicitly out of scope, per the ticket: restructuring CNV into a fanned-out sub-DAG the way SNV was in
SJRA-1751. That duplicates germline CNV's two known gaps into the somatic path — accepted, tracked as
SJRA-1784 so a fix covers both flows.

## ☑️ TO-DOs

- [ ] **Merge SJRA-1777 (widened `cnv_id` UDF) first.** The released jar returns NULL for anything but
      `<DUP>`/`<DEL>` against a `NOT NULL` key column, so until it ships *both* the germline and somatic
      CNV loads fail. CI will not catch it: `EXPLAIN` type-checks the signature and never executes the UDF.
- [ ] End-to-end run on a part with a real DRAGEN tumor-only CNV file (blocked on the above).

## 🧪 Tests

- `tests/unit/dags/test_import_part.py` — three new task ids in the exact-set assertion, plus dependency
  assertions for the two properties the wiring rests on: the `germline → somatic` group edge with
  `NONE_FAILED`, and the `extract_task_ids → insert_variant_hashes` edge.
- `make test-unit`: 537 passed. `make test-static`: clean.
- Also parsed the DAG under `IS_AWS=true` with stubbed `AWS_ECS_*` variables, since the unit tests only
  exercise the K8s branch. It validates, and `cleanup_tasks_files` correctly waits on
  `import_somatic_cnv_vcf_ecs`.
- No change needed to `test_init_iceberg_tables.py` (somatic CNV init landed with SJRA-1774) or
  `tests/integration/dags/sql/test_queries.py` (already `EXPLAIN`s the somatic CNV delta SQL).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1776](https://d3b.atlassian.net/browse/SJRA-1776)
- Parent: [SJRA-1770](https://d3b.atlassian.net/browse/SJRA-1770)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

Three decisions worth a look:

1. **Placement is Phase 3, next to germline CNV — not after the somatic SNV insert.** The ticket flagged
   a risk that `nb_snv` would force it into Phase 4, "annoying to discover late as a silently-zero
   column". It does not: `somatic_cnv_occurrence_insert_partition_delta.sql` joins
   `iceberg_somatic_snv_occurrence` — the Iceberg table, written in Phase 2 — not StarRocks
   `somatic__snv__occurrence`. `refresh_iceberg_tables` at the top of Phase 3 already covers it.
2. **Serial after germline, not parallel.** `max_active_tis_per_dagrun=1` is per-task, so parallel groups
   would let a germline and a somatic partition swap submit concurrently, doubling the insert concurrency
   the DAG caps on purpose. That chaining is what makes `trigger_rule=NONE_FAILED` on the short-circuit
   load-bearing: a germline-only part skips the germline insert upstream, and an `ALL_SUCCESS` root would
   be skipped with it. Same idiom as germline-SNV → somatic-SNV in Phase 4.
3. **The sanity check omits `and not deleted`** — matching germline CNV rather than the SNV checks. The
   copy-partition SQL filters `deleted_seq_ids`, so a part of only-deleted tumor-only tasks must still run
   the swap to purge those rows.

One subtlety worth preserving on future edits: the new container must stay **inside** the `vcf_imports`
list literal. `vcf_imports >> cleanup.expand(params=stored_tasks)` reads the list as it exists at that
line, and `cleanup` deletes the very `stored_tasks` S3 JSON the container reads — appending after that
line would race a deletion of its own input.


[SJRA-1776]: https://d3b.atlassian.net/browse/SJRA-1776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ