### PR TITLE
feat: SJRA-1778 tests, data QA and clinical seeds for somatic CNV

### DIFF
--- a/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
+++ b/design/SJRA-1770-somatic-cnv-tumor-only-ingestion.md
@@ -619,11 +619,37 @@ count is the cost, not any single item. The reasoning for each lives in the refe
    released UDF only understands `<DUP>`/`<DEL>` and returns NULL for anything else, against a `NOT NULL`
    key column — so until the widened jar is out, *both* the germline and the somatic CNV load fail. CI will
    not catch a violation: `EXPLAIN` type-checks the `(string, bigint, bigint, string)` signature, which
-   `type` satisfies, and never executes the function.
-7. **[SJRA-1778](https://d3b.atlassian.net/browse/SJRA-1778) — Tests, data QA and seeds.** A fixture VCF covering GAIN, LOSS, a `.`-ALT
-   row and **both** LOH spellings; `somatic_cnv_occurrence.yml` per §5; seeds are net-new and should carry
-   both an `scnv` and a raw `ssnv` document so the §3 gate is exercised. (The `test_queries.py` gap moved to
-   item 4.)
+   `type` satisfies, and never executes the function. **Jar status, checked while doing item 7:** `v2.0.0`
+   is released and *is* the widened layout (type codes LOSS 0, GAIN 1, CNLOH 2, GAINLOH 3; `start` and
+   `length` 28 bits each), and `test_queries.py` already pins it. What is left for this ticket is the
+   pipeline side: `init_starrocks_tables.py` still defaults `udf_release_version` to `v1.2.0`, and the
+   germline `cnv_id` backfill has not run.
+7. **[SJRA-1778](https://d3b.atlassian.net/browse/SJRA-1778) — Tests, data QA and seeds.** A fixture VCF
+   covering GAIN, LOSS, a `.`-ALT row and **both** LOH spellings; `somatic_cnv_occurrence.yml` per §5; seeds
+   are net-new and should carry both an `scnv` and a raw `ssnv` document so the §3 gate is exercised. (The
+   `test_queries.py` gap moved to item 4.) *Done*, but most of it had already arrived with items 1-5, each of
+   which carried its own tests: the fixture VCFs (`test_somatic_cnv.vcf`, `test_somatic_cnv_no_ascn.vcf`),
+   the three somatic CNV unit-test files, the integration extraction test, the seeds (task 70 with documents
+   263/264 `scnv` + 265 the raw `ssnv` decoy) and the delta-gate assertion all pre-existed. What was
+   actually left:
+   - **Data QA** — `sources/somatic_cnv_occurrence.yml`, a new `dict_cnv_type()`, and two singular tests
+     (`validate_start_end_order`, plus `validate_type_alternate_consistency`, which asserts the
+     `ALTERNATE_BY_TYPE` invariant of §4 — the thing that makes the two DRAGEN VCF versions
+     interchangeable). `svlen` is **not** in the `should_not_contain_only_null` except list, unlike
+     germline: germline's VCF carries no `SVLEN`, both measured somatic files do.
+   - **`clinical_somatic_cnv_vcf`** in `tests/integration/conftest.py`, gated on `scnv`. Like its germline
+     twin `clinical_cnv_vcf`, no test references it — it is scaffolding for driving the seeded stack.
+   - **The two-sample rejection through `process_tasks`**, on a real two-sample fixture. The existing test
+     passed a synthetic sample list straight to `validate_task_is_tumor_only`, so nothing covered the
+     ordering the check depends on: `vcf.samples` must be read *before* `set_samples` narrows it (§3).
+
+   Three deliberate omissions, decided rather than overlooked: **no `filter` split-and-check test** (it
+   needs a net-new generic test macro, germline sidesteps `filter` entirely, and the vocabulary is
+   version-dependent); **runtime SQL verification stays EXPLAIN-only**, as item 4 left it; and
+   `dict_cnv_type()` carries **all four** values, so QA records the domain and passes rather than firing on
+   `CNLOH`/`GAINLOH` — the portal coordination stays tracked as §9 Q1. Germline CNV's own test gaps
+   (no unit coverage of its `process_occurrence`/`process_tasks`, a much thinner integration assertion set
+   than its somatic twin, no `gcnv` gate test) were left alone; they belong with SJRA-1784/1785.
 
 ## 9. Open questions
 

--- a/radiant/data_qa/macros/dictionaries.sql
+++ b/radiant/data_qa/macros/dictionaries.sql
@@ -33,6 +33,12 @@
              'substitution', 'sequence_alteration']) }}
 {% endmacro %}
 
+{% macro dict_cnv_type() %}
+  {# Notion: https://app.notion.com/p/ferlab/83970f81d6ca44628abd12f697627ab1?v=e787d2d6aa1b46148d58bb936d59c230 #}
+  {# mirrors facets.go + i18n — keep in sync #}
+  {{ return(['GAIN', 'LOSS', 'CNLOH', 'GAINLOH']) }}
+{% endmacro %}
+
 {% macro dict_clinvar_interpretation() %}
   {# Notion: https://app.notion.com/p/ferlab/79b61815da5c4fbb898d65a6e88b5256?v=af0f09733b8345d3a68ee75dafabecfb #}
   {# mirrors facets.go + classification-badge.tsx + i18n — keep in sync #}

--- a/radiant/data_qa/sources/somatic_cnv_occurrence.yml
+++ b/radiant/data_qa/sources/somatic_cnv_occurrence.yml
@@ -1,0 +1,102 @@
+version: 2
+
+sources:
+  - name: radiant
+    schema: "{{ env_var('SR_SCHEMA', 'radiant') }}"
+    tables:
+      - name: somatic__cnv__occurrence
+        tests:
+          # --- Should Not Be Empty -------------------------------------------
+          - should_not_be_empty:
+              name: somatic_cnv_occurrence__should_not_be_empty
+          # --- Should Not Contain Only Null ----------------------------------
+          - should_not_contain_only_null:
+              name: somatic_cnv_occurrence__should_not_contain_only_null
+              except:
+                # Already covered by somatic_cnv_occurrence__should_not_contain_null__*
+                - part
+                - task_id
+                - cnv_id
+                # Constant by construction
+                - cipos
+                - ciend
+                - cn
+                - cnf
+                - cnq
+                - mcn
+                - mcnf
+                - mcnq
+                - maf
+                - sd
+                - ascn_as
+
+          # --- Should Not Contain Same Value ---------------------------------
+          - should_not_contain_same_value:
+              name: somatic_cnv_occurrence__should_not_contain_same_value
+              except:
+                # Constant by construction
+                - part
+                - phased
+                - svtype
+                # Single tumor-only task QA dataset
+                - seq_id
+                - task_id
+                - aliquot
+
+          # --- Should Be Within Range ----------------------------------------
+          # gnomAD frequencies must be in [0,1] (defaults: 0..1)
+          - should_be_within_range:
+              name: somatic_cnv_occurrence__should_be_within_range_gnomad_af
+              like: gnomad_af
+          - should_be_within_range:
+              name: somatic_cnv_occurrence__should_be_within_range_gnomad_sf
+              like: gnomad_sf
+          # minor allele frequency must be in [0,1] (defaults: 0..1)
+          - should_be_within_range:
+              name: somatic_cnv_occurrence__should_be_within_range_maf
+              like: maf
+
+          # --- Should Be Unique ----------------------------------------------
+          - dbt_utils.unique_combination_of_columns:
+              name: somatic_cnv_occurrence__should_be_unique__part_seq_id_task_id_cnv_id
+              combination_of_columns:
+                - part
+                - seq_id
+                - task_id
+                - cnv_id
+        columns:
+          - name: part
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_cnv_occurrence__should_not_contain_null__part
+          - name: task_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_cnv_occurrence__should_not_contain_null__task_id
+          - name: cnv_id
+            tests:
+              # --- Should Not Contain Null -----------------------------------
+              - not_null:
+                  name: somatic_cnv_occurrence__should_not_contain_null__cnv_id
+          - name: chromosome
+            description: "VARCHAR(20)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_chromosome() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: somatic_cnv_occurrence__accepted_values_chromosome
+                  values: "{{ dict_chromosome() }}"
+                  config:
+                    where: "chromosome is not null"
+          - name: type
+            description: "VARCHAR(10)."
+            tests:
+              # --- Accepted Values -------------------------------------------
+              # values: dict_cnv_type() — see macros/dictionaries.sql
+              - accepted_values:
+                  name: somatic_cnv_occurrence__accepted_values_type
+                  values: "{{ dict_cnv_type() }}"
+                  config:
+                    where: "type is not null"

--- a/radiant/data_qa/tests/somatic_cnv_occurrence__validate_start_end_order.sql
+++ b/radiant/data_qa/tests/somatic_cnv_occurrence__validate_start_end_order.sql
@@ -1,0 +1,12 @@
+{#
+  Genomic coordinate sanity for somatic CNV occurrences:
+    - start must not exceed end (1-based inclusive span).
+#}
+
+select
+    cnv_id,
+    chromosome,
+    start,
+    `end`
+from {{ source('radiant', 'somatic__cnv__occurrence') }}
+where start > `end`

--- a/radiant/data_qa/tests/somatic_cnv_occurrence__validate_type_alternate_consistency.sql
+++ b/radiant/data_qa/tests/somatic_cnv_occurrence__validate_type_alternate_consistency.sql
@@ -1,0 +1,16 @@
+{#
+  `alternate` is derived from the resolved `type`, never copied from the VCF:
+    - GAIN -> <DUP>, LOSS -> <DEL>, CNLOH / GAINLOH -> <LOH>.
+#}
+
+select
+    cnv_id,
+    chromosome,
+    start,
+    `end`,
+    type,
+    alternate
+from {{ source('radiant', 'somatic__cnv__occurrence') }}
+where (type = 'GAIN' and alternate != '<DUP>')
+   or (type = 'LOSS' and alternate != '<DEL>')
+   or (type in ('CNLOH', 'GAINLOH') and alternate != '<LOH>')

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -445,6 +445,55 @@ def clinical_cnv_vcf(s3_fs, starrocks_session, starrocks_jdbc_catalog):
 
 
 @pytest.fixture(scope="session")
+def clinical_somatic_cnv_vcf(s3_fs, starrocks_session, starrocks_jdbc_catalog):
+    """
+    Creates "mock" somatic (tumor-only) CNV VCFs for clinical documents.
+
+    Gated on `data_type_code='scnv'`, which is how the staging view finds a tumor-only CNV file --
+    never by filename. The reference VCF lives in the unit resources directory rather than
+    `resources/integration`, so it is read from there instead of through the session `indexed_vcfs`
+    fixture, as `test_process_somatic_cnv_vcf.py` already does.
+    """
+    reference_vcf = CURRENT_DIR.parent / "resources" / "test_somatic_cnv.vcf"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        with open(reference_vcf) as f:
+            vcf_content = f.read()
+
+        with starrocks_session.cursor() as cursor:
+            cursor.execute(f"""
+                SELECT
+                     aliquot,
+                     d.name
+                FROM {starrocks_jdbc_catalog.catalog}.{starrocks_jdbc_catalog.database}.sequencing_experiment se
+                LEFT JOIN
+                {starrocks_jdbc_catalog.catalog}.{starrocks_jdbc_catalog.database}.task_context tc
+                ON se.id = tc.sequencing_experiment_id
+                LEFT JOIN
+                {starrocks_jdbc_catalog.catalog}.{starrocks_jdbc_catalog.database}.task_has_document thd
+                ON tc.task_id = thd.task_id
+                LEFT JOIN
+                {starrocks_jdbc_catalog.catalog}.{starrocks_jdbc_catalog.database}.document d
+                ON thd.document_id = d.id
+                WHERE d.data_type_code='scnv' and d.format_code='vcf'
+                """)
+            results = cursor.fetchall()
+
+        for aliquot, document_name in results:
+            _path = document_name.replace(".gz", "")
+            src_path = os.path.join(tmpdir, f"source_{_path}")
+            dest_path = os.path.join(tmpdir, f"{_path}.gz")
+
+            with open(src_path, "w") as f:
+                # The somatic fixture's sample is the file's own aliquot, not germline's `SA0001`.
+                _new_content = vcf_content.replace("TCRBOA6-T", str(aliquot))
+                f.write(_new_content)
+
+            compress_and_index_vcf(src_path, dest_path)
+            s3_fs.put(dest_path, "test-vcf/" + document_name)
+            s3_fs.put(dest_path + ".tbi", "test-vcf/" + document_name + ".tbi")
+
+
+@pytest.fixture(scope="session")
 def sample_exomiser_tsv(s3_fs):
     """
     Uploads the sample Exomiser TSV to S3.

--- a/tests/resources/test_somatic_cnv_two_samples.vcf
+++ b/tests/resources/test_somatic_cnv_two_samples.vcf
@@ -1,0 +1,18 @@
+##fileformat=VCFv4.2
+##ALT=<ID=CNV,Description="Copy number variant region">
+##ALT=<ID=DEL,Description="Deletion relative to the reference">
+##ALT=<ID=DUP,Description="Region of elevated copy number relative to the reference">
+##contig=<ID=chr1,length=248956422>
+##reference=file:///ephemeral/reference/index
+##INFO=<ID=REFLEN,Number=1,Type=Integer,Description="Number of REF positions included in this record">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=SVLEN,Number=.,Type=Integer,Description="Difference in length between REF and ALT alleles">
+##INFO=<ID=END,Number=1,Type=Integer,Description="End position of the variant described in this record">
+##FILTER=<ID=cnvQual,Description="CNV with quality below threshold">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=SM,Number=1,Type=Float,Description="Linear copy ratio of the segment mean">
+##FORMAT=<ID=BC,Number=1,Type=Integer,Description="Number of bins in the region">
+##FORMAT=<ID=PE,Number=2,Type=Integer,Description="Number of improperly paired end reads at start and stop breakpoints">
+##DRAGENVersion=<ID=dragen,Version="SW: 07.021.732.4.2.4, HW: 07.021.732">
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	TCRBOA6-T	TCRBOA6-N
+chr1	124941718	DRAGEN:GAIN:chr1:124941719-124975661	N	<DUP>	36	PASS	SVTYPE=CNV;SVLEN=33943;END=124975661;REFLEN=33943	GT:SM:BC:PE	0/1:1.43012:20:5,30	0/0:1.00214:20:1,2

--- a/tests/unit/vcf/somatic/test_somatic_cnv_process.py
+++ b/tests/unit/vcf/somatic/test_somatic_cnv_process.py
@@ -108,6 +108,24 @@ def test_process_tasks_buffers_only_classifiable_records():
     assert {occ["task_id"] for occ in buffered} == {70}
 
 
+def test_process_tasks_rejects_a_two_sample_vcf():
+    """The multi-sample check has to see the *file's* sample list, which only exists before
+    `set_samples` narrows it -- narrowing rewrites `vcf.samples` and `vcf.raw_header` and destroys the
+    evidence. Exercised through `process_tasks` rather than `validate_task_is_tumor_only` directly,
+    because it is that ordering, not the validation itself, that a refactor would quietly break."""
+    task = _task().model_copy(update={"cnv_vcf_filepath": str(RESOURCES_DIR / "test_somatic_cnv_two_samples.vcf")})
+
+    with (
+        patch.object(cnv_process, "load_catalog"),
+        patch.object(cnv_process, "pa") as mock_pa,
+        pytest.raises(ValueError, match="declares 2 samples"),
+    ):
+        cnv_process.process_tasks([task], namespace="radiant")
+
+    # Tumor-normal CNV is out of scope: fail loudly rather than half-succeed on the tumor sample.
+    mock_pa.Table.from_pylist.assert_not_called()
+
+
 def test_import_somatic_cnv_vcf_processes_only_tumor_only_tasks():
     tasks = [
         _task_dict(1, "s3://bucket/germline.cnv.vcf.gz", task_type=ALIGNMENT_GERMLINE_VARIANT_CALLING_TASK),


### PR DESCRIPTION
## 📌 Context

Last sub-task of SJRA-1770. Most of what the ticket asks for arrived with items 1–5 — both fixture VCFs
(GAIN, LOSS, `.`-ALT, `<CNV>` and **both** LOH spellings), the three somatic CNV unit-test files, the
integration extraction test, the `test_queries.py` CNV DDL/UDF/EXPLAIN coverage, and the seeds (task 70
with documents 263/264 `scnv` + 265 the raw `ssnv` decoy) with its delta-gate assertion.

What was genuinely missing was the **data QA layer**, plus two small gaps.

## 📝 Changes

- **`data_qa/sources/somatic_cnv_occurrence.yml`** (new) — mirrors `germline_cnv_occurrence.yml`.
  `should_not_contain_only_null` additionally excepts the 9-column DRAGEN ASCN block and `cipos`/`ciend`
  (absent or unpopulated depending on DRAGEN version); `should_not_contain_same_value` additionally
  excepts `seq_id`/`task_id`/`aliquot`, per the single-task precedent in `somatic_snv_occurrence.yml`.
  `svlen` is deliberately **not** excepted: germline excepts it because its VCF carries no `SVLEN`, both
  measured somatic files do populate it.
- **`data_qa/macros/dictionaries.sql`** — new `dict_cnv_type()` (`GAIN, LOSS, CNLOH, GAINLOH`), used by an
  `accepted_values` test on `type`. Not wired to germline CNV, which derives `type` from ALT and emits
  `UNKNOWN`.
- **Two singular tests** — `validate_start_end_order` (germline mirror) and
  `validate_type_alternate_consistency`, asserting `ALTERNATE_BY_TYPE` (GAIN→`<DUP>`, LOSS→`<DEL>`,
  CNLOH/GAINLOH→`<LOH>`) — the invariant that makes the two DRAGEN VCF spellings interchangeable.
- **`tests/integration/conftest.py`** — `clinical_somatic_cnv_vcf`, gated on `data_type_code='scnv'`,
  rewriting the fixture's sample to the seeded aliquot.
- **`tests/resources/test_somatic_cnv_two_samples.vcf`** + one unit test — a two-sample file handed to a
  `tumor_only_variant_calling` task must raise before anything is buffered.
- **`design/SJRA-1770-*.md`** — §8 item 7 marked done, with what pre-existed and the deliberate omissions.

Three decided omissions: no `filter` split-and-check test (needs a net-new generic macro, germline
sidesteps `filter` entirely, and the vocabulary is DRAGEN-version dependent); runtime SQL verification
stays EXPLAIN-only as SJRA-1775 left it; `dict_cnv_type()` carries all four values, so QA records the
domain and passes rather than firing on `CNLOH`/`GAINLOH` — portal coordination stays §9 Q1.

## ☑️ TO-DOs

- [ ] Run `dbt parse` + `dbt test --select source:radiant.somatic__cnv__occurrence` in an environment
      that has dbt (it is not installable in CI or my local sandbox — see Tests).
- [ ] Still gated on SJRA-1777's pipeline side: `init_starrocks_tables.py` defaults
      `udf_release_version` to `v1.2.0`. The **jar `v2.0.0` is released and is the widened 3-bit-type
      layout** (LOSS 0, GAIN 1, CNLOH 2, GAINLOH 3), so what remains there is the default bump and the
      germline `cnv_id` backfill.

## 🧪 Tests

- `make test-unit`: **538 passed**. `make test-static`: clean.
- `USE_DOCKER_FIXTURES=true make test-integration`: **23 passed** (3m54s).
- Data QA cannot run in CI (needs a live StarRocks with somatic CNV rows) and dbt would not install
  locally, so it was validated two other ways: rendering `dictionaries.sql` and both singular tests
  through Jinja, and cross-checking every `except:` / `combination_of_columns` / column name and both
  `like:` selectors against the DDL's 43 real columns — no typos, and each `like:` resolves to exactly
  one column (`gnomad_af`, `gnomad_sf`, `maf`).

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1778](https://d3b.atlassian.net/browse/SJRA-1778)
- Parent: [SJRA-1770](https://d3b.atlassian.net/browse/SJRA-1770)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Expect two failures on the first real QA run, both signal rather than bug.** `should_not_be_empty`
  fails until somatic CNV data actually lands in the QA environment; and if that dataset yields no
  80%-reciprocal-overlap gnomAD hits, `gnomad_*`/`nb_snv` will need adding to the except list with a
  reason comment. Left out deliberately — a failure there is real information.
- **The fixture VCF was not copied to `tests/resources/integration/`** as the ticket suggested. A second
  copy of a 7-record fixture would drift; `clinical_somatic_cnv_vcf` reads it from the unit resources dir
  instead, as `test_process_somatic_cnv_vcf.py` already does.
- **`clinical_somatic_cnv_vcf` is referenced by no test** — like its germline twin `clinical_cnv_vcf` (and
  `clinical_snv_vcf`, `clinical_exomiser_tsv`), it is scaffolding for driving the seeded stack manually,
  not CI coverage.
- Germline CNV's own test gaps found while here (no unit coverage of its `process_occurrence` /
  `process_tasks`, a thinner integration assertion set than its somatic twin, no `gcnv` gate test) were
  left alone; they sit naturally with SJRA-1784/1785.


[SJRA-1778]: https://d3b.atlassian.net/browse/SJRA-1778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ