### PR TITLE
feat: SJRA-749 add a nextflow dag

### DIFF
--- a/.github/workflows/build_and_push_nextflow_launcher.yml
+++ b/.github/workflows/build_and_push_nextflow_launcher.yml
@@ -1,0 +1,63 @@
+# This workflow builds and pushes a Docker image to GitHub Packages
+name: Build and Push Docker Image for the Nextflow Driver
+
+env:
+  IMAGE_NAME: nextflow-launcher
+  NAMESPACE: radiant-network
+  REGISTRY: ghcr.io
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build_and_push:
+    name: Build and Push Docker Image to GitHub Packages
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{raw}} 
+            type=semver,pattern={{version}}
+            type=sha,format=short
+
+          flavor: |
+            latest=auto
+
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: Dockerfile.nextflow.launcher
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.NAMESPACE }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile.nextflow.launcher
+++ b/Dockerfile.nextflow.launcher
@@ -1,0 +1,66 @@
+# Nextflow driver image. Runs as the `postprocessing-driver` K8s Job on
+# qlin-eks (namespace `nextflow`): it mounts the FSx-Lustre PVC, runs
+# `nextflow run`, and the K8s executor spawns one worker pod per task.
+#
+# Ported from poc-nextflow-aws/container/launcher/Dockerfile, which had no
+# build automation - it was built and pushed by hand to the `poc-nextflow`
+# ECR repo. Here it follows the same GHCR + tag-triggered workflow as the
+# other images in this repo.
+#
+# IMPORTANT: the framework, the pipeline assets and the plugins are all
+# baked at build time. Nothing in the runtime path fetches from nextflow.io,
+# nf-co.re or github.com - the LZ egress firewall blocks part of that, and
+# a driver that resolves its own pipeline at runtime is a boot-time failure
+# waiting to happen. The consequence is that bumping PIPELINE_REV requires
+# rebuilding this image.
+
+FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
+
+ARG NXF_VER=24.10.5
+ARG PIPELINE_REPO=Ferlab-Ste-Justine/Post-processing-Pipeline
+ARG PIPELINE_REV=v3.0.0
+
+# Keep in sync with the pipeline's own `plugins` block: v3.0.0 declares
+# nf-schema@2.1.0 (v2.11.0 declared nf-validation@1.1.3 - a different
+# plugin, not a version bump). A mismatch fails at plugin resolution,
+# offline, with no way to recover at runtime.
+ARG NXF_PLUGINS="nf-schema@2.1.0 nf-amazon"
+
+# Set NXF_HOME *before* installing Nextflow, so the build-time
+# `nextflow -version` populates ${NXF_HOME}/framework/... and the build-time
+# `nextflow pull` populates ${NXF_HOME}/assets/...
+ENV NXF_HOME=/opt/nextflow \
+    NXF_ASSETS=/opt/nextflow/assets
+
+RUN dnf install -y \
+        java-21-amazon-corretto-headless \
+        awscli-2 \
+        git \
+        bash \
+        tar \
+        gzip \
+        which \
+        findutils \
+        procps-ng \
+        shadow-utils \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf \
+    && mkdir -p ${NXF_HOME} ${NXF_ASSETS}
+
+RUN curl -fsSL https://get.nextflow.io | NXF_VER=${NXF_VER} bash \
+    && mv nextflow /usr/local/bin/nextflow \
+    && chmod +x /usr/local/bin/nextflow \
+    && /usr/local/bin/nextflow -version \
+    && /usr/local/bin/nextflow pull "${PIPELINE_REPO}" -r "${PIPELINE_REV}" \
+    && for p in ${NXF_PLUGINS}; do /usr/local/bin/nextflow plugin install "$p"; done
+
+WORKDIR /workspace
+
+# Sanity: confirm framework + pipeline + plugins are all baked in, so a
+# missing piece fails the build instead of the first production run.
+RUN ls "${NXF_HOME}/framework/${NXF_VER}/" \
+    && ls "${NXF_ASSETS}/${PIPELINE_REPO}/.git" >/dev/null 2>&1 \
+    && ls "${NXF_HOME}/plugins/" | grep -E 'nf-schema|nf-amazon' \
+    || (echo "ERROR: cache layout incomplete" && exit 1)
+
+CMD ["/bin/bash"]

--- a/radiant/.airflowignore
+++ b/radiant/.airflowignore
@@ -1,0 +1,15 @@
+# dag-sync copies this whole package into the Airflow DAGs folder, because the DAGs
+# import `radiant.tasks.*`. That makes the DAG processor scan `tasks/` too, and
+# DAG_DISCOVERY_SAFE_MODE imports any .py containing both "airflow" and "dag" -- which
+# `tasks/vcf/snv/somatic/process.py` does incidentally (a `getLogger("airflow.task")`
+# and a comment). It then fails on `from cyvcf2 import VCF`, since cyvcf2 is a
+# task-image dependency and is deliberately absent from the Airflow image.
+#
+# Only DAG discovery is affected; `sys.path` imports from task bodies still resolve,
+# so the k8s/ECS operators keep working.
+#
+# Bare `tasks/` on purpose: Airflow 2 matches these as regex and Airflow 3 as glob,
+# and this is the spelling that works under both. `radiant/tasks/` would match the
+# regex but not the glob.
+tasks/
+data_qa/

--- a/radiant/dags/docs/nextflow_postprocessing.md
+++ b/radiant/dags/docs/nextflow_postprocessing.md
@@ -1,0 +1,70 @@
+# Nextflow Post-processing
+
+Runs the Ferlab [Post-processing-Pipeline](https://github.com/Ferlab-Ste-Justine/Post-processing-Pipeline)
+on qlin-eks: joint genotyping from per-sample gVCFs, then VEP → slivar → Exomiser.
+
+One Airflow task launches a Nextflow **driver** pod in the `nextflow` namespace. The
+driver spawns one worker pod per pipeline process itself, through Nextflow's
+Kubernetes executor — so a single task in the Airflow UI is a fan-out of dozens of
+pods in Kubernetes. Watch them with:
+
+```sh
+kubectl -n nextflow get pods -w
+```
+
+## Parameters
+
+| Param | Required | Meaning |
+|---|---|---|
+| `input` | yes | Absolute path to the samplesheet CSV on the shared workspace, e.g. `/workspace/inputs/1000genomes-dragen-v4-4-7/samplesheet.csv`. Columns: `familyId,sample,sequencingType,gvcf,familyPheno,familyPed`. |
+| `outdir` | no | Absolute path for published outputs. Empty means `/workspace/outputs/qlin/<run tag>`. |
+
+Both paths are **pod paths**, not S3 URIs. `/workspace` is the FSx-Lustre filesystem;
+its `/inputs` and `/reference` prefixes are auto-imported from S3 and `/outputs` is
+auto-exported back, so anything published under `outdir` reaches
+`s3://qlin-qa-nextflow-outputs-*` without an explicit copy.
+
+Everything else — reference genome, VEP cache, Exomiser data, `tools`, `step` — is
+run-invariant and lives in the `nextflow-params` ConfigMap, alongside `nextflow-cfg`
+for the executor and per-process resources. Both are owned by the kustomization in
+`qlin-qa-infra/kubernetes-manifests/apps/nextflow/`.
+
+## Retries and resume
+
+The Nextflow launch directory is `/workspace/work/.nextflow-launchdir/<run tag>`,
+where the run tag comes from the Airflow `run_id`. It is stable across task retries
+and unique per DAG run, so:
+
+- **A retry resumes.** `-resume` finds the previous session's `.nextflow/cache` and
+  skips completed processes. On WGS that is the difference between minutes and hours.
+- **Concurrent runs cannot collide**, and `max_active_runs=1` keeps them from trying.
+
+The task is **deferrable**: it releases its worker slot and the triggerer polls the
+pod, so a multi-hour run costs no Airflow capacity. Logs are flushed to the task log
+roughly every 10 minutes rather than streamed live.
+
+## Before clearing a failed task
+
+Clearing a deferred task does **not** delete its pod. If the driver is still running,
+a retry starts a second driver against the same launch directory, and two Nextflow
+sessions sharing one resume cache is how that cache gets corrupted. Check first:
+
+```sh
+kubectl -n nextflow get pods -l dag_id=radiant-nextflow-postprocessing
+kubectl -n nextflow delete pod <driver-pod>   # if one is still Running
+```
+
+`active_deadline_seconds` (24h by default) is the backstop if nobody does.
+
+## Failure triage
+
+A failed driver pod is kept rather than deleted, so its logs survive:
+
+```sh
+kubectl -n nextflow logs <driver-pod> --tail=200
+```
+
+The full Nextflow log, including per-process work directories, is on the shared
+filesystem at `<launch dir>/.nextflow.log`. Each failed process reports its own work
+directory — `.command.err` and `.command.log` there are usually more informative than
+the driver's summary.

--- a/radiant/dags/nextflow_postprocessing.py
+++ b/radiant/dags/nextflow_postprocessing.py
@@ -1,0 +1,84 @@
+"""Run the Ferlab Post-processing-Pipeline (VEP / slivar / Exomiser) from Airflow.
+
+A single task launches a Nextflow *driver* pod on qlin-eks; that driver then spawns
+one worker pod per pipeline process through Nextflow's own k8s executor. Airflow
+sees one task, Kubernetes sees a fan-out.
+
+Run-invariant settings (reference paths, tools, VEP/Exomiser versions) live in the
+`nextflow-params` ConfigMap, the executor and resource layout in `nextflow-cfg` --
+both owned by the kustomization in qlin-qa-infra. Only the two values that change
+every run are exposed here as DAG params.
+
+Resume
+------
+The Nextflow launch directory is keyed by ``RUN_TAG``, derived from the Airflow
+``run_id``: stable across task retries, unique per DAG run. A retry therefore
+re-enters the same launch dir and `-resume` skips what already completed, which on
+WGS is the difference between minutes and hours. It only helps if the task actually
+retries, hence the explicit ``retries`` below -- ``DEFAULT_ARGS`` carries only
+``owner`` and Airflow defaults ``retries`` to 0.
+"""
+
+import pendulum
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from radiant.dags import DEFAULT_ARGS, NAMESPACE, load_docs_md
+
+# K8s only: the driver needs the FSx-Lustre PVC and the `nextflow` namespace, so
+# unlike import_part.py this DAG has no ECS branch.
+from radiant.dags.operators import k8s as operators
+
+dag_params = {
+    "input": Param(
+        type="string",
+        title="Input samplesheet (CSV)",
+        description=(
+            "Absolute path to the samplesheet on the shared workspace, e.g. "
+            "/workspace/inputs/1000genomes-dragen-v4-4-7/samplesheet.csv"
+        ),
+        minLength=1,
+    ),
+    "outdir": Param(
+        default="",
+        type="string",
+        title="Output directory",
+        description=("Absolute path for published outputs. Leave empty to use /workspace/outputs/qlin/<run tag>."),
+    ),
+}
+
+
+@dag(
+    dag_id=f"{NAMESPACE}-nextflow-postprocessing",
+    dag_display_name="Radiant - Nextflow Post-processing",
+    # retries are load-bearing here, not defensive: they are what makes -resume
+    # reachable (see the module docstring).
+    default_args=DEFAULT_ARGS | {"retries": 2, "retry_delay": pendulum.duration(minutes=5)},
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    # One driver at a time: concurrent runs would share the same FSx workspace.
+    max_active_runs=1,
+    tags=["radiant", "nextflow", "manual"],
+    params=dag_params,
+    doc_md=load_docs_md("nextflow_postprocessing.md"),
+)
+def nextflow_postprocessing():
+    # Not ts_nodash: an Airflow 3 manual run can have a null logical_date, and
+    # date-derived templates then raise UndefinedError at render time.
+    run_tag = "{{ run_id | replace(':', '-') | replace('+', '-') }}"
+
+    run = operators.NextflowPostprocessing.get_run_postprocessing(
+        input_csv="{{ params.input }}",
+        outdir="{{ params.outdir }}",
+        run_tag=run_tag,
+    )
+    cleanup = operators.NextflowPostprocessing.get_cleanup_work(run_tag=run_tag)
+
+    # Default trigger rule (all_success) on purpose: the scratch is exactly what
+    # `-resume` reads, so cleaning up after a failure would make every retry a full
+    # re-run. A failed run keeps its workdir until the work-cleanup CronJob ages it out.
+    run >> cleanup
+
+
+nextflow_postprocessing()

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -65,6 +65,18 @@ def _metadata_container_resources() -> k8s.V1ResourceRequirements:
     return _container_resources("METADATA", cpu="500m", memory="1Gi", memory_limit="2Gi")
 
 
+def _nextflow_container_resources() -> k8s.V1ResourceRequirements:
+    """The Nextflow driver orchestrates; it does not process data. Every VCF actually
+    gets read in a worker pod that Nextflow's k8s executor spawns itself, sized by
+    `nextflow.config` rather than by anything here.
+
+    So this sizes a JVM that holds the task graph and polls the API server. It is the
+    one long-lived pod in the run, which is why it is worth requesting properly: a
+    driver OOMKilled halfway through loses the whole pipeline, not one task.
+    """
+    return _container_resources("NEXTFLOW", cpu="1", memory="2Gi", memory_limit="4Gi")
+
+
 class RadiantTaskK8SOperator:
     @staticmethod
     def _get_k8s_context(radiant_namespace: str, container_resources: k8s.V1ResourceRequirements | None = None):
@@ -374,4 +386,180 @@ class CheckDataIntegrity:
             # block other tasks.
             deferrable=False,
             is_delete_operator_pod=True,
+        )
+
+
+# `cmds`/`arguments` are Jinja-templated fields, so nothing here may contain `{{` or
+# `{%`; per-run values arrive as env vars instead.
+#
+# The `cd` is load-bearing: Nextflow reads `.nextflow/cache` from the working
+# directory, so a launch dir keyed by RUN_TAG is what lets a retry `-resume`.
+_NEXTFLOW_DRIVER_SCRIPT = """
+set -euo pipefail
+LAUNCH="${NXF_WORKSPACE}/work/.nextflow-launchdir/${RUN_TAG}"
+OUTDIR="${NXF_OUTDIR:-${NXF_WORKSPACE}/outputs/qlin/${RUN_TAG}}"
+mkdir -p "$LAUNCH" && cd "$LAUNCH"
+echo ">> run_tag=$RUN_TAG input=$NXF_INPUT outdir=$OUTDIR"
+nextflow run "${NXF_HOME}/assets/Ferlab-Ste-Justine/Post-processing-Pipeline" \
+    -profile docker \
+    -c /etc/nextflow/nextflow.config \
+    -resume \
+    -params-file /etc/nextflow-params/params.json \
+    --input "$NXF_INPUT" \
+    --outdir "$OUTDIR"
+# Let the /outputs DRA flush the last file events to S3 before the pod terminates.
+sleep "${POST_RUN_DRAIN_SECONDS}"
+"""
+
+
+# `${RUN_TAG:?}` is load-bearing, not defensive style: an empty RUN_TAG would expand
+# the paths below to `/workspace/work/` and `/workspace/work/.nextflow-launchdir/`,
+# deleting every run's scratch on the shared filesystem. The guard aborts instead.
+_NEXTFLOW_CLEANUP_SCRIPT = """
+set -euo pipefail
+: "${RUN_TAG:?RUN_TAG is empty - refusing to delete}"
+: "${NXF_WORKSPACE:?NXF_WORKSPACE is empty - refusing to delete}"
+WORK="${NXF_WORKSPACE}/work/${RUN_TAG}"
+LAUNCH="${NXF_WORKSPACE}/work/.nextflow-launchdir/${RUN_TAG}"
+echo ">> before:"; df -h "${NXF_WORKSPACE}" | tail -1
+for d in "$WORK" "$LAUNCH"; do
+  if [ -d "$d" ]; then
+    echo ">> removing $d ($(du -sh "$d" 2>/dev/null | cut -f1))"
+    rm -rf "$d"
+  else
+    echo ">> $d absent, nothing to do"
+  fi
+done
+echo ">> after:"; df -h "${NXF_WORKSPACE}" | tail -1
+"""
+
+
+class NextflowPostprocessing:
+    """Runs the Ferlab Post-processing-Pipeline (VEP / slivar / Exomiser) as a
+    Nextflow driver pod, which spawns its own worker pods via Nextflow's k8s executor.
+
+    Unlike every other operator here it runs in the `nextflow` namespace under the
+    `nextflow` service account -- that SA carries the Pod Identity for S3 and the RBAC
+    to spawn workers -- and it is the only one that mounts volumes.
+    """
+
+    @staticmethod
+    def get_run_postprocessing(input_csv: str, outdir: str, run_tag: str) -> KubernetesPodOperator:
+        workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
+        return KubernetesPodOperator(
+            task_id="run_postprocessing",
+            task_display_name="[K8s] Run Nextflow Post-processing",
+            name="nextflow-postprocessing-driver",
+            namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
+            service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
+            image=os.getenv("NEXTFLOW_OPERATOR_IMAGE"),
+            image_pull_policy="IfNotPresent",
+            cmds=["/bin/bash", "-c"],
+            arguments=[_NEXTFLOW_DRIVER_SCRIPT],
+            env_vars={
+                # nextflow.config also reads RUN_TAG via System.getenv, for
+                # `workDir = /workspace/work/${runTag}` -- so one tag stabilises both
+                # the work dir and the launch dir, which is what -resume needs.
+                "RUN_TAG": run_tag,
+                "NXF_INPUT": input_csv,
+                "NXF_OUTDIR": outdir,
+                "NXF_WORKSPACE": workspace,
+                # ANSI progress redraws are unreadable once captured into a task log.
+                "NXF_ANSI_LOG": "false",
+                "POST_RUN_DRAIN_SECONDS": os.getenv("NEXTFLOW_OPERATOR_DRAIN_SECONDS", "30"),
+                # No AWS_* here, unlike the other operators: this pod has Pod Identity,
+                # and injecting empty credentials would break the chain.
+            },
+            volumes=[
+                k8s.V1Volume(
+                    name="workspace",
+                    persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
+                    ),
+                ),
+                k8s.V1Volume(
+                    name="nextflow-cfg",
+                    config_map=k8s.V1ConfigMapVolumeSource(
+                        name=os.getenv("NEXTFLOW_OPERATOR_CONFIG_CONFIGMAP", "nextflow-cfg"),
+                    ),
+                ),
+                k8s.V1Volume(
+                    name="nextflow-params",
+                    config_map=k8s.V1ConfigMapVolumeSource(
+                        name=os.getenv("NEXTFLOW_OPERATOR_PARAMS_CONFIGMAP", "nextflow-params"),
+                    ),
+                ),
+            ],
+            volume_mounts=[
+                k8s.V1VolumeMount(name="workspace", mount_path=workspace),
+                k8s.V1VolumeMount(name="nextflow-cfg", mount_path="/etc/nextflow", read_only=True),
+                k8s.V1VolumeMount(name="nextflow-params", mount_path="/etc/nextflow-params", read_only=True),
+            ],
+            # The nodepool is pinned to the FSx AZ; landing elsewhere means a cross-AZ
+            # Lustre mount. do-not-disrupt stops Karpenter consolidating the driver away.
+            node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
+            annotations={"karpenter.sh/do-not-disrupt": "true"},
+            container_resources=_nextflow_container_resources(),
+            get_logs=True,
+            # A WGS run takes hours, so the worker slot is released and the triggerer
+            # polls instead. Both run as the `airflow` SA, which needs RBAC in the
+            # `nextflow` namespace (see apps/nextflow/rbac.yaml in qlin-qa-infra).
+            deferrable=True,
+            poll_interval=float(os.getenv("NEXTFLOW_OPERATOR_POLL_INTERVAL", "30")),
+            # Without this a deferred pod's logs only surface once it finishes, so a
+            # multi-hour run looks silent in the UI.
+            logging_interval=int(os.getenv("NEXTFLOW_OPERATOR_LOGGING_INTERVAL", "600")),
+            # The provider default of 120s is short of a Karpenter cold start plus a
+            # multi-GB image pull on a fresh node.
+            startup_timeout_seconds=int(os.getenv("NEXTFLOW_OPERATOR_STARTUP_TIMEOUT_SECONDS", "1800")),
+            # Backstop: clearing a deferred task does not delete its pod, and a second
+            # driver against the same launch dir corrupts the resume cache.
+            active_deadline_seconds=int(os.getenv("NEXTFLOW_OPERATOR_ACTIVE_DEADLINE_SECONDS", "86400")),
+            # Keep a failed driver for inspection; clean up successful ones.
+            on_finish_action="delete_succeeded_pod",
+        )
+
+    @staticmethod
+    def get_cleanup_work(run_tag: str) -> KubernetesPodOperator:
+        """Delete this run's Nextflow scratch after a successful pipeline.
+
+        A WGS run leaves ~200-280 GB in workDir plus the launch dir, and the
+        work-cleanup CronJob only sweeps launchdirs older than MAX_AGE_DAYS -- so
+        without this, a couple of runs fill the 1.2 TiB filesystem and the failure
+        surfaces as ENOSPC on whichever task happens to be writing.
+
+        Only ever wired downstream of a SUCCESSFUL run: the scratch is what `-resume`
+        needs, so deleting it after a failure would turn every Airflow retry into a
+        full re-run.
+        """
+        workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
+        return KubernetesPodOperator(
+            task_id="cleanup_work",
+            task_display_name="[K8s] Clean up Nextflow scratch",
+            name="nextflow-postprocessing-cleanup",
+            namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
+            service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
+            # Reuse the driver image: it is already cached on these nodes, so this
+            # adds no pull.
+            image=os.getenv("NEXTFLOW_OPERATOR_IMAGE"),
+            image_pull_policy="IfNotPresent",
+            cmds=["/bin/bash", "-c"],
+            arguments=[_NEXTFLOW_CLEANUP_SCRIPT],
+            env_vars={"RUN_TAG": run_tag, "NXF_WORKSPACE": workspace},
+            volumes=[
+                k8s.V1Volume(
+                    name="workspace",
+                    persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
+                        claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
+                    ),
+                ),
+            ],
+            volume_mounts=[k8s.V1VolumeMount(name="workspace", mount_path=workspace)],
+            node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
+            container_resources=_container_resources(
+                "NEXTFLOW_CLEANUP", cpu="500m", memory="512Mi", memory_limit="1Gi"
+            ),
+            get_logs=True,
+            deferrable=False,
+            on_finish_action="delete_succeeded_pod",
         )

--- a/tests/unit/dags/operators/k8s/test_nextflow_postprocessing_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_nextflow_postprocessing_k8s_operator.py
@@ -1,0 +1,134 @@
+import os
+from unittest.mock import patch
+
+from radiant.dags.operators.k8s import NextflowPostprocessing
+
+
+def _build(env: dict):
+    with patch.dict(os.environ, env, clear=True):
+        return NextflowPostprocessing.get_run_postprocessing(
+            input_csv="/workspace/inputs/samplesheet.csv",
+            outdir="/workspace/outputs/qlin/run1",
+            run_tag="manual__2026-08-20T14-30-00-00-00",
+        )
+
+
+def test_get_run_postprocessing_with_env():
+    fake_env = {
+        "NEXTFLOW_OPERATOR_IMAGE": "my-registry/nextflow-launcher:test",
+        "NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE": "nf",
+        "NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME": "nf-sa",
+        "NEXTFLOW_OPERATOR_PVC_NAME": "fsx-test",
+        "NEXTFLOW_OPERATOR_NODEPOOL": "test-pool",
+        "NEXTFLOW_OPERATOR_WORKSPACE_PATH": "/ws",
+        "RADIANT_TASK_OPERATOR_NEXTFLOW_MEMORY": "8Gi",
+    }
+    op = _build(fake_env)
+
+    assert op.task_id == "run_postprocessing"
+    assert op.namespace == "nf"
+    assert op.service_account_name == "nf-sa"
+    assert op.image == "my-registry/nextflow-launcher:test"
+
+    # Deferrable so a multi-hour run does not hold an Airflow worker slot.
+    assert op.deferrable is True
+    assert op.get_logs is True
+    assert op.node_selector == {"nodepool": "test-pool"}
+    assert op.annotations == {"karpenter.sh/do-not-disrupt": "true"}
+
+    # The env-var override path on the shared _container_resources helper.
+    assert op.container_resources.requests["memory"] == "8Gi"
+
+    volumes = {v.name: v for v in op.volumes}
+    assert set(volumes) == {"workspace", "nextflow-cfg", "nextflow-params"}
+    assert volumes["workspace"].persistent_volume_claim.claim_name == "fsx-test"
+    assert volumes["nextflow-cfg"].config_map.name == "nextflow-cfg"
+    assert volumes["nextflow-params"].config_map.name == "nextflow-params"
+
+    mounts = {m.name: m for m in op.volume_mounts}
+    assert mounts["workspace"].mount_path == "/ws"
+    assert mounts["nextflow-cfg"].mount_path == "/etc/nextflow"
+    assert mounts["nextflow-cfg"].read_only is True
+    assert mounts["nextflow-params"].read_only is True
+
+    env = {e.name: e.value for e in op.env_vars}
+    assert env["NXF_INPUT"] == "/workspace/inputs/samplesheet.csv"
+    assert env["NXF_OUTDIR"] == "/workspace/outputs/qlin/run1"
+    assert env["RUN_TAG"] == "manual__2026-08-20T14-30-00-00-00"
+    assert env["NXF_WORKSPACE"] == "/ws"
+    assert env["NXF_ANSI_LOG"] == "false"
+
+    # Pod Identity provides the credentials; injecting empty AWS_* would break the
+    # credential chain, so unlike the other operators none are set here.
+    assert not [name for name in env if name.startswith("AWS_")]
+
+
+def test_get_run_postprocessing_defaults_match_the_qa_topology():
+    """With nothing configured, the operator still targets the real deployment --
+    only the image has no sensible default."""
+    op = _build({})
+
+    assert op.namespace == "nextflow"
+    assert op.service_account_name == "nextflow"
+    assert op.node_selector == {"nodepool": "qlin-nextflow"}
+    assert op.volumes[0].persistent_volume_claim.claim_name == "fsx-nextflow"
+    assert op.volume_mounts[0].mount_path == "/workspace"
+    assert op.container_resources.requests == {"cpu": "1", "memory": "2Gi"}
+    assert op.container_resources.limits == {"memory": "4Gi"}
+
+    # A missing image must fail loudly at pod creation rather than silently pull
+    # something unintended.
+    assert op.image is None
+
+
+def test_startup_timeout_survives_a_karpenter_cold_start():
+    """The provider default is 120s, which a node launch plus a multi-GB image pull
+    exceeds -- the trigger would raise PodLaunchTimeoutException before the driver
+    ever starts."""
+    op = _build({})
+    assert op.startup_timeout_seconds == 1800
+    # Backstop for a cleared deferred task, whose pod is not deleted.
+    assert op.active_deadline_seconds == 86400
+
+
+def test_driver_script_is_jinja_safe():
+    """cmds/arguments are templated fields: a stray {{ or {% in the launch script
+    would fail DAG parsing, and the failure would look nothing like its cause."""
+    (script,) = op_arguments = _build({}).arguments
+    assert op_arguments  # sanity
+    assert "{{" not in script
+    assert "{%" not in script
+    # The cd is what makes -resume work: Nextflow reads .nextflow/cache from cwd.
+    assert 'cd "$LAUNCH"' in script
+    assert "-resume" in script
+
+
+def _cleanup(env: dict):
+    with patch.dict(os.environ, env, clear=True):
+        return NextflowPostprocessing.get_cleanup_work(run_tag="manual__2026-08-20T14-30-00-00-00")
+
+
+def test_cleanup_targets_only_this_run():
+    op = _cleanup({"NEXTFLOW_OPERATOR_IMAGE": "img:test"})
+    assert op.task_id == "cleanup_work"
+    assert op.namespace == "nextflow"
+    env = {e.name: e.value for e in op.env_vars}
+    assert env["RUN_TAG"] == "manual__2026-08-20T14-30-00-00-00"
+    assert env["NXF_WORKSPACE"] == "/workspace"
+    # Not deferrable: it is a few seconds of rm, not a multi-hour wait.
+    assert op.deferrable is False
+    # Mounts the PVC so it can delete scratch, and nothing else.
+    assert [v.name for v in op.volumes] == ["workspace"]
+    assert op.volumes[0].persistent_volume_claim.claim_name == "fsx-nextflow"
+
+
+def test_cleanup_script_refuses_to_run_with_an_empty_run_tag():
+    """An empty RUN_TAG would expand to /workspace/work/ and wipe every run's
+    scratch on the shared filesystem, including a concurrently running job."""
+    (script,) = _cleanup({}).arguments
+    assert "${RUN_TAG:?" in script
+    assert "${NXF_WORKSPACE:?" in script
+    assert "set -euo pipefail" in script
+    # Deletion must be scoped to the interpolated paths, never a bare prefix.
+    assert 'rm -rf "$d"' in script
+    assert "{{" not in script and "{%" not in script

--- a/tests/unit/dags/test_nextflow_postprocessing.py
+++ b/tests/unit/dags/test_nextflow_postprocessing.py
@@ -1,0 +1,53 @@
+import pytest
+
+DAG_ID = "radiant-nextflow-postprocessing"
+
+
+def test_dag_is_importable(dag_bag):
+    assert dag_bag.get_dag(DAG_ID) is not None
+    assert not dag_bag.import_errors
+
+
+def test_dag_contains_the_driver_and_cleanup_tasks(dag_bag):
+    dag = dag_bag.get_dag(DAG_ID)
+    assert set(dag.task_ids) == {"run_postprocessing", "cleanup_work"}
+    assert dag.validate() is None
+
+
+def test_cleanup_only_runs_after_a_successful_pipeline(dag_bag):
+    """The scratch is what `-resume` reads. If cleanup ran after a failure, every
+    Airflow retry would become a full re-run instead of resuming."""
+    dag = dag_bag.get_dag(DAG_ID)
+    cleanup = dag.get_task("cleanup_work")
+    assert cleanup.trigger_rule == "all_success"
+    assert {t.task_id for t in cleanup.upstream_list} == {"run_postprocessing"}
+
+
+def test_dag_exposes_exactly_input_and_outdir(dag_bag):
+    """Guards against param creep: everything run-invariant belongs in the
+    nextflow-params ConfigMap, not here."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert set(dag.params) == {"input", "outdir"}
+
+
+def test_input_is_required_and_outdir_is_not(dag_bag):
+    dag = dag_bag.get_dag(DAG_ID)
+    # outdir defaults to empty, which the driver reads as "derive from the run tag".
+    assert dag.params["outdir"] == ""
+    with pytest.raises(Exception):
+        dag.params.validate()
+
+
+def test_retries_are_configured_so_resume_is_reachable(dag_bag):
+    """RUN_TAG is derived from run_id precisely so a retry re-enters the same
+    Nextflow launch dir. DEFAULT_ARGS carries only `owner` and Airflow defaults
+    retries to 0, so without an explicit override there would be no retry to
+    resume from and the whole mechanism would be dead code."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert dag.default_args["retries"] >= 1
+
+
+def test_only_one_driver_runs_at_a_time(dag_bag):
+    """Concurrent runs would share the same FSx workspace."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert dag.max_active_runs == 1


### PR DESCRIPTION
## 📌 Context

The Nextflow post-processing pipeline (joint genotyping → VEP → slivar → Exomiser) could only be run by hand on qlin-eks, via a shell script that applied a `postprocessing-driver` Job. That script and Job were always meant to be replaced by an Airflow task.

This adds the DAG, plus the driver image it launches.

## 📝 Changes

- `radiant/dags/nextflow_postprocessing.py` — new DAG `radiant-nextflow-postprocessing`, two params (`input` samplesheet CSV, `outdir`), everything run-invariant stays in the `nextflow-params` ConfigMap.
- `radiant/dags/operators/k8s.py` — `NextflowPostprocessing` with two factories: `get_run_postprocessing` (deferrable driver pod) and `get_cleanup_work` (deletes the run's scratch on success).
- `Dockerfile.nextflow.launcher` + `.github/workflows/build_and_push_nextflow_launcher.yml` — driver image, ported from `poc-nextflow-aws` where it had no build automation. Publishes `ghcr.io/radiant-network/nextflow-launcher` on `v*` tags, same shape as the other images here.
- `radiant/.airflowignore` — stop the DAG processor importing `radiant/tasks/`.

Pod runs in the `nextflow` namespace with that namespace's service account and the FSx-Lustre PVC, so it is K8s-only and does not branch on `IS_AWS`.

## ☑️ TO-DOs

- [ ] Cut a `v*` tag so the launcher image is published, then point `NEXTFLOW_OPERATOR_IMAGE` at it (currently a hand-pushed build in `poc-nextflow`)
- [ ] Infra PR in `qlin-qa-infra`: RBAC letting the `airflow` SA manage pods **and list events** in the `nextflow` namespace, plus the `NEXTFLOW_OPERATOR_IMAGE` env var

## 🧪 Tests

- `tests/unit/dags/test_nextflow_postprocessing.py` — DAG parses, task set, params, retries present, `max_active_runs=1`, cleanup gated on `all_success`.
- `tests/unit/dags/operators/k8s/.../test_nextflow_postprocessing_k8s_operator.py` — namespace/SA/image, deferrable, volumes and mounts, node selector, env vars, and that the inlined scripts contain no Jinja.
- `make test-unit` → 61 passing in `tests/unit/dags/`; `make test-static` clean.
- Validated end to end against the real cluster: driver runs, spawns workers, and completes the pipeline for 9 families.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-749
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **`retries` is load-bearing.** `RUN_TAG` derives from `run_id`, so it is stable across retries and a retry resumes the Nextflow session instead of re-running joint genotyping. `DEFAULT_ARGS` has no `retries` and Airflow defaults it to 0, hence the explicit override.
- **`run_id`, not `ts_nodash`.** An Airflow 3 manual run can have a null `logical_date`, and date-derived templates then raise `UndefinedError` at render time — a failure the 2.10-based tests here cannot reproduce.
- **Cleanup is gated on `all_success` on purpose.** The scratch is what `-resume` reads; deleting it after a failure would make every retry a full re-run. Note the `${RUN_TAG:?}` guard — an empty value would expand to `/workspace/work/` and wipe every run's scratch on the shared filesystem.
- **First use of volumes / a non-default namespace** in this repo's operators, so there is no local precedent to compare against; the reference is the driver Job in `qlin-qa-infra`.
- `startup_timeout_seconds=1800` because the provider default of 120s is shorter than a Karpenter cold start plus a multi-GB image pull.
