### PR TITLE
fix: SJRA-1822 CSQ field lookup — SOURCE and MANE_SELECT are never read

### DIFF
--- a/radiant/tasks/vcf/snv/consequence.py
+++ b/radiant/tasks/vcf/snv/consequence.py
@@ -67,17 +67,23 @@ SCHEMA = merge_schemas(
 
 def get_csq_field(csq_fields, fields, field_name):
     """
-    Safely retrieves a field from CSQ annotation by name.
+    Safely retrieves a field from CSQ annotation by name, ignoring case.
+
+    VEP does not spell its CSQ column names consistently across versions and plugins
+    (`SOURCE` vs `Source`), and a lookup under the wrong spelling silently yields None.
+    Matching on the lowercased name removes that failure mode.
 
     Args:
-        csq_fields (dict): Mapping of CSQ field names to indexes.
+        csq_fields (dict): Mapping of lowercased CSQ field names to indexes, as
+            returned by `parse_csq_header`.
         fields (list): Parsed CSQ annotation fields from a single transcript.
-        field_name (str): Name of the CSQ field to retrieve.
+        field_name (str): Name of the CSQ field to retrieve, in any case.
 
     Returns:
         str or None: Value of the CSQ field or None if not found.
     """
-    return fields[csq_fields[field_name]] if field_name in csq_fields else None
+    index = csq_fields.get(field_name.lower())
+    return fields[index] if index is not None else None
 
 
 def process_consequence(record: Variant, csq_fields: dict[str, int], common: Common) -> tuple[dict, list[dict]]:
@@ -101,7 +107,8 @@ def process_consequence(record: Variant, csq_fields: dict[str, int], common: Com
         csq_data = csq.split(",")
         for c in csq_data:
             fields = c.split("|")
-            exon = get_csq_field(csq_fields, fields, "EXON").split("/")
+            exon_field = get_csq_field(csq_fields, fields, "EXON")
+            exon = exon_field.split("/") if exon_field else []
             vep_impact = get_csq_field(csq_fields, fields, "IMPACT")
             hgvsg = get_csq_field(csq_fields, fields, "HGVSg")
             hgvsp = get_csq_field(csq_fields, fields, "HGVSp")
@@ -122,13 +129,13 @@ def process_consequence(record: Variant, csq_fields: dict[str, int], common: Com
                 "hgvsc": hgvsc,
                 "symbol": get_csq_field(csq_fields, fields, "SYMBOL"),
                 "transcript_id": get_csq_field(csq_fields, fields, "Feature"),
-                "source": get_csq_field(csq_fields, fields, "Source"),
+                "source": get_csq_field(csq_fields, fields, "SOURCE"),
                 "biotype": get_csq_field(csq_fields, fields, "BIOTYPE"),
                 "strand": get_csq_field(csq_fields, fields, "STRAND"),
                 "exon": {"rank": str(exon[0]), "total": str(exon[1])} if len(exon) == 2 else None,
                 "vep_impact": vep_impact,
                 "consequences": get_csq_field(csq_fields, fields, "Consequence").split("&"),
-                "mane_select": get_csq_field(csq_fields, fields, "ManeSelect"),
+                "mane_select": get_csq_field(csq_fields, fields, "MANE_SELECT"),
                 "is_mane_select": False,
                 "is_mane_plus": False,
                 "is_picked": picked,
@@ -153,13 +160,13 @@ def parse_csq_header(vcf):
         vcf: A cyvcf2.VCF reader object.
 
     Returns:
-        dict[str, int]: Mapping from CSQ field names to their indexes.
+        dict[str, int]: Mapping from lowercased CSQ field names to their indexes.
     """
     info_csq = vcf.get_header_type(CSQ_FORMAT_FIELD)
     csq_meta = info_csq.get("Description", "")
     csq_meta = csq_meta.split("Format:")[-1].strip(' "')
     csq_fields = csq_meta.split("|") if csq_meta else []
-    return {f: i for i, f in enumerate(csq_fields)}
+    return {f.lower(): i for i, f in enumerate(csq_fields)}
 
 
 IMPACT_SCORE = {"HIGH": 4, "MODERATE": 3, "LOW": 2, "MODIFIER": 1}

--- a/tests/resources/test_consequence_lowercase_csq_no_exon.vcf
+++ b/tests/resources/test_consequence_lowercase_csq_no_exon.vcf
@@ -1,0 +1,5 @@
+##fileformat=VCFv4.2
+##INFO=<ID=CSQ,Number=.,Type=String,Description="Consequence annotations from Ensembl VEP. Format: Allele|Consequence|IMPACT|SYMBOL|Feature|BIOTYPE|STRAND|VARIANT_CLASS|HGVSg|HGVSc|HGVSp|CANONICAL|PICK|Mane_Select|Source">
+##contig=<ID=chr1,length=249250621>
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO
+chr1	12345	.	G	A	99	PASS	CSQ=A|missense_variant|MODERATE|BRCA1|ENST00000357654|protein_coding|1|SNV|g.12345G>A|c.227A>T|p.Lys76Asn|YES|1|NM_007294.3|Ensembl

--- a/tests/unit/vcf/test_consequence.py
+++ b/tests/unit/vcf/test_consequence.py
@@ -51,9 +51,9 @@ def test_one_sample():
         "is_picked": True,
         "locus": "1-1000-AC-A",
         "locus_hash": "hash",
-        "mane_select": None,
+        "mane_select": "ENST00000357654.7",
         "reference": "AC",
-        "source": None,
+        "source": "Ensembl",
         "start": 1000,
         "strand": "1",
         "symbol": "BRCA1",
@@ -65,3 +65,54 @@ def test_one_sample():
     picked, consequences = process_consequence(v, csq_header, common)
     assert picked == expected_picked
     assert consequences is not None
+
+
+def test_one_sample_second_consequence_is_refseq():
+    v = variant("test_consequence_one_sample.vcf", row_number=2)
+    with vcf("test_consequence_one_sample.vcf") as vcf_file:
+        csq_header = parse_csq_header(vcf_file)
+
+    _, consequences = process_consequence(v, csq_header, common)
+
+    assert len(consequences) == 1
+    assert consequences[0]["source"] == "RefSeq"
+    assert consequences[0]["mane_select"] == "ENST00000269305.9"
+
+
+def test_source_column_absent_from_header_stays_none():
+    # test_somatic_snv.vcf declares MANE_SELECT but no SOURCE. An absent column must stay
+    # null rather than pick up a neighbouring field's value; a declared-but-empty one is "".
+    v = variant("test_somatic_snv.vcf")
+    with vcf("test_somatic_snv.vcf") as vcf_file:
+        csq_header = parse_csq_header(vcf_file)
+
+    _, consequences = process_consequence(v, csq_header, common)
+
+    assert consequences
+    assert all(c["source"] is None for c in consequences)
+    assert all(c["mane_select"] == "" for c in consequences)
+
+
+def test_csq_field_names_are_matched_case_insensitively():
+    # VEP spells these columns differently across versions and plugins, so the lookup
+    # must not depend on the casing used in the header.
+    v = variant("test_consequence_lowercase_csq_no_exon.vcf")
+    with vcf("test_consequence_lowercase_csq_no_exon.vcf") as vcf_file:
+        csq_header = parse_csq_header(vcf_file)
+
+    picked, _ = process_consequence(v, csq_header, common)
+
+    assert picked["source"] == "Ensembl"
+    assert picked["mane_select"] == "NM_007294.3"
+
+
+def test_missing_exon_field_does_not_raise():
+    # EXON is optional: `.split("/")` on the missing value used to raise AttributeError.
+    v = variant("test_consequence_lowercase_csq_no_exon.vcf")
+    with vcf("test_consequence_lowercase_csq_no_exon.vcf") as vcf_file:
+        csq_header = parse_csq_header(vcf_file)
+
+    picked, _ = process_consequence(v, csq_header, common)
+
+    assert picked["exon"] is None
+    assert picked["symbol"] == "BRCA1"


### PR DESCRIPTION
## 📌 Context

`radiant/tasks/vcf/snv/consequence.py` looked up two CSQ columns under names VEP never
emits: `"Source"` (VEP's key is `SOURCE`) and `"ManeSelect"` (VEP's key is `MANE_SELECT`).
`get_csq_field` returns `None` for an unknown name instead of raising, so this failed
silently — the Iceberg `source` (schema id 207) and `mane_select` (id 216) columns have
been null on every file ingested so far, including files that carried the data.

Bug fix, and a prerequisite for the rest of SJRA-1820 (merged Ensembl/RefSeq ingestion),
which needs both columns populated before it can classify a consequence's source.

## 📝 Changes

- **Case-insensitive CSQ lookup.** `parse_csq_header` lowercases its keys and
  `get_csq_field` lowercases the requested name. VEP's spelling is not stable across
  versions and plugins, so pinning to one casing is what created the bug; this removes the
  failure mode for the sub-tasks that follow.
- **Corrected the two call sites** to `SOURCE` and `MANE_SELECT`.
- **Guarded the `EXON` access.** `get_csq_field(...).split("/")` raised `AttributeError`
  when the column is absent. Latent today only because every existing fixture has `EXON`.

## ☑️ TO-DOs

- [ ] Nothing blocking. Existing rows keep their null `source` / `mane_select` until a
      reload — no migration here, and none needed before SJRA-1826 rebuilds the table.

## 🧪 Tests

```
make test-static && make test-unit
```

623 unit tests pass, ruff clean. In `tests/unit/vcf/test_consequence.py`:

- `test_one_sample` expectations move from `None` to `source="Ensembl"` /
  `mane_select="ENST00000357654.7"` — `test_consequence_one_sample.vcf` carries both
  columns, so that assertion is the proof the fix works. A second test covers the RefSeq
  row of the same fixture.
- Regression test on `test_somatic_snv.vcf`, which declares `MANE_SELECT` but has no
  `SOURCE` column: `source` stays `None`, `mane_select` is `""`.
- New fixture `test_consequence_lowercase_csq_no_exon.vcf` — mixed-case header
  (`Mane_Select|Source`) and no `EXON` — covering the case-insensitive lookup and the
  `EXON` guard.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1822

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **`mane_select` now flows into `snv__variant`.** `variant.py` copies it off the picked
  consequence, so that StarRocks column starts receiving values on the next run. Expected.
  Note it keeps VEP's version suffix (`.7`) for now — SJRA-1824 stores the cross-reference
  unversioned, which is what the MANE join in §7 of the design doc needs.
- **The ticket's stated verification fixture was wrong**, worth knowing if you check it
  against the Jira: `test_somatic_snv.vcf` has the `MANE_SELECT` header column but every
  value in it is empty, so it can't carry the positive assertion. It's the negative case
  here instead.
- **`"consequences": get_csq_field(..., "Consequence").split("&")` has the identical
  latent `AttributeError`** the `EXON` guard just fixed. Left alone — out of this
  sub-task's scope and `Consequence` is a mandatory VEP field — but say the word and it's
  the same one-line change.
