### PR TITLE
feat: SJRA-1833 add pick_source to snv__variant and its derivated tables

### DIFF
--- a/radiant/dags/sql/radiant/init/snv_staging_variant_create_table.sql
+++ b/radiant/dags/sql/radiant/init/snv_staging_variant_create_table.sql
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS {{ mapping.starrocks_snv_staging_variant }} (
     dna_change VARCHAR(2000),
     aa_change VARCHAR(2000),
     transcript_id varchar(100) COMMENT "",
+    pick_source varchar(20) NULL COMMENT "",
     omim_inheritance_code array<varchar(5)> COMMENT ""
 )
 PRIMARY KEY(locus_id)

--- a/radiant/dags/sql/radiant/init/snv_tmp_variant_create_table.sql
+++ b/radiant/dags/sql/radiant/init/snv_tmp_variant_create_table.sql
@@ -23,7 +23,8 @@ CREATE TABLE IF NOT EXISTS {{ mapping.starrocks_snv_tmp_variant }}
     `locus_hash` varchar(64) NULL,
     `dna_change` varchar(2000),
     `aa_change` varchar(2000),
-    `transcript_id` varchar(100) COMMENT ""
+    `transcript_id` varchar(100) COMMENT "",
+    `pick_source` varchar(20) NULL COMMENT ""
 )
 ENGINE=OLAP
 PRIMARY KEY(`locus_id`)

--- a/radiant/dags/sql/radiant/init/snv_variant_create_table.sql
+++ b/radiant/dags/sql/radiant/init/snv_variant_create_table.sql
@@ -57,6 +57,7 @@ CREATE TABLE IF NOT EXISTS {{ mapping.starrocks_snv_variant }} (
     dna_change VARCHAR(2000),
     aa_change VARCHAR(2000),
     transcript_id varchar(100) COMMENT "",
+    pick_source varchar(20) NULL COMMENT "",
     omim_inheritance_code array<varchar(5)> COMMENT ""
 )
 PRIMARY KEY(locus_id)

--- a/radiant/dags/sql/radiant/init/snv_variant_partitioned_create_table.sql
+++ b/radiant/dags/sql/radiant/init/snv_variant_partitioned_create_table.sql
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS {{ mapping.starrocks_snv_variant_partitioned }} (
     dna_change VARCHAR(2000),
     aa_change VARCHAR(2000),
     transcript_id varchar(100) COMMENT "",
+    pick_source varchar(20) NULL COMMENT "",
     omim_inheritance_code array<varchar(5)> COMMENT ""
 )
 PARTITION BY (`part`)

--- a/radiant/dags/sql/radiant/migrations/SJRA-1833_snv_variant_add_pick_source.sql
+++ b/radiant/dags/sql/radiant/migrations/SJRA-1833_snv_variant_add_pick_source.sql
@@ -1,0 +1,114 @@
+-- SJRA-1833 — record which transcript catalogue VEP's picked consequence came from.
+--
+-- `snv__variant` carries a headline block copied verbatim from the picked consequence: transcript_id,
+-- symbol, hgvsg, hgvsc, hgvsp, dna_change, aa_change, is_canonical, is_mane_select, is_mane_plus,
+-- consequences, vep_impact, impact_score. With VEP `--merged` that pick is a RefSeq transcript for
+-- ~1.4% of variants and nothing in the row says so. `pick_source` says so. The pick itself is
+-- unchanged — see §5 of design/SJRA-1820-vep-merged-refseq-ingestion.md for why overriding it would
+-- break the block's internal coherence.
+--
+-- Run manually, ONCE per database. Unlike the SJRA-1820 consequence migration, this one spans both
+-- scopes (radiant/tasks/data/radiant_tables.py):
+--
+--   base database           snv__tmp_variant, snv__staging_variant   (STARROCKS_RADIANT_BASE_MAPPING)
+--   every {tenant}_tenant   snv__variant, snv__variant_partitioned   (STARROCKS_RADIANT_PER_TENANT_MAPPING)
+--
+-- `USE` each database in turn and run only its block. A single-tenant deployment keeps all four in the
+-- base database.
+--
+-- The `AFTER transcript_id` positions are required, not cosmetic: snv_tmp_variant_insert.sql,
+-- snv_staging_variant_insert.sql and snv_variant_insert.sql are positional INSERTs with no target
+-- column list, and snv_variant_part_insert_part.sql copies `v.*` from `snv__variant` into
+-- `snv__variant_partitioned`. All four tables must end up in exactly the order declared by their
+-- init/*_create_table.sql.
+--
+-- New deployments get the column from init/snv_*_variant*_create_table.sql and must NOT run this
+-- script. StarRocks has no `ADD COLUMN IF NOT EXISTS` (3.4.2), so re-running it fails on the ALTER.
+--
+-- Issue each ALTER separately and let it reach FINISHED before the next: StarRocks rejects a second
+-- ALTER while the table state is not NORMAL.
+--
+-- HARD PREREQUISITE. snv_tmp_variant_insert.sql now reads `t.pick_source` from the *Iceberg* variant
+-- table; SJRA-1833 added that field to radiant/tasks/vcf/snv/variant.py::SCHEMA.
+-- `create_variant_table()` in radiant/tasks/iceberg/initialization.py drops and recreates the Iceberg
+-- table from that schema, so the init-iceberg-tables DAG must have run before the new SQL is deployed.
+-- Against an older Iceberg table the insert dies on an unresolved column. CI never sees this: the test
+-- fixtures build the table from the live SCHEMA.
+--
+-- Cost. Every ALTER is a metadata-only light schema change and returns immediately. The two UPDATEs
+-- rewrite every Ensembl row on primary-key tables, which means write load, a new data version and
+-- persistent-index churn — schedule them in a maintenance window.
+
+
+-- ---------------------------------------------------------------------------------------------------
+-- Base database.
+-- ---------------------------------------------------------------------------------------------------
+
+ALTER TABLE snv__tmp_variant
+    ADD COLUMN pick_source VARCHAR(20) AFTER transcript_id;
+
+-- No backfill on snv__tmp_variant: it is INSERT OVERWRITE-d from Iceberg on every import and holds
+-- nothing worth preserving between runs.
+
+ALTER TABLE snv__staging_variant
+    ADD COLUMN pick_source VARCHAR(20) AFTER transcript_id;
+
+-- snv__staging_variant is INSERT INTO, so it accumulates across imports and is what snv__variant is
+-- rebuilt from. Labelling it here is what makes the backfill stick past the next import.
+--
+-- Factual rather than a guess: every file ingested to date was annotated against the Ensembl cache.
+-- `pick_source IS NULL` makes the statement re-runnable and stops it overwriting RefSeq rows should it
+-- ever run after a merged file has landed. Variants whose picked consequence had no transcript keep a
+-- NULL pick_source on purpose — that matches `resolve_source()` rule 4 in
+-- radiant/tasks/vcf/snv/consequence.py: we record "unknown" rather than guessing a catalogue.
+UPDATE snv__staging_variant
+   SET pick_source = 'Ensembl'
+ WHERE pick_source IS NULL
+   AND transcript_id LIKE 'ENST%';
+
+
+-- ---------------------------------------------------------------------------------------------------
+-- Every {tenant}_tenant database.
+-- ---------------------------------------------------------------------------------------------------
+
+ALTER TABLE snv__variant
+    ADD COLUMN pick_source VARCHAR(20) AFTER transcript_id;
+
+UPDATE snv__variant
+   SET pick_source = 'Ensembl'
+ WHERE pick_source IS NULL
+   AND transcript_id LIKE 'ENST%';
+
+ALTER TABLE snv__variant_partitioned
+    ADD COLUMN pick_source VARCHAR(20) AFTER transcript_id;
+
+-- No UPDATE here, and not an oversight: snv__variant_partitioned declares no key clause, so it is a
+-- Duplicate Key table and StarRocks restricts UPDATE to Primary Key tables. The column fills in per
+-- part on the next import_part run, which dynamic_overwrite-s that part from the now-backfilled
+-- snv__variant. If it must be populated everywhere sooner, re-run snv_variant_part_insert_part.sql for
+-- each existing `part` value.
+
+
+-- ---------------------------------------------------------------------------------------------------
+-- Post-checks, read-only.
+-- ---------------------------------------------------------------------------------------------------
+--
+--   SHOW ALTER TABLE COLUMN FROM <database>;
+--       -- expect State = FINISHED immediately for every statement
+--
+--   DESC snv__variant;
+--       -- pick_source must sit between transcript_id and omim_inheritance_code, matching
+--       -- init/snv_variant_create_table.sql. Same check on the other three tables.
+--
+--   SELECT pick_source, count(*) FROM snv__variant GROUP BY 1;
+--       -- expect Ensembl plus, possibly, a NULL bucket for transcript-less picks. No RefSeq yet.
+--
+-- And after the first merged-file load:
+--
+--   SELECT pick_source, count(*) FROM snv__variant GROUP BY 1;
+--       -- expect a RefSeq slice near 1.4%. Zero means the source never reached the picked consequence.
+--
+--   SELECT count(*) AS should_be_zero FROM snv__variant
+--    WHERE (pick_source = 'RefSeq' AND transcript_id LIKE 'ENST%')
+--       OR (pick_source = 'Ensembl' AND transcript_id NOT LIKE 'ENST%' AND transcript_id <> '');
+--       -- pick_source and the headline transcript must agree; a mismatch means the block was mixed

--- a/radiant/dags/sql/radiant/snv_staging_variant_insert.sql
+++ b/radiant/dags/sql/radiant/snv_staging_variant_insert.sql
@@ -28,6 +28,7 @@ SELECT
     v.dna_change,
     v.aa_change,
     v.transcript_id,
+    v.pick_source,
     om.inheritance_code AS omim_inheritance_code
 FROM {{ mapping.starrocks_snv_tmp_variant }} v
 LEFT JOIN {{ mapping.starrocks_gnomad_genomes_v3 }} g ON g.locus_id = v.locus_id

--- a/radiant/dags/sql/radiant/snv_tmp_variant_insert.sql
+++ b/radiant/dags/sql/radiant/snv_tmp_variant_insert.sql
@@ -22,7 +22,8 @@ SELECT COALESCE(GET_VARIANT_ID(t.chromosome, t.start, t.reference, t.alternate),
     t.locus_hash,
     t.dna_change,
     t.aa_change,
-    t.transcript_id
+    t.transcript_id,
+    t.pick_source
 FROM {{ mapping.iceberg_snv_variant }} t
 LEFT JOIN {{ mapping.starrocks_variant_lookup }} v ON t.locus_hash = v.locus_hash
 where t.task_id in %(task_ids)s and t.alternate <> '*';

--- a/radiant/dags/sql/radiant/snv_variant_insert.sql
+++ b/radiant/dags/sql/radiant/snv_variant_insert.sql
@@ -79,6 +79,7 @@ SELECT
     v.dna_change,
     v.aa_change,
     v.transcript_id,
+    v.pick_source,
     v.omim_inheritance_code
 FROM {{ mapping.starrocks_snv_staging_variant }} v
 LEFT SEMI JOIN tenant_loci tl ON tl.locus_id = v.locus_id

--- a/radiant/data_qa/sources/snv_variant.yml
+++ b/radiant/data_qa/sources/snv_variant.yml
@@ -27,6 +27,7 @@ sources:
               # SJRA-1550 is_mane_select is_mane_plus
               name: snv_variant__should_not_contain_same_value_SJRA-1550
               except:
+                - pick_source
                 # Already covered by snv_variant__should_be_unique__*
                 - locus_id
                 - locus

--- a/radiant/tasks/vcf/snv/variant.py
+++ b/radiant/tasks/vcf/snv/variant.py
@@ -49,6 +49,7 @@ SCHEMA = merge_schemas(
         NestedField(316, "dna_change", StringType(), required=False),
         NestedField(317, "aa_change", StringType(), required=False),
         NestedField(318, "transcript_id", StringType(), required=False),
+        NestedField(319, "pick_source", StringType(), required=False),
     ),
 )
 
@@ -94,6 +95,7 @@ def process_variant(record: Variant, picked_consequence: dict, common: Common):
             "dna_change": picked_consequence.get("dna_change"),
             "aa_change": picked_consequence.get("aa_change"),
             "transcript_id": picked_consequence.get("transcript_id"),
+            "pick_source": picked_consequence.get("source"),
         }
 
         variant = {**variant, **picked_fields}

--- a/tests/integration/dags/sql/test_snv_variant_tenant_isolation.py
+++ b/tests/integration/dags/sql/test_snv_variant_tenant_isolation.py
@@ -23,6 +23,10 @@ _TENANT_A, _TENANT_B = TENANT_CODES
 # have no tenant), so it proves the insert restricts to the loci the tenant actually carries.
 _STAGING_LOCI = (1, 2, 3, 4)
 
+# Locus 2 is the one both tenants carry, so giving it the odd value proves pick_source travels with
+# its own row rather than being broadcast.
+_STAGING_PICK_SOURCE = {1: "Ensembl", 2: "RefSeq", 3: "Ensembl", 4: "Ensembl"}
+
 # locus_id -> (pc_wgs, pn_wgs). `pn_*` is the tenant's whole cohort, broadcast onto every row by
 # germline_snv_variant_frequency_insert.sql.
 _GERMLINE_FREQ = {
@@ -54,6 +58,9 @@ _CATALOG_COLUMNS = (
     "somatic_pc_to_wxs",
     "somatic_pn_to_wxs",
     "somatic_pf_to_wxs",
+    # SJRA-1833. Not a frequency, but it sits next to `transcript_id` in the middle of the positional
+    # projection, so a wrong ordinal there surfaces here rather than as a silent column swap.
+    "pick_source",
 )
 
 
@@ -81,8 +88,8 @@ def test_snv_variant_is_isolated_per_tenant(starrocks_session, mapping_conf, sta
         _seed(
             cursor,
             base_mapping["starrocks_snv_staging_variant"],
-            ("locus_id", "chromosome", "start", "reference", "alternate"),
-            [(locus_id, "1", 1000 + locus_id, "A", "T") for locus_id in _STAGING_LOCI],
+            ("locus_id", "chromosome", "start", "reference", "alternate", "pick_source"),
+            [(locus_id, "1", 1000 + locus_id, "A", "T", _STAGING_PICK_SOURCE[locus_id]) for locus_id in _STAGING_LOCI],
         )
 
         for tenant, mapping in mappings.items():
@@ -148,3 +155,9 @@ def test_snv_variant_is_isolated_per_tenant(starrocks_session, mapping_conf, sta
     ) == (0, 0, 0)
     assert {row["somatic_pc_to_wgs"] for row in catalogs[_TENANT_B].values()} == {0}
     assert {row["somatic_pn_to_wgs"] for row in catalogs[_TENANT_B].values()} == {0}
+
+    # pick_source is copied from the shared staging catalog, per row (SJRA-1833).
+    assert catalogs[_TENANT_A][1]["pick_source"] == "Ensembl"
+    assert catalogs[_TENANT_A][2]["pick_source"] == "RefSeq"
+    assert catalogs[_TENANT_B][2]["pick_source"] == "RefSeq"
+    assert catalogs[_TENANT_B][3]["pick_source"] == "Ensembl"

--- a/tests/integration/test_process_somatic_snv_vcf.py
+++ b/tests/integration/test_process_somatic_snv_vcf.py
@@ -68,6 +68,13 @@ def test_import_somatic_snv_vcf(
     assert len(variants) == 21, "Unexpected number of rows in variants table"
     assert variants.chromosome.unique().tolist() == ["1", "4", "12"], "Unexpected chromosome values in variants table"
 
+    # SJRA-1833: the picked consequence's catalogue reaches the variant row. This fixture is not a
+    # merged file, so every populated value is Ensembl and must agree with the transcript namespace.
+    picked = variants[variants.transcript_id.notna() & (variants.transcript_id != "")]
+    assert not picked.empty, "Expected at least one variant carrying a picked transcript"
+    assert picked.pick_source.unique().tolist() == ["Ensembl"], "Unexpected pick_source values in variants table"
+    assert picked.transcript_id.str.startswith("ENST").all(), "pick_source disagrees with the picked transcript"
+
     assert len(consequences) == 236, "Unexpected number of rows in consequences table"
     assert variants.chromosome.unique().tolist() == ["1", "4", "12"], (
         "Unexpected chromosome values in consequences table"

--- a/tests/unit/vcf/test_variants.py
+++ b/tests/unit/vcf/test_variants.py
@@ -68,5 +68,14 @@ def test_variants_with_picked():
         "dna_change": None,
         "aa_change": None,
         "transcript_id": None,
+        "pick_source": None,
     }
     assert expected == result
+
+
+def test_variants_picked_source_is_carried_through():
+    v = variant("test_variants.vcf")
+    picked = {"transcript_id": "NM_012234", "source": "RefSeq"}
+    result = process_variant(v, picked, common)
+    assert result["transcript_id"] == "NM_012234"
+    assert result["pick_source"] == "RefSeq"


### PR DESCRIPTION
## 📌 Context

`snv__variant` carries a headline block copied verbatim from VEP's picked consequence — `transcript_id`, `symbol`, `hgvsg`, `hgvsc`, `hgvsp`, `dna_change`, `aa_change`, the MANE/canonical flags, `consequences`, `vep_impact`, `impact_score`.

With VEP `--merged`, VEP ranks both catalogues together (source is not one of its default `--pick_order` criteria), so that pick is a **RefSeq** transcript for ~1.4% of variants — and nothing in the row says so. The portal cannot tell an `ENST…` from an `NM_…` without parsing it.

Forcing Ensembl is not an option: those fields all describe the *same* transcript and must stay coherent. Re-picking a lower-ranked Ensembl candidate would display a deliberately worse annotation; swapping in an Ensembl identifier while keeping the RefSeq HGVS would produce an `aa_change` that does not belong to the displayed transcript. So the pick is left alone and its source recorded.

`resolve_source()` (SJRA-1823) already classifies every consequence — this PR plumbs that value through to StarRocks.

See §5 of `design/SJRA-1820-vep-merged-refseq-ingestion.md`.

## 📝 Changes

- **Iceberg** — `pick_source` added to `snv_variant`'s schema (field id 319), populated from the picked consequence's `source`.
- **StarRocks** — `pick_source varchar(20)` added `AFTER transcript_id` to all four tables (`snv__tmp_variant`, `snv__staging_variant`, `snv__variant`, `snv__variant_partitioned`) and at the matching ordinal in the three positional inserts. `snv_variant_part_insert_part.sql` is unchanged — it copies `v.*`.
- **Migration** — `migrations/SJRA-1833_snv_variant_add_pick_source.sql`, split by scope: the first two tables live in the base database, the last two in each `{tenant}_tenant`. Existing rows are labelled `Ensembl`; transcript-less picks stay NULL, matching `resolve_source()` rule 4.
- **Fallback pick** — the `CANONICAL=YES` fallback is left source-agnostic, deliberately, and now says so in a comment: VEP emits every Ensembl block before any RefSeq one, so it lands on Ensembl whenever an Ensembl canonical exists and falls through to RefSeq only when none does. `pick_source` records which it was.
- **QA** — `pick_source` added to the `except` list of `snv_variant__should_not_contain_same_value_SJRA-1550`; it is legitimately constant until merged files land.

## ☑️ TO-DOs

- [ ] Run `init-iceberg-tables` **before** deploying this SQL — see Notes.
- [ ] Run the migration once in the base database and once per `{tenant}_tenant`.

## 🧪 Tests

```sh
make test-unit                                   # 689 passed
USE_DOCKER_FIXTURES=true make test-integration   # 35 passed
```

- `tests/unit/vcf/test_variants.py` — `pick_source` is carried through from the picked consequence.
- `tests/integration/dags/sql/test_snv_variant_tenant_isolation.py` — seeds `pick_source` per row in the shared staging catalog and reads it back from each tenant's catalog. This is what catches a wrong ordinal in the positional projection.
- `tests/integration/test_process_somatic_snv_vcf.py` — asserts the value reaches the Iceberg variant row from a real VCF and agrees with the transcript namespace.
- `tests/integration/dags/sql/test_queries.py` already EXPLAINs the tenant-scoped inserts against a live StarRocks, so an arity mismatch fails there.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1833](https://d3b.atlassian.net/browse/SJRA-1833)
- [SJRA-1820](https://d3b.atlassian.net/browse/SJRA-1820)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Deployment ordering is a hard prerequisite.** `create_variant_table()` drops and recreates the Iceberg table from the live schema, so `init-iceberg-tables` must run before this SQL deploys — otherwise `snv_tmp_variant_insert.sql` dies on an unresolved `t.pick_source`. CI cannot catch this: the fixtures build the table from the live schema.
- **`snv__variant_partitioned` gets no backfill `UPDATE`, and that is not an oversight.** It declares no key clause, so it is a Duplicate Key table and StarRocks restricts `UPDATE` to Primary Key tables. The column fills in per part on the next `import_part` run, which dynamic-overwrites that part from the backfilled `snv__variant`. To populate it sooner, re-run `snv_variant_part_insert_part.sql` for each existing `part`.
- The `AFTER transcript_id` positions in the migration are load-bearing: all three inserts are positional with no target column list.
- No portal change is required for this to ship.


[SJRA-1833]: https://d3b.atlassian.net/browse/SJRA-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ