### PR TITLE
fix: SJRA-1849 surface the real error when an S3 VCF download fails

### DIFF
--- a/radiant/tasks/utils.py
+++ b/radiant/tasks/utils.py
@@ -78,7 +78,9 @@ def download_s3_file(s3_path, dest_dir, randomize_filename=False):
     try:
         s3_client.download_file(bucket_name, object_key, local_path)
     except (BotoCoreError, ClientError, Boto3Error, OSError) as e:
-        raise S3DownloadError(f"Failed to download S3 file {s3_path}") from e
+        # Inline the cause: callers log `str(e)`, so without it AccessDenied, 404 and
+        # "unable to locate credentials" are indistinguishable in a task log.
+        raise S3DownloadError(f"Failed to download S3 file {s3_path}: {e}") from e
     return local_path
 
 

--- a/radiant/tasks/vcf/cnv/germline/process.py
+++ b/radiant/tasks/vcf/cnv/germline/process.py
@@ -94,14 +94,16 @@ def import_cnv_vcf(tasks: list[dict], namespace: str) -> None:
                 continue
 
             attempted += 1
-            logger.info(f"Downloading VCF and index files from {task['cnv_vcf_filepath']} to a temporary directory")
+            # No index is fetched, unlike SNV: the whole file is iterated, never queried by region.
+            logger.info(f"Downloading VCF from {task['cnv_vcf_filepath']} to a temporary directory")
             try:
                 cnv_vcf_local = download_s3_file(task["cnv_vcf_filepath"], tmpdir, randomize_filename=True)
             except S3DownloadError as e:
                 skipped += 1
                 logger.warning(
                     f"Failed to download CNV VCF for task [{task.get('task_id')}] "
-                    f"from {task['cnv_vcf_filepath']}, skipping: {e}"
+                    f"from {task['cnv_vcf_filepath']}, skipping: {e}",
+                    exc_info=True,
                 )
                 continue
             logger.info(f"Downloaded CNV VCF to {cnv_vcf_local}")

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -77,6 +77,9 @@ def test_download_s3_file_propagates_error_with_s3_path():
         download_s3_file(s3_path, "/tmp/dest")
 
     assert s3_path in str(exc_info.value)
+    # The cause must be in the message, not only on __cause__: callers log `str(e)`,
+    # so a path-only message cannot distinguish AccessDenied from a missing key.
+    assert "AccessDenied" in str(exc_info.value)
     assert exc_info.value.__cause__ is original
 
 


### PR DESCRIPTION
## 📌 Context

Every germline CNV import in QA failed to download its VCF — all 15 DRAGEN files — with a log line that named no cause:

```
WARNING:radiant.tasks.vcf.cnv.germline.process:Failed to download CNV VCF for task [1034] from
s3://qlin-qa-nextflow-inputs-.../1000genomes-dragen-v4-4-7/individuals/HG00512/HG00512.cnv.vcf.gz,
skipping: Failed to download S3 file s3://...
```

The actual cause was an IAM gap, fixed separately in `qlin-qa-infra`: `qlin-airflow-pod-role` had `s3:GetObject` on the nextflow **outputs** bucket but not on **inputs**. That asymmetry is by design in `staging_external_sequencing_experiment_create_table.sql` — `vcf_filepath` is the *annotated* VCF from `radiant_germline_annotation` and lives in outputs, while `cnv_vcf_filepath` is the *raw DRAGEN* `gcnv` document and stays in inputs. So SNV worked and CNV could not.

Diagnosing that took an out-of-band `head-object` and an IAM policy read, because the log was structurally incapable of saying `AccessDenied`. This PR fixes that: `download_s3_file` discarded the botocore message, keeping it only on `__cause__`, which no caller logs.

## 📝 Changes

- **`radiant/tasks/utils.py`** — `S3DownloadError` now inlines the cause: `f"Failed to download S3 file {s3_path}: {e}"`. `AccessDenied`, `404`, `NoCredentialsError` and `ENOSPC` were previously indistinguishable, since callers log `str(e)`.
- **`radiant/tasks/vcf/cnv/germline/process.py`** — `exc_info=True` on the skip warning, so the chained traceback reaches the task log. This is the only site in `radiant/` or `scripts/` that catches `S3DownloadError`.
- Same file — the `logger.info` claimed to download "VCF and index files"; germline CNV fetches only the `.vcf.gz`, unlike SNV. Corrected, with a note on why no index is needed (the file is iterated whole, never queried by region).

## ☑️ TO-DOs

- [x] Apply the `qlin-qa-infra` IAM change granting the pod role read on the nextflow inputs bucket.
- [ ] Re-trigger `radiant-import-part` for the affected parts and confirm the 15 CNV files ingest.

## 🧪 Tests

```sh
make test-unit    # 689 passed
make test-static  # clean
```

- `tests/unit/test_utils.py::test_download_s3_file_propagates_error_with_s3_path` — now asserts the cause text appears in `str(e)`, not only on `__cause__`. That assertion is the regression guard; the old message passed the path check while telling an operator nothing.
- `tests/unit/vcf/germline/test_germline_cnv_process.py` — unchanged and still passing: skip/abort behaviour is untouched.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
- [SJRA-1849](https://d3b.atlassian.net/browse/SJRA-1849)
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Logging only — no behavioural change.** A failed germline CNV download is still caught, warned and skipped; the abort-if-all-failed guard is untouched.
- **SJRA-1784 is deliberately not addressed here.** A *partial* germline CNV failure still lets the Airflow task succeed, so `sequencing_experiment_update.sql` marks the experiment ingested and the incremental delta never re-offers it. In this incident all 15 downloads failed in each part, so the `RuntimeError` guard fired and nothing was marked — but the defect stands and needs its own ticket.
- Worth confirming no QA experiment was marked `ingested_at` by a partial skip before re-running; if so it needs `ingested_at` cleared to be re-offered.


[SJRA-1849]: https://d3b.atlassian.net/browse/SJRA-1849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ