### PR TITLE
fix: SJRA-1853 oom errors in starrocks

### DIFF
--- a/radiant/dags/sql/radiant/snv_consequence_insert.sql
+++ b/radiant/dags/sql/radiant/snv_consequence_insert.sql
@@ -8,8 +8,8 @@ SELECT
     c.consequences,
     c.impact_score,
     c.biotype,
-    c.exon.rank,
-    c.exon.total,
+    c.exon_rank,
+    c.exon_total,
     sp.spliceai_ds,
     sp.spliceai_type,
     c.is_canonical,
@@ -34,23 +34,56 @@ SELECT
     gc.loeuf,
     d.phyloP17way_primate,
     d.phyloP100way_vertebrate,
-    COALESCE(c.source = 'RefSeq' AND NULLIF(c.mane_pair_transcript_id, '') IS NOT NULL, FALSE)
+    COALESCE(c.source = 'RefSeq' AND c.score_transcript_id IS NOT NULL, FALSE)
         AS scores_from_mane_pair,
     c.vep_impact,
     c.aa_change,
     c.dna_change
-FROM {{ mapping.iceberg_snv_consequence }} c
-LEFT JOIN {{ mapping.starrocks_snv_tmp_variant }} v ON c.locus_hash = v.locus_hash
-LEFT JOIN {{ mapping.starrocks_dbnsfp }} d
-    ON v.locus_id=d.locus_id
-   AND d.ensembl_transcript_id = CASE
-           WHEN c.source = 'RefSeq' THEN NULLIF(c.mane_pair_transcript_id, '')
-           ELSE NULLIF(c.transcript_id, '')
-       END
-LEFT JOIN {{ mapping.starrocks_spliceai }} sp ON v.locus_id=sp.locus_id AND sp.symbol = c.symbol
+FROM (
+    SELECT
+        locus_hash,
+        symbol,
+        transcript_id,
+        transcript_version,
+        source,
+        consequences,
+        impact_score,
+        biotype,
+        exon.rank AS exon_rank,
+        exon.total AS exon_total,
+        is_canonical,
+        is_picked,
+        is_mane_select,
+        is_mane_plus,
+        mane_select,
+        mane_pair_transcript_id,
+        vep_impact,
+        aa_change,
+        dna_change,
+        -- A RefSeq row reads its scores under the Ensembl twin its MANE pair names.
+        CASE
+            WHEN source = 'RefSeq' THEN NULLIF(mane_pair_transcript_id, '')
+            ELSE NULLIF(transcript_id, '')
+        END AS score_transcript_id
+    FROM {{ mapping.iceberg_snv_consequence }}
+    -- No literal per-cent sign in this file: task_ids binds via pymysql printf paramstyle.
+    WHERE task_id in %(task_ids)s
+) c
+-- INNER, not LEFT: locus_id leads the target primary key and is NOT NULL, so unmatched rows cannot land.
+JOIN {{ mapping.starrocks_snv_tmp_variant }} v ON c.locus_hash = v.locus_hash
+-- Only this batch's loci can match: the colocate semi joins cut dbnsfp 239M -> ~101k, spliceai 80M -> ~14k.
+-- [BROADCAST] is required, not tuning: without it the ~600M-row stream becomes a RIGHT OUTER build side, ~120GB.
+LEFT JOIN [BROADCAST] (
+    SELECT d.*
+    FROM {{ mapping.starrocks_dbnsfp }} d
+    LEFT SEMI JOIN {{ mapping.starrocks_snv_tmp_variant }} tv ON d.locus_id = tv.locus_id
+) d
+    ON v.locus_id = d.locus_id
+   AND d.ensembl_transcript_id = c.score_transcript_id
+LEFT JOIN [BROADCAST] (
+    SELECT s.*
+    FROM {{ mapping.starrocks_spliceai }} s
+    LEFT SEMI JOIN {{ mapping.starrocks_snv_tmp_variant }} tv ON s.locus_id = tv.locus_id
+) sp ON v.locus_id = sp.locus_id AND sp.symbol = c.symbol
 LEFT JOIN {{ mapping.starrocks_gnomad_constraint }} gc
-    ON gc.transcript_id = CASE
-           WHEN c.source = 'RefSeq' THEN NULLIF(c.mane_pair_transcript_id, '')
-           ELSE NULLIF(c.transcript_id, '')
-       END
-WHERE c.task_id in %(task_ids)s
+    ON gc.transcript_id = c.score_transcript_id


### PR DESCRIPTION
## 📌 Context

`import_snv_consequence` failed on tasks 1024-1056: a BE ran out of memory, and on retry filled its spill disk instead.

`snv_consequence_insert.sql` joins ~600M Iceberg consequence rows against three whole-genome reference tables. StarRocks was converting `LEFT JOIN spliceai` into a `RIGHT OUTER JOIN`, which puts the entire ~600M-row stream (~120 GB) on the hash-join build side — where it cannot be streamed. `dbnsfp` compounded it with a 239M-row build side of its own.

Only a sliver of those reference tables can ever match a batch: 101,035 of 239M `dbnsfp` rows, and 13,626 of 80M `spliceai` rows.

## 📝 Changes

- Pre-filter `dbnsfp` and `spliceai` through `LEFT SEMI JOIN snv__tmp_variant`. Same colocate group and bucket key, so both are colocate joins (measured: 0.57s for the pair).
- Pin both annotation joins with `[BROADCAST]`. Required, not tuning: the optimizer does not propagate a semi join's selectivity into its cardinality estimate, so without the hint it re-derives the `RIGHT OUTER` conversion.
- `LEFT JOIN` → `JOIN` on `snv__tmp_variant`. `locus_id` is `NOT NULL` and leads the target primary key, so unmatched rows could never be inserted (measured: zero). Also lets `locus_hash IS NOT NULL` push down into the Iceberg scan.
- Hoisted the repeated MANE-pair `CASE` into a single `score_transcript_id`.

The output projection is unchanged.

## ☑️ TO-DOs

- [x] None blocking merge.

## 🧪 Tests

`tests/integration/dags/sql/test_snv_consequence_insert.py` — 3/3 pass on StarRocks 4.0.13:

```
USE_DOCKER_FIXTURES=true pytest tests/integration/dags/sql/test_snv_consequence_insert.py
```

That includes `test_score_borrow_joins_are_hash_joins`, which pins that the SJRA-1827 MANE-pair score key stays an equi-join — the assertion most at risk from adding join hints.

`EXPLAIN` on the real batch (1024-1056) after the change: all four joins are `(BROADCAST)`, no `RIGHT OUTER` anywhere, and every exchange is `UNPARTITIONED`, so the 600M-row stream never leaves its fragment. Build-side memory ~120 GB → ~1.1 GB. The Airflow task has since run to completion.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->

SJRA-1853

<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- The `[BROADCAST]` hints are load-bearing — dropping them restores the OOM. Verified on StarRocks 4.0.11 (QA) and 4.0.13 (test container); worth re-checking the plan on a version bump.
- **This fixes the memory failure only.** The disk pressure is a separate, untouched problem: `snv__consequence` is a 10-bucket shared-data primary-key table with a cloud-native persistent index, and a full batch pushes ~601M upserts through those 10 tablets to land ~179M rows. Chunking `task_ids` in `import_part.py` is the proposed follow-up; rebucketing is not available in isolation, since the whole colocate group would have to move together.
- Keep literal per-cent signs out of this file: `task_ids` binds through pymysql's printf paramstyle, so a stray one fails the statement at mogrify time.
