### PR TITLE
feat: SJRA-1856 nextflow quality-control pipeline DAG

### DIFF
--- a/Dockerfile.nextflow.launcher
+++ b/Dockerfile.nextflow.launcher
@@ -11,8 +11,12 @@
 # baked at build time. Nothing in the runtime path fetches from nextflow.io,
 # nf-co.re or github.com - the LZ egress firewall blocks part of that, and
 # a driver that resolves its own pipeline at runtime is a boot-time failure
-# waiting to happen. The consequence is that bumping PIPELINE_REV requires
-# rebuilding this image.
+# waiting to happen. The consequence is that bumping either *_PIPELINE_REV
+# requires rebuilding this image.
+#
+# Two pipelines share this image, because they share a driver: same cluster,
+# same FSx PVC, same node pool, so a second image would only add a second
+# multi-GB pull to cache on those nodes.
 
 FROM --platform=linux/amd64 public.ecr.aws/amazonlinux/amazonlinux:2023
 
@@ -20,11 +24,19 @@ ARG NXF_VER=24.10.5
 ARG PIPELINE_REPO=Ferlab-Ste-Justine/Post-processing-Pipeline
 ARG PIPELINE_REV=v3.0.0
 
-# Keep in sync with the pipeline's own `plugins` block: v3.0.0 declares
-# nf-schema@2.1.0 (v2.11.0 declared nf-validation@1.1.3 - a different
-# plugin, not a version bump). A mismatch fails at plugin resolution,
-# offline, with no way to recover at runtime.
-ARG NXF_PLUGINS="nf-schema@2.1.0 nf-amazon"
+# `-r` is load-bearing on this one: its manifest declares
+# `defaultBranch = 'master'` while the repo's actual default branch is `main`,
+# so a bare `nextflow pull` resolves a revision that does not exist.
+ARG QC_PIPELINE_REPO=Ferlab-Ste-Justine/quality-control-pipeline
+ARG QC_PIPELINE_REV=v2.0.0
+
+# Keep in sync with each pipeline's own `plugins` block: Post-processing-Pipeline
+# v3.0.0 declares nf-schema@2.1.0 (v2.11.0 declared nf-validation@1.1.3 - a
+# different plugin, not a version bump), quality-control-pipeline v2.0.0 declares
+# nf-schema@2.3.0. Nextflow keeps versioned plugin directories side by side, so
+# both resolve; a missing one fails at plugin resolution, offline, with no way to
+# recover at runtime.
+ARG NXF_PLUGINS="nf-schema@2.1.0 nf-schema@2.3.0 nf-amazon"
 
 # Set NXF_HOME *before* installing Nextflow, so the build-time
 # `nextflow -version` populates ${NXF_HOME}/framework/... and the build-time
@@ -52,15 +64,32 @@ RUN curl -fsSL https://get.nextflow.io | NXF_VER=${NXF_VER} bash \
     && chmod +x /usr/local/bin/nextflow \
     && /usr/local/bin/nextflow -version \
     && /usr/local/bin/nextflow pull "${PIPELINE_REPO}" -r "${PIPELINE_REV}" \
+    && /usr/local/bin/nextflow pull "${QC_PIPELINE_REPO}" -r "${QC_PIPELINE_REV}" \
     && for p in ${NXF_PLUGINS}; do /usr/local/bin/nextflow plugin install "$p"; done
 
 WORKDIR /workspace
 
-# Sanity: confirm framework + pipeline + plugins are all baked in, so a
+# Sanity: confirm framework + both pipelines + every plugin are baked in, so a
 # missing piece fails the build instead of the first production run.
-RUN ls "${NXF_HOME}/framework/${NXF_VER}/" \
-    && ls "${NXF_ASSETS}/${PIPELINE_REPO}/.git" >/dev/null 2>&1 \
-    && ls "${NXF_HOME}/plugins/" | grep -E 'nf-schema|nf-amazon' \
-    || (echo "ERROR: cache layout incomplete" && exit 1)
+#
+# Each plugin is checked by name, not by one grep over the directory: `nf-schema`
+# matches on either version alone, and a single missing version is exactly the
+# case this needs to catch. `nf-schema@2.1.0` installs as `nf-schema-2.1.0`, while
+# an unversioned `nf-amazon` resolves to whatever version it pulled - hence the
+# `@`->`-` rewrite plus a trailing glob rather than an exact directory name.
+#
+# `set -eu` and `{ ...; exit 1; }` are load-bearing: inside `( ... )` the exit
+# would leave a subshell, and as the last command of a loop body it would leave
+# the RUN's status to the final iteration - so a missing middle plugin would
+# build green.
+RUN set -eu \
+    && ls "${NXF_HOME}/framework/${NXF_VER}/" >/dev/null \
+    && ls "${NXF_ASSETS}/${PIPELINE_REPO}/.git" >/dev/null \
+    && ls "${NXF_ASSETS}/${QC_PIPELINE_REPO}/.git" >/dev/null \
+    && for p in ${NXF_PLUGINS}; do \
+           d=$(echo "$p" | tr '@' '-'); \
+           ls -d "${NXF_HOME}/plugins/${d}"* >/dev/null \
+               || { echo "ERROR: plugin $p not baked"; exit 1; }; \
+       done
 
 CMD ["/bin/bash"]

--- a/radiant/dags/docs/nextflow_quality_control.md
+++ b/radiant/dags/docs/nextflow_quality_control.md
@@ -1,0 +1,154 @@
+# Nextflow Quality Control
+
+Runs the Ferlab [quality-control-pipeline](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline)
+on qlin-eks in its **DRAGEN-metrics mode**: the samples have already been through
+DRAGEN, so the MultiQC report is built from DRAGEN's per-sample metric CSVs instead
+of being recomputed. Somalier still runs, against whatever BAM/CRAM the samplesheet
+lists, for pedigree validation.
+
+One Airflow task launches a Nextflow **driver** pod in the `nextflow` namespace. The
+driver spawns one worker pod per pipeline process itself, through Nextflow's
+Kubernetes executor — so a single task in the Airflow UI is a fan-out of pods in
+Kubernetes. Watch them with:
+
+```sh
+kubectl -n nextflow get pods -w
+```
+
+## Parameters
+
+| Param | Required | Meaning |
+|---|---|---|
+| `input` | yes | Absolute path to the samplesheet CSV on the shared workspace. Columns below. |
+| `dragen_metrics_dir` | yes | Absolute path to the directory of DRAGEN per-sample metric CSVs. |
+| `outdir` | no | Absolute path for published outputs. Empty means `/workspace/outputs/qlin/<run tag>`. |
+
+All three are **pod paths**, not S3 URIs. `/workspace` is the FSx-Lustre filesystem;
+its `/inputs` and `/reference` prefixes are auto-imported from S3 and `/outputs` is
+auto-exported back, so anything published under `outdir` reaches S3 without an
+explicit copy.
+
+Everything else — reference genome, `somalier_sites`, QC thresholds, `cohort_mode` —
+is run-invariant and lives in the `nextflow-qc-params` ConfigMap, alongside
+`nextflow-qc-cfg` for the executor and per-process resources. Both are owned by the
+kustomization in `qlin-qa-infra/kubernetes-manifests/apps/nextflow/`.
+
+They are a **separate pair** from the post-processing `nextflow-cfg` / `nextflow-params`,
+and not by preference: the post-processing config references `params.save_genotyped`
+and `params.tools`, and a param referenced from a `-c` config but absent from the
+`-params-file` kills the run at config parse.
+
+## Samplesheet
+
+| Column | Required | Notes |
+|---|---|---|
+| `participant` | yes | Groups samples from the same person across sequencing types. |
+| `sample` | yes | Output directory name (`reports/QC/{sample}`). Unique per participant + strategy. |
+| `fileType` | yes | `FASTQ`, `BAM`, `CRAM`, `VCF` or `GVCF` (case-insensitive). |
+| `file1` | yes | FASTQ R1, BAM, CRAM, or VCF/GVCF. |
+| `file2` | no | FASTQ R2, or the index (`.bai`/`.crai`/`.tbi`/`.csi`). Requires `file1`. |
+| `familyId` | no | Needed when `cohort_mode` is false (the default) or with a `ped_file`. |
+| `experimentalStrategy` | no | `WGS` (default), `WXS`, `TARS`, `RNAS`, `ATACS`, `BIS`, `TMS`, `CHIPS`. |
+| `sex` | no | `Female`, `Male`, `Other`, `NA` (default). |
+| `status` | no | `0` normal (default), `1` tumor. |
+| `relationship_to_proband` | no | `Proband` (default), `Mother`, `Father`, … Used to derive a pedigree. |
+| `affected_status` | no | `Affected`, `Unaffected`, `Unknown` (default). |
+| `lane`, `runId` | no | Rows sharing participant + sample + strategy are merged before QC. |
+
+The schema marks `file1`/`file2` as `exists: true`, so **every path is stat'd in the
+driver pod at launch**. A wrong path fails the run in seconds rather than hours in —
+but it also means the paths must be visible on the FSx mount, not S3 URIs.
+
+## `dragen_metrics_dir` fails open
+
+The directory is globbed at any depth; both `<sample>.<type>.csv` and
+`<sample>.final.<type>.csv` are recognised, for `mapping_metrics`,
+`wgs_coverage_metrics`, `vc_metrics` and `ploidy_estimation_metrics` (plus paired
+`*_cov_report.bed` / `*_read_cov_report.bed` for per-gene coverage).
+
+Files are matched to samplesheet rows **by sample prefix**, and a file matching no row
+is **silently ignored**. So a mistyped sample name, or a metrics dir from the wrong
+batch, produces a run that succeeds with a half-empty report rather than an error.
+
+Check the report rather than the task status: every sample in the samplesheet should
+have populated alignment and coverage sections. The driver log also lists what the
+DRAGEN channels picked up.
+
+## Retries and resume
+
+The Nextflow launch directory is `/workspace/work/.nextflow-launchdir/qc-<run id>`.
+The `qc-` prefix matters: `RUN_TAG` drives the work dir, the launch dir and the default
+outdir, Airflow run ids are only unique *within* a DAG, and this DAG can run at the
+same time as `radiant-nextflow-postprocessing`. Without the prefix the two could share
+a launch dir — which is how a resume cache gets corrupted — and either `cleanup_work`
+could delete the other's scratch.
+
+The tag is stable across task retries and unique per DAG run, so:
+
+- **A retry resumes.** `-resume` finds the previous session's `.nextflow/cache` and
+  skips completed processes.
+- **Concurrent runs cannot collide**, and `max_active_runs=1` keeps them from trying.
+
+The task is **deferrable**: it releases its worker slot and the triggerer polls the
+pod, so a long run costs no Airflow capacity. Logs are flushed to the task log roughly
+every 10 minutes rather than streamed live.
+
+## Before clearing a failed task
+
+Clearing a deferred task does **not** delete its pod. If the driver is still running,
+a retry starts a second driver against the same launch directory, and two Nextflow
+sessions sharing one resume cache is how that cache gets corrupted. Check first:
+
+```sh
+kubectl -n nextflow get pods -l dag_id=radiant-nextflow-quality-control
+kubectl -n nextflow delete pod <driver-pod>   # if one is still Running
+```
+
+`active_deadline_seconds` (24h by default) is the backstop if nobody does.
+
+## Failure triage
+
+A failed driver pod is kept rather than deleted, so its logs survive:
+
+```sh
+kubectl -n nextflow logs <driver-pod> --tail=200
+```
+
+The full Nextflow log, including per-process work directories, is on the shared
+filesystem at `<launch dir>/.nextflow.log`. Each failed process reports its own work
+directory — `.command.err` and `.command.log` there are usually more informative than
+the driver's summary.
+
+## The pipeline runs from the shared filesystem, not the image
+
+The driver copies the pipeline out of its own image to
+`/workspace/pipelines/quality-control-pipeline-<commit>` and runs *that*.
+
+It is not tidiness. This pipeline ships nf-core module resource scripts —
+`modules/local/multiqc_python/resources/usr/bin/multiqc_report.py`. Nextflow puts them
+on a task's PATH by exporting the **projectDir** path into the task wrapper, but the
+task runs in the module's own container (`biocontainers/multiqc`), which mounts only
+`/workspace` and has no `/opt/nextflow`. Run from the image path, `MULTIQC_PYTHON`
+dies with `multiqc_report.py: command not found` (exit 127). Post-processing never hit
+this because it has no module resource scripts.
+
+The copy is keyed by the asset's git commit, so a rebuilt image with a new pipeline
+revision lands in a new directory rather than silently reusing a stale one. It is
+~2 MB per revision, and the work-cleanup CronJob does not sweep `pipelines/` — so old
+revisions accumulate slowly and can be deleted by hand if they ever matter.
+
+Because the project path is part of each task's hash, the first run after a revision
+bump re-executes rather than resuming. That is correct: the pipeline code changed.
+
+Three failure modes are specific to this pipeline:
+
+- **`<script>.py: command not found` (exit 127) in a module task.** The projectDir the
+  worker was given is not on the shared filesystem — see above.
+
+- **Config parse dies on an unknown `params.*` attribute.** A `withName:` block in
+  `nextflow-qc-cfg` references a param that `nextflow-qc-params` does not declare. Add
+  the key, or drop the reference.
+- **An output lands in S3 as ~80 bytes.** A `publishDir` fell back to `symlink`, and
+  the FSx auto-export does not dereference symlinks. Check that `nextflow-qc-cfg` sets
+  `params.publish_dir_mode = 'copy'` and that the module in question does not use the
+  `publish_mode:` key, which Nextflow silently ignores.

--- a/radiant/dags/nextflow_quality_control.py
+++ b/radiant/dags/nextflow_quality_control.py
@@ -1,0 +1,113 @@
+"""Run the Ferlab quality-control-pipeline from Airflow, in DRAGEN-metrics mode.
+
+A single task launches a Nextflow *driver* pod on qlin-eks; that driver then spawns
+one worker pod per pipeline process through Nextflow's own k8s executor. Airflow
+sees one task, Kubernetes sees a fan-out. Same shape as
+`nextflow_postprocessing.py`, and the same driver image -- only the pipeline asset
+and the ConfigMap pair differ.
+
+DRAGEN metrics only
+-------------------
+The samples this runs on have already been through DRAGEN, so the report is built
+from DRAGEN's per-sample metric CSVs rather than recomputed. That mode is selected
+purely by passing ``--dragen_metrics_dir``, which is why the param is **required**
+here although it is optional upstream: triggering without it would silently launch a
+full BAM_QC/VCF_QC recompute, which is hours of worker pods nobody asked for.
+
+Run-invariant settings (reference genome, somalier sites, QC thresholds, cohort
+mode) live in the `nextflow-qc-params` ConfigMap, the executor and resource layout in
+`nextflow-qc-cfg` -- both owned by the kustomization in qlin-qa-infra. Only the three
+values that change every run are exposed here as DAG params.
+
+Resume
+------
+The Nextflow launch directory is keyed by ``RUN_TAG``, derived from the Airflow
+``run_id``: stable across task retries, unique per DAG run. A retry therefore
+re-enters the same launch dir and `-resume` skips what already completed. It only
+helps if the task actually retries, hence the explicit ``retries`` below --
+``DEFAULT_ARGS`` carries only ``owner`` and Airflow defaults ``retries`` to 0.
+"""
+
+import pendulum
+from airflow.decorators import dag
+from airflow.models.param import Param
+
+from radiant.dags import DEFAULT_ARGS, NAMESPACE, load_docs_md
+
+# K8s only: the driver needs the FSx-Lustre PVC and the `nextflow` namespace, so
+# unlike import_part.py this DAG has no ECS branch.
+from radiant.dags.operators import k8s as operators
+
+dag_params = {
+    "input": Param(
+        type="string",
+        title="Input samplesheet (CSV)",
+        description=(
+            "Absolute path to the samplesheet on the shared workspace, e.g. "
+            "/workspace/inputs/qc/1000genomes-dragen-v4-4-7/samplesheet.csv. Columns: "
+            "participant,sample,fileType,file1 required; file2, familyId, experimentalStrategy, "
+            "sex, status, relationship_to_proband, affected_status, lane, runId optional."
+        ),
+        minLength=1,
+    ),
+    "dragen_metrics_dir": Param(
+        type="string",
+        title="DRAGEN metrics directory",
+        description=(
+            "Absolute path to the directory of DRAGEN per-sample metric CSVs. Globbed at any "
+            "depth and matched to samplesheet rows by sample prefix; files matching no row are "
+            "silently ignored. Setting it is what skips BAM_QC and VCF_QC."
+        ),
+        minLength=1,
+    ),
+    "outdir": Param(
+        default="",
+        type="string",
+        title="Output directory",
+        description=("Absolute path for published outputs. Leave empty to use /workspace/outputs/qlin/<run tag>."),
+    ),
+}
+
+
+@dag(
+    dag_id=f"{NAMESPACE}-nextflow-quality-control",
+    dag_display_name="Radiant - Nextflow Quality Control",
+    # retries are load-bearing here, not defensive: they are what makes -resume
+    # reachable (see the module docstring).
+    default_args=DEFAULT_ARGS | {"retries": 2, "retry_delay": pendulum.duration(minutes=5)},
+    start_date=pendulum.datetime(2021, 1, 1, tz="UTC"),
+    schedule=None,
+    catchup=False,
+    # One driver at a time: concurrent runs would share the FSx workspace.
+    max_active_runs=1,
+    tags=["radiant", "nextflow", "qc", "manual"],
+    params=dag_params,
+    doc_md=load_docs_md("nextflow_quality_control.md"),
+)
+def nextflow_quality_control():
+    # The `qc-` prefix is load-bearing, not labelling. RUN_TAG drives the Nextflow
+    # workDir, the launch dir *and* the default outdir, and Airflow run ids are only
+    # unique within a DAG -- while this DAG and radiant-nextflow-postprocessing are
+    # separate DAGs that can run at the same time (and the cases DAG pins a child
+    # run id explicitly). Without the prefix, two runs could share one launch dir,
+    # corrupting the resume cache, and either cleanup could delete the other's scratch.
+    #
+    # Not ts_nodash: an Airflow 3 manual run can have a null logical_date, and
+    # date-derived templates then raise UndefinedError at render time.
+    run_tag = "qc-{{ run_id | replace(':', '-') | replace('+', '-') }}"
+
+    run = operators.NextflowQualityControl.get_run_quality_control(
+        input_csv="{{ params.input }}",
+        outdir="{{ params.outdir }}",
+        dragen_metrics_dir="{{ params.dragen_metrics_dir }}",
+        run_tag=run_tag,
+    )
+    cleanup = operators.NextflowQualityControl.get_cleanup_work(run_tag=run_tag)
+
+    # Default trigger rule (all_success) on purpose: the scratch is exactly what
+    # `-resume` reads, so cleaning up after a failure would make every retry a full
+    # re-run. A failed run keeps its workdir until the work-cleanup CronJob ages it out.
+    run >> cleanup
+
+
+nextflow_quality_control()

--- a/radiant/dags/operators/k8s.py
+++ b/radiant/dags/operators/k8s.py
@@ -391,11 +391,16 @@ class CheckDataIntegrity:
         )
 
 
-# `cmds`/`arguments` are Jinja-templated fields, so nothing here may contain `{{` or
-# `{%`; per-run values arrive as env vars instead.
+# `cmds`/`arguments` are Jinja-templated fields, so nothing in these scripts may
+# contain `{{` or `{%`; per-run values arrive as env vars instead.
 #
 # The `cd` is load-bearing: Nextflow reads `.nextflow/cache` from the working
 # directory, so a launch dir keyed by RUN_TAG is what lets a retry `-resume`.
+#
+# Both scripts read their config from the same paths (`/etc/nextflow`,
+# `/etc/nextflow-params`) even though the two pipelines need different content --
+# it is the ConfigMap *names* that differ, not the mounts, which is what keeps the
+# scripts near-identical.
 _NEXTFLOW_DRIVER_SCRIPT = """
 set -euo pipefail
 LAUNCH="${NXF_WORKSPACE}/work/.nextflow-launchdir/${RUN_TAG}"
@@ -409,6 +414,59 @@ nextflow run "${NXF_HOME}/assets/Ferlab-Ste-Justine/Post-processing-Pipeline" \
     -params-file /etc/nextflow-params/params.json \
     --input "$NXF_INPUT" \
     --outdir "$OUTDIR"
+# Let the /outputs DRA flush the last file events to S3 before the pod terminates.
+sleep "${POST_RUN_DRAIN_SECONDS}"
+"""
+
+
+# `--dragen_metrics_dir` is what selects the pipeline's DRAGEN-metrics mode: with it
+# set, BAM_QC and VCF_QC are skipped and the report is built from DRAGEN's per-sample
+# CSVs. It is unconditional here because that is the only mode this DAG runs -- the
+# param is required, so the variable is never empty.
+#
+# The pipeline is run from a copy on the SHARED filesystem, not from the image's own
+# `${NXF_HOME}/assets/...`, and that is load-bearing rather than tidiness.
+#
+# This pipeline carries nf-core module resource scripts (`modules/local/multiqc_python/
+# resources/usr/bin/multiqc_report.py`). Nextflow puts those on PATH by exporting the
+# *projectDir* path into the task wrapper -- but the task runs in the module's own
+# container (biocontainers/multiqc), which mounts only ${NXF_WORKSPACE} and has no
+# /opt/nextflow. Run from the image path, MULTIQC_PYTHON dies with
+# `multiqc_report.py: command not found` (exit 127). Post-processing never hit this
+# because it has no module resource scripts.
+#
+# The copy is keyed by the asset's git commit, so a rebuilt image with a new pipeline
+# revision lands in a new directory instead of silently reusing a stale one. The
+# temp-dir-then-`mv -T` dance makes a concurrent driver racing on the same revision
+# harmless: whoever loses the rename just reuses the winner's directory.
+#
+# No `-r` on `nextflow run`: the source is a local directory whose revision is
+# whatever Dockerfile.nextflow.launcher pulled at build time.
+_NEXTFLOW_QC_DRIVER_SCRIPT = """
+set -euo pipefail
+SRC="${NXF_HOME}/assets/Ferlab-Ste-Justine/quality-control-pipeline"
+REV="$(git -C "$SRC" rev-parse --short HEAD)"
+PROJECT="${NXF_WORKSPACE}/pipelines/quality-control-pipeline-${REV}"
+if [ ! -d "$PROJECT" ]; then
+  mkdir -p "${NXF_WORKSPACE}/pipelines"
+  TMP="${PROJECT}.tmp.$$"
+  rm -rf "$TMP"
+  cp -a "$SRC" "$TMP"
+  mv -T "$TMP" "$PROJECT" 2>/dev/null || rm -rf "$TMP"
+fi
+echo ">> pipeline rev=$REV project=$PROJECT"
+LAUNCH="${NXF_WORKSPACE}/work/.nextflow-launchdir/${RUN_TAG}"
+OUTDIR="${NXF_OUTDIR:-${NXF_WORKSPACE}/outputs/qlin/${RUN_TAG}}"
+mkdir -p "$LAUNCH" && cd "$LAUNCH"
+echo ">> run_tag=$RUN_TAG input=$NXF_INPUT outdir=$OUTDIR dragen=$NXF_DRAGEN_METRICS_DIR"
+nextflow run "$PROJECT" \
+    -profile docker \
+    -c /etc/nextflow/nextflow.config \
+    -resume \
+    -params-file /etc/nextflow-params/params.json \
+    --input "$NXF_INPUT" \
+    --outdir "$OUTDIR" \
+    --dragen_metrics_dir "$NXF_DRAGEN_METRICS_DIR"
 # Let the /outputs DRA flush the last file events to S3 before the pod terminates.
 sleep "${POST_RUN_DRAIN_SECONDS}"
 """
@@ -436,132 +494,229 @@ echo ">> after:"; df -h "${NXF_WORKSPACE}" | tail -1
 """
 
 
+def _nextflow_image(*env_vars: str) -> str | None:
+    """First env var that is set wins.
+
+    Lets one pipeline be pointed at an ad-hoc image -- a locally built tag while a
+    revision is being tested -- without moving the other one with it. Returns None
+    when none is set, so a missing image fails loudly at pod creation rather than
+    silently pulling something unintended.
+    """
+    for name in env_vars:
+        value = os.getenv(name)
+        if value:
+            return value
+    return None
+
+
+def _nextflow_driver_operator(
+    *,
+    task_id: str,
+    task_display_name: str,
+    name: str,
+    script: str,
+    image: str | None,
+    env_vars: dict[str, str],
+    config_configmap: str,
+    params_configmap: str,
+) -> KubernetesPodOperator:
+    """The pod every Nextflow driver runs in, whichever pipeline it launches.
+
+    Unlike every other operator here a driver runs in the `nextflow` namespace under
+    the `nextflow` service account -- that SA carries the Pod Identity for S3 and the
+    RBAC to spawn workers -- and it is the only kind that mounts volumes.
+
+    Only the launch script, the pod name and the two ConfigMap *names* differ between
+    pipelines. Everything below is topology: which cluster, which filesystem, how long
+    to wait. Sharing it is what stops the two drivers drifting apart on the settings
+    that are about the deployment rather than about the pipeline.
+    """
+    workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
+    return KubernetesPodOperator(
+        task_id=task_id,
+        task_display_name=task_display_name,
+        name=name,
+        namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
+        service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
+        image=image,
+        image_pull_policy="IfNotPresent",
+        cmds=["/bin/bash", "-c"],
+        arguments=[script],
+        env_vars={
+            "NXF_WORKSPACE": workspace,
+            # ANSI progress redraws are unreadable once captured into a task log.
+            "NXF_ANSI_LOG": "false",
+            "POST_RUN_DRAIN_SECONDS": os.getenv("NEXTFLOW_OPERATOR_DRAIN_SECONDS", "30"),
+            # No AWS_* here, unlike the other operators: this pod has Pod Identity,
+            # and injecting empty credentials would break the chain.
+            #
+            # Callers add the per-run values, RUN_TAG among them. nextflow.config
+            # reads RUN_TAG via System.getenv too, for `workDir = /workspace/work/
+            # ${runTag}` -- so one tag stabilises both the work dir and the launch
+            # dir, which is what -resume needs.
+            **env_vars,
+        },
+        volumes=[
+            k8s.V1Volume(
+                name="workspace",
+                persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
+                    claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
+                ),
+            ),
+            k8s.V1Volume(
+                name="nextflow-cfg",
+                config_map=k8s.V1ConfigMapVolumeSource(name=config_configmap),
+            ),
+            k8s.V1Volume(
+                name="nextflow-params",
+                config_map=k8s.V1ConfigMapVolumeSource(name=params_configmap),
+            ),
+        ],
+        volume_mounts=[
+            k8s.V1VolumeMount(name="workspace", mount_path=workspace),
+            k8s.V1VolumeMount(name="nextflow-cfg", mount_path="/etc/nextflow", read_only=True),
+            k8s.V1VolumeMount(name="nextflow-params", mount_path="/etc/nextflow-params", read_only=True),
+        ],
+        # The nodepool is pinned to the FSx AZ; landing elsewhere means a cross-AZ
+        # Lustre mount. do-not-disrupt stops Karpenter consolidating the driver away.
+        node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
+        annotations={"karpenter.sh/do-not-disrupt": "true"},
+        container_resources=_nextflow_container_resources(),
+        get_logs=True,
+        # A WGS run takes hours, so the worker slot is released and the triggerer
+        # polls instead. Both run as the `airflow` SA, which needs RBAC in the
+        # `nextflow` namespace (see apps/nextflow/rbac.yaml in qlin-qa-infra).
+        deferrable=True,
+        poll_interval=float(os.getenv("NEXTFLOW_OPERATOR_POLL_INTERVAL", "30")),
+        # Without this a deferred pod's logs only surface once it finishes, so a
+        # multi-hour run looks silent in the UI.
+        logging_interval=int(os.getenv("NEXTFLOW_OPERATOR_LOGGING_INTERVAL", "600")),
+        # The provider default of 120s is short of a Karpenter cold start plus a
+        # multi-GB image pull on a fresh node.
+        startup_timeout_seconds=int(os.getenv("NEXTFLOW_OPERATOR_STARTUP_TIMEOUT_SECONDS", "1800")),
+        # Backstop: clearing a deferred task does not delete its pod, and a second
+        # driver against the same launch dir corrupts the resume cache.
+        active_deadline_seconds=int(os.getenv("NEXTFLOW_OPERATOR_ACTIVE_DEADLINE_SECONDS", "86400")),
+        # Keep a failed driver for inspection; clean up successful ones.
+        on_finish_action="delete_succeeded_pod",
+    )
+
+
+def _nextflow_cleanup_operator(run_tag: str, name: str, image: str | None) -> KubernetesPodOperator:
+    """Delete this run's Nextflow scratch after a successful pipeline.
+
+    A WGS run leaves ~200-280 GB in workDir plus the launch dir, and the
+    work-cleanup CronJob only sweeps launchdirs older than MAX_AGE_DAYS -- so
+    without this, a couple of runs fill the 1.2 TiB filesystem and the failure
+    surfaces as ENOSPC on whichever task happens to be writing.
+
+    Only ever wired downstream of a SUCCESSFUL run: the scratch is what `-resume`
+    needs, so deleting it after a failure would turn every Airflow retry into a
+    full re-run.
+
+    Shared by every Nextflow DAG. It deletes by RUN_TAG on a filesystem all of them
+    share, so keeping one copy keeps the `${RUN_TAG:?}` guard in one place too.
+    """
+    workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
+    return KubernetesPodOperator(
+        task_id="cleanup_work",
+        task_display_name="[K8s] Clean up Nextflow scratch",
+        name=name,
+        namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
+        service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
+        # Reuse the driver image: it is already cached on these nodes, so this
+        # adds no pull.
+        image=image,
+        image_pull_policy="IfNotPresent",
+        cmds=["/bin/bash", "-c"],
+        arguments=[_NEXTFLOW_CLEANUP_SCRIPT],
+        env_vars={"RUN_TAG": run_tag, "NXF_WORKSPACE": workspace},
+        volumes=[
+            k8s.V1Volume(
+                name="workspace",
+                persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
+                    claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
+                ),
+            ),
+        ],
+        volume_mounts=[k8s.V1VolumeMount(name="workspace", mount_path=workspace)],
+        node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
+        container_resources=_container_resources("NEXTFLOW_CLEANUP", cpu="500m", memory="512Mi", memory_limit="1Gi"),
+        get_logs=True,
+        deferrable=False,
+        on_finish_action="delete_succeeded_pod",
+    )
+
+
 class NextflowPostprocessing:
     """Runs the Ferlab Post-processing-Pipeline (VEP / slivar / Exomiser) as a
     Nextflow driver pod, which spawns its own worker pods via Nextflow's k8s executor.
-
-    Unlike every other operator here it runs in the `nextflow` namespace under the
-    `nextflow` service account -- that SA carries the Pod Identity for S3 and the RBAC
-    to spawn workers -- and it is the only one that mounts volumes.
     """
 
     @staticmethod
     def get_run_postprocessing(input_csv: str, outdir: str, run_tag: str) -> KubernetesPodOperator:
-        workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
-        return KubernetesPodOperator(
+        return _nextflow_driver_operator(
             task_id="run_postprocessing",
             task_display_name="[K8s] Run Nextflow Post-processing",
             name="nextflow-postprocessing-driver",
-            namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
-            service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
-            image=os.getenv("NEXTFLOW_OPERATOR_IMAGE"),
-            image_pull_policy="IfNotPresent",
-            cmds=["/bin/bash", "-c"],
-            arguments=[_NEXTFLOW_DRIVER_SCRIPT],
+            script=_NEXTFLOW_DRIVER_SCRIPT,
+            image=_nextflow_image("NEXTFLOW_OPERATOR_IMAGE"),
             env_vars={
-                # nextflow.config also reads RUN_TAG via System.getenv, for
-                # `workDir = /workspace/work/${runTag}` -- so one tag stabilises both
-                # the work dir and the launch dir, which is what -resume needs.
                 "RUN_TAG": run_tag,
                 "NXF_INPUT": input_csv,
                 "NXF_OUTDIR": outdir,
-                "NXF_WORKSPACE": workspace,
-                # ANSI progress redraws are unreadable once captured into a task log.
-                "NXF_ANSI_LOG": "false",
-                "POST_RUN_DRAIN_SECONDS": os.getenv("NEXTFLOW_OPERATOR_DRAIN_SECONDS", "30"),
-                # No AWS_* here, unlike the other operators: this pod has Pod Identity,
-                # and injecting empty credentials would break the chain.
             },
-            volumes=[
-                k8s.V1Volume(
-                    name="workspace",
-                    persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
-                        claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
-                    ),
-                ),
-                k8s.V1Volume(
-                    name="nextflow-cfg",
-                    config_map=k8s.V1ConfigMapVolumeSource(
-                        name=os.getenv("NEXTFLOW_OPERATOR_CONFIG_CONFIGMAP", "nextflow-cfg"),
-                    ),
-                ),
-                k8s.V1Volume(
-                    name="nextflow-params",
-                    config_map=k8s.V1ConfigMapVolumeSource(
-                        name=os.getenv("NEXTFLOW_OPERATOR_PARAMS_CONFIGMAP", "nextflow-params"),
-                    ),
-                ),
-            ],
-            volume_mounts=[
-                k8s.V1VolumeMount(name="workspace", mount_path=workspace),
-                k8s.V1VolumeMount(name="nextflow-cfg", mount_path="/etc/nextflow", read_only=True),
-                k8s.V1VolumeMount(name="nextflow-params", mount_path="/etc/nextflow-params", read_only=True),
-            ],
-            # The nodepool is pinned to the FSx AZ; landing elsewhere means a cross-AZ
-            # Lustre mount. do-not-disrupt stops Karpenter consolidating the driver away.
-            node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
-            annotations={"karpenter.sh/do-not-disrupt": "true"},
-            container_resources=_nextflow_container_resources(),
-            get_logs=True,
-            # A WGS run takes hours, so the worker slot is released and the triggerer
-            # polls instead. Both run as the `airflow` SA, which needs RBAC in the
-            # `nextflow` namespace (see apps/nextflow/rbac.yaml in qlin-qa-infra).
-            deferrable=True,
-            poll_interval=float(os.getenv("NEXTFLOW_OPERATOR_POLL_INTERVAL", "30")),
-            # Without this a deferred pod's logs only surface once it finishes, so a
-            # multi-hour run looks silent in the UI.
-            logging_interval=int(os.getenv("NEXTFLOW_OPERATOR_LOGGING_INTERVAL", "600")),
-            # The provider default of 120s is short of a Karpenter cold start plus a
-            # multi-GB image pull on a fresh node.
-            startup_timeout_seconds=int(os.getenv("NEXTFLOW_OPERATOR_STARTUP_TIMEOUT_SECONDS", "1800")),
-            # Backstop: clearing a deferred task does not delete its pod, and a second
-            # driver against the same launch dir corrupts the resume cache.
-            active_deadline_seconds=int(os.getenv("NEXTFLOW_OPERATOR_ACTIVE_DEADLINE_SECONDS", "86400")),
-            # Keep a failed driver for inspection; clean up successful ones.
-            on_finish_action="delete_succeeded_pod",
+            config_configmap=os.getenv("NEXTFLOW_OPERATOR_CONFIG_CONFIGMAP", "nextflow-cfg"),
+            params_configmap=os.getenv("NEXTFLOW_OPERATOR_PARAMS_CONFIGMAP", "nextflow-params"),
         )
 
     @staticmethod
     def get_cleanup_work(run_tag: str) -> KubernetesPodOperator:
-        """Delete this run's Nextflow scratch after a successful pipeline.
-
-        A WGS run leaves ~200-280 GB in workDir plus the launch dir, and the
-        work-cleanup CronJob only sweeps launchdirs older than MAX_AGE_DAYS -- so
-        without this, a couple of runs fill the 1.2 TiB filesystem and the failure
-        surfaces as ENOSPC on whichever task happens to be writing.
-
-        Only ever wired downstream of a SUCCESSFUL run: the scratch is what `-resume`
-        needs, so deleting it after a failure would turn every Airflow retry into a
-        full re-run.
-        """
-        workspace = os.getenv("NEXTFLOW_OPERATOR_WORKSPACE_PATH", "/workspace")
-        return KubernetesPodOperator(
-            task_id="cleanup_work",
-            task_display_name="[K8s] Clean up Nextflow scratch",
+        return _nextflow_cleanup_operator(
+            run_tag,
             name="nextflow-postprocessing-cleanup",
-            namespace=os.getenv("NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE", "nextflow"),
-            service_account_name=os.getenv("NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME", "nextflow"),
-            # Reuse the driver image: it is already cached on these nodes, so this
-            # adds no pull.
-            image=os.getenv("NEXTFLOW_OPERATOR_IMAGE"),
-            image_pull_policy="IfNotPresent",
-            cmds=["/bin/bash", "-c"],
-            arguments=[_NEXTFLOW_CLEANUP_SCRIPT],
-            env_vars={"RUN_TAG": run_tag, "NXF_WORKSPACE": workspace},
-            volumes=[
-                k8s.V1Volume(
-                    name="workspace",
-                    persistent_volume_claim=k8s.V1PersistentVolumeClaimVolumeSource(
-                        claim_name=os.getenv("NEXTFLOW_OPERATOR_PVC_NAME", "fsx-nextflow"),
-                    ),
-                ),
-            ],
-            volume_mounts=[k8s.V1VolumeMount(name="workspace", mount_path=workspace)],
-            node_selector={"nodepool": os.getenv("NEXTFLOW_OPERATOR_NODEPOOL", "qlin-nextflow")},
-            container_resources=_container_resources(
-                "NEXTFLOW_CLEANUP", cpu="500m", memory="512Mi", memory_limit="1Gi"
-            ),
-            get_logs=True,
-            deferrable=False,
-            on_finish_action="delete_succeeded_pod",
+            image=_nextflow_image("NEXTFLOW_OPERATOR_IMAGE"),
+        )
+
+
+class NextflowQualityControl:
+    """Runs the Ferlab quality-control-pipeline in its DRAGEN-metrics mode as a
+    Nextflow driver pod, which spawns its own worker pods via Nextflow's k8s executor.
+
+    It shares the driver image, the FSx workspace and the node pool with
+    `NextflowPostprocessing`, but not its configuration: the post-processing
+    `nextflow.config` references `params.save_genotyped` and `params.tools`, and a
+    param referenced from a `-c` config but absent from the `-params-file` kills the
+    run at config parse. Hence a separate ConfigMap pair.
+    """
+
+    @staticmethod
+    def get_run_quality_control(
+        input_csv: str, outdir: str, dragen_metrics_dir: str, run_tag: str
+    ) -> KubernetesPodOperator:
+        return _nextflow_driver_operator(
+            task_id="run_quality_control",
+            task_display_name="[K8s] Run Nextflow Quality Control",
+            name="nextflow-quality-control-driver",
+            script=_NEXTFLOW_QC_DRIVER_SCRIPT,
+            # Both pipelines are baked into one image, so the shared var is the norm.
+            # NEXTFLOW_QC_OPERATOR_IMAGE exists to pin QC to an ad-hoc build while a
+            # pipeline revision is being tested, without moving post-processing too.
+            image=_nextflow_image("NEXTFLOW_QC_OPERATOR_IMAGE", "NEXTFLOW_OPERATOR_IMAGE"),
+            env_vars={
+                "RUN_TAG": run_tag,
+                "NXF_INPUT": input_csv,
+                "NXF_OUTDIR": outdir,
+                "NXF_DRAGEN_METRICS_DIR": dragen_metrics_dir,
+            },
+            config_configmap=os.getenv("NEXTFLOW_QC_OPERATOR_CONFIG_CONFIGMAP", "nextflow-qc-cfg"),
+            params_configmap=os.getenv("NEXTFLOW_QC_OPERATOR_PARAMS_CONFIGMAP", "nextflow-qc-params"),
+        )
+
+    @staticmethod
+    def get_cleanup_work(run_tag: str) -> KubernetesPodOperator:
+        return _nextflow_cleanup_operator(
+            run_tag,
+            name="nextflow-quality-control-cleanup",
+            image=_nextflow_image("NEXTFLOW_QC_OPERATOR_IMAGE", "NEXTFLOW_OPERATOR_IMAGE"),
         )

--- a/tests/unit/dags/operators/k8s/test_nextflow_quality_control_k8s_operator.py
+++ b/tests/unit/dags/operators/k8s/test_nextflow_quality_control_k8s_operator.py
@@ -1,0 +1,201 @@
+import os
+from unittest.mock import patch
+
+from radiant.dags.operators.k8s import NextflowQualityControl
+
+
+def _build(env: dict):
+    with patch.dict(os.environ, env, clear=True):
+        return NextflowQualityControl.get_run_quality_control(
+            input_csv="/workspace/inputs/qc/samplesheet.csv",
+            outdir="/workspace/outputs/qlin/qc-run1",
+            dragen_metrics_dir="/workspace/inputs/qc/metrics",
+            run_tag="qc-manual__2026-08-20T14-30-00-00-00",
+        )
+
+
+def test_get_run_quality_control_with_env():
+    fake_env = {
+        "NEXTFLOW_OPERATOR_IMAGE": "my-registry/nextflow-launcher:test",
+        "NEXTFLOW_OPERATOR_KUBERNETES_NAMESPACE": "nf",
+        "NEXTFLOW_OPERATOR_SERVICE_ACCOUNT_NAME": "nf-sa",
+        "NEXTFLOW_OPERATOR_PVC_NAME": "fsx-test",
+        "NEXTFLOW_OPERATOR_NODEPOOL": "test-pool",
+        "NEXTFLOW_OPERATOR_WORKSPACE_PATH": "/ws",
+        "RADIANT_TASK_OPERATOR_NEXTFLOW_MEMORY": "8Gi",
+    }
+    op = _build(fake_env)
+
+    assert op.task_id == "run_quality_control"
+    assert op.namespace == "nf"
+    assert op.service_account_name == "nf-sa"
+    # Same driver image as post-processing: both pipelines are baked into it.
+    assert op.image == "my-registry/nextflow-launcher:test"
+
+    # Deferrable so a long run does not hold an Airflow worker slot.
+    assert op.deferrable is True
+    assert op.get_logs is True
+    assert op.node_selector == {"nodepool": "test-pool"}
+    assert op.annotations == {"karpenter.sh/do-not-disrupt": "true"}
+
+    # The env-var override path on the shared _container_resources helper.
+    assert op.container_resources.requests["memory"] == "8Gi"
+
+    volumes = {v.name: v for v in op.volumes}
+    assert set(volumes) == {"workspace", "nextflow-cfg", "nextflow-params"}
+    assert volumes["workspace"].persistent_volume_claim.claim_name == "fsx-test"
+
+    mounts = {m.name: m for m in op.volume_mounts}
+    assert mounts["workspace"].mount_path == "/ws"
+    # The mount paths are the same as post-processing's; only the ConfigMaps differ.
+    assert mounts["nextflow-cfg"].mount_path == "/etc/nextflow"
+    assert mounts["nextflow-cfg"].read_only is True
+    assert mounts["nextflow-params"].mount_path == "/etc/nextflow-params"
+    assert mounts["nextflow-params"].read_only is True
+
+    env = {e.name: e.value for e in op.env_vars}
+    assert env["NXF_INPUT"] == "/workspace/inputs/qc/samplesheet.csv"
+    assert env["NXF_OUTDIR"] == "/workspace/outputs/qlin/qc-run1"
+    assert env["NXF_DRAGEN_METRICS_DIR"] == "/workspace/inputs/qc/metrics"
+    assert env["RUN_TAG"] == "qc-manual__2026-08-20T14-30-00-00-00"
+    assert env["NXF_WORKSPACE"] == "/ws"
+    assert env["NXF_ANSI_LOG"] == "false"
+
+    # Pod Identity provides the credentials; injecting empty AWS_* would break the
+    # credential chain, so unlike the other operators none are set here.
+    assert not [name for name in env if name.startswith("AWS_")]
+
+
+def test_qc_uses_its_own_configmaps():
+    """The post-processing nextflow.config references params.save_genotyped and
+    params.tools; a param referenced from a `-c` config but absent from the
+    -params-file kills the run at config parse. Hence a separate pair."""
+    op = _build({})
+    volumes = {v.name: v for v in op.volumes}
+    assert volumes["nextflow-cfg"].config_map.name == "nextflow-qc-cfg"
+    assert volumes["nextflow-params"].config_map.name == "nextflow-qc-params"
+
+    overridden = _build(
+        {
+            "NEXTFLOW_QC_OPERATOR_CONFIG_CONFIGMAP": "qc-cfg-test",
+            "NEXTFLOW_QC_OPERATOR_PARAMS_CONFIGMAP": "qc-params-test",
+        }
+    )
+    volumes = {v.name: v for v in overridden.volumes}
+    assert volumes["nextflow-cfg"].config_map.name == "qc-cfg-test"
+    assert volumes["nextflow-params"].config_map.name == "qc-params-test"
+
+
+def test_get_run_quality_control_defaults_match_the_qa_topology():
+    """With nothing configured, the operator still targets the real deployment --
+    only the image has no sensible default."""
+    op = _build({})
+
+    assert op.namespace == "nextflow"
+    assert op.service_account_name == "nextflow"
+    assert op.node_selector == {"nodepool": "qlin-nextflow"}
+    assert op.volumes[0].persistent_volume_claim.claim_name == "fsx-nextflow"
+    assert op.volume_mounts[0].mount_path == "/workspace"
+    assert op.container_resources.requests == {"cpu": "1", "memory": "2Gi"}
+    assert op.container_resources.limits == {"memory": "4Gi"}
+
+    # A missing image must fail loudly at pod creation rather than silently pull
+    # something unintended.
+    assert op.image is None
+
+
+def test_startup_timeout_survives_a_karpenter_cold_start():
+    """The provider default is 120s, which a node launch plus a multi-GB image pull
+    exceeds -- the trigger would raise PodLaunchTimeoutException before the driver
+    ever starts."""
+    op = _build({})
+    assert op.startup_timeout_seconds == 1800
+    # Backstop for a cleared deferred task, whose pod is not deleted.
+    assert op.active_deadline_seconds == 86400
+
+
+def test_driver_script_is_jinja_safe_and_runs_the_qc_pipeline():
+    """cmds/arguments are templated fields: a stray {{ or {% in the launch script
+    would fail DAG parsing, and the failure would look nothing like its cause."""
+    (script,) = _build({}).arguments
+    assert "{{" not in script
+    assert "{%" not in script
+    # The cd is what makes -resume work: Nextflow reads .nextflow/cache from cwd.
+    assert 'cd "$LAUNCH"' in script
+    assert "-resume" in script
+    # The QC pipeline asset, not the post-processing one.
+    assert "assets/Ferlab-Ste-Justine/quality-control-pipeline" in script
+    assert "Post-processing-Pipeline" not in script
+    # Passing this flag is the whole point: it is what skips BAM_QC and VCF_QC.
+    assert '--dragen_metrics_dir "$NXF_DRAGEN_METRICS_DIR"' in script
+
+
+def _cleanup(env: dict):
+    with patch.dict(os.environ, env, clear=True):
+        return NextflowQualityControl.get_cleanup_work(run_tag="qc-manual__2026-08-20T14-30-00-00-00")
+
+
+def test_cleanup_targets_only_this_run():
+    op = _cleanup({"NEXTFLOW_OPERATOR_IMAGE": "img:test"})
+    assert op.task_id == "cleanup_work"
+    assert op.name == "nextflow-quality-control-cleanup"
+    assert op.namespace == "nextflow"
+    env = {e.name: e.value for e in op.env_vars}
+    assert env["RUN_TAG"] == "qc-manual__2026-08-20T14-30-00-00-00"
+    assert env["NXF_WORKSPACE"] == "/workspace"
+    # Not deferrable: it is a few seconds of rm, not a multi-hour wait.
+    assert op.deferrable is False
+    # Mounts the PVC so it can delete scratch, and nothing else.
+    assert [v.name for v in op.volumes] == ["workspace"]
+    assert op.volumes[0].persistent_volume_claim.claim_name == "fsx-nextflow"
+
+
+def test_qc_image_falls_back_to_the_shared_var():
+    """Both pipelines are baked into one image, so the shared var is the normal case."""
+    op = _build({"NEXTFLOW_OPERATOR_IMAGE": "shared:v1"})
+    assert op.image == "shared:v1"
+    assert _cleanup({"NEXTFLOW_OPERATOR_IMAGE": "shared:v1"}).image == "shared:v1"
+
+
+def test_qc_image_can_be_pinned_without_moving_postprocessing():
+    """NEXTFLOW_QC_OPERATOR_IMAGE exists to point QC at an ad-hoc build while a
+    pipeline revision is being tested. Post-processing must not follow it."""
+    from radiant.dags.operators.k8s import NextflowPostprocessing
+
+    env = {
+        "NEXTFLOW_OPERATOR_IMAGE": "shared:v1",
+        "NEXTFLOW_QC_OPERATOR_IMAGE": "poc-nextflow:qc-2.0.0",
+    }
+    assert _build(env).image == "poc-nextflow:qc-2.0.0"
+    # The cleanup pod must follow the driver, or it lands on a node that may not
+    # have the other image cached.
+    assert _cleanup(env).image == "poc-nextflow:qc-2.0.0"
+
+    with patch.dict(os.environ, env, clear=True):
+        assert (
+            NextflowPostprocessing.get_run_postprocessing(input_csv="/i.csv", outdir="", run_tag="t").image
+            == "shared:v1"
+        )
+
+
+def test_qc_image_is_none_when_nothing_is_set():
+    """A missing image must fail loudly at pod creation rather than silently pull."""
+    assert _build({}).image is None
+
+
+def test_driver_runs_the_pipeline_from_the_shared_filesystem():
+    """This pipeline ships nf-core module resource scripts (multiqc_report.py). Nextflow
+    puts them on PATH by exporting the *projectDir* path into the task wrapper, but the
+    task runs in the module's own container, which mounts only the workspace and has no
+    /opt/nextflow. Running from the image path makes MULTIQC_PYTHON die with
+    `multiqc_report.py: command not found`."""
+    (script,) = _build({}).arguments
+    # Staged under the workspace, keyed by the asset's commit so a rebuilt image with a
+    # new revision cannot silently reuse a stale copy.
+    assert 'PROJECT="${NXF_WORKSPACE}/pipelines/quality-control-pipeline-${REV}"' in script
+    assert 'REV="$(git -C "$SRC" rev-parse --short HEAD)"' in script
+    # And it is the staged copy that runs, never the image path.
+    assert 'nextflow run "$PROJECT"' in script
+    assert 'nextflow run "${NXF_HOME}' not in script
+    # Concurrent drivers on the same revision must not corrupt each other's copy.
+    assert 'mv -T "$TMP" "$PROJECT"' in script

--- a/tests/unit/dags/test_nextflow_quality_control.py
+++ b/tests/unit/dags/test_nextflow_quality_control.py
@@ -1,0 +1,69 @@
+import pytest
+from airflow.exceptions import ParamValidationError
+
+DAG_ID = "radiant-nextflow-quality-control"
+
+
+def test_dag_is_importable(dag_bag):
+    assert dag_bag.get_dag(DAG_ID) is not None
+    assert not dag_bag.import_errors
+
+
+def test_dag_contains_the_driver_and_cleanup_tasks(dag_bag):
+    dag = dag_bag.get_dag(DAG_ID)
+    assert set(dag.task_ids) == {"run_quality_control", "cleanup_work"}
+    assert dag.validate() is None
+
+
+def test_cleanup_only_runs_after_a_successful_pipeline(dag_bag):
+    """The scratch is what `-resume` reads. If cleanup ran after a failure, every
+    Airflow retry would become a full re-run."""
+    dag = dag_bag.get_dag(DAG_ID)
+    cleanup = dag.get_task("cleanup_work")
+    assert cleanup.trigger_rule == "all_success"
+    assert {t.task_id for t in cleanup.upstream_list} == {"run_quality_control"}
+
+
+def test_dag_exposes_exactly_the_three_per_run_values(dag_bag):
+    """Guards against param creep: everything run-invariant belongs in the
+    nextflow-qc-params ConfigMap, not here."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert set(dag.params) == {"input", "dragen_metrics_dir", "outdir"}
+
+
+def test_input_and_dragen_metrics_dir_are_required_and_outdir_is_not(dag_bag):
+    """dragen_metrics_dir is optional upstream but required here: it is what selects
+    DRAGEN-metrics mode, and omitting it would silently launch a full BAM_QC/VCF_QC
+    recompute instead of failing."""
+    dag = dag_bag.get_dag(DAG_ID)
+    # outdir defaults to empty, which the driver reads as "derive from the run tag".
+    assert dag.params["outdir"] == ""
+    with pytest.raises(ParamValidationError):
+        dag.params.validate()
+
+
+def test_retries_are_configured_so_resume_is_reachable(dag_bag):
+    """RUN_TAG is derived from run_id precisely so a retry re-enters the same
+    Nextflow launch dir. DEFAULT_ARGS carries only `owner` and Airflow defaults
+    retries to 0, so without an explicit override there would be no retry to
+    resume from and the whole mechanism would be dead code."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert dag.default_args["retries"] >= 1
+
+
+def test_only_one_driver_runs_at_a_time(dag_bag):
+    """Concurrent runs would share the same FSx workspace."""
+    dag = dag_bag.get_dag(DAG_ID)
+    assert dag.max_active_runs == 1
+
+
+def test_run_tag_is_namespaced_away_from_the_postprocessing_dag(dag_bag):
+    """RUN_TAG drives the Nextflow workDir, the launch dir and the default outdir,
+    but Airflow run ids are only unique *within* a DAG -- and this DAG can run
+    concurrently with radiant-nextflow-postprocessing. Sharing a launch dir is how a
+    resume cache gets corrupted, and either cleanup_work would delete the other's
+    scratch."""
+    dag = dag_bag.get_dag(DAG_ID)
+    for task_id in ("run_quality_control", "cleanup_work"):
+        env = {e.name: e.value for e in dag.get_task(task_id).env_vars}
+        assert env["RUN_TAG"].startswith("qc-")


### PR DESCRIPTION
## 📌 Context

Adds an Airflow DAG to run the Ferlab [quality-control-pipeline](https://github.com/Ferlab-Ste-Justine/quality-control-pipeline) v2.0.0 in its **DRAGEN-metrics** mode: samples already processed by DRAGEN, so the MultiQC report is built from DRAGEN's per-sample metric CSVs instead of recomputing them with BAM_QC / VCF_QC. Somalier still runs for pedigree validation.

Same shape as `radiant-nextflow-postprocessing` — one Airflow task launches a Nextflow driver pod that fans out worker pods via Nextflow's k8s executor.

The ConfigMaps (`nextflow-qc-cfg` / `nextflow-qc-params`), the `quay` ECR pull-through cache and the Airflow env vars land separately in `qlin-qa-infra`.

## 📝 Changes

- **New DAG** `radiant-nextflow-quality-control` with exactly three params: `input`, `dragen_metrics_dir`, `outdir`. Everything run-invariant lives in the `nextflow-qc-params` ConfigMap.
  - `dragen_metrics_dir` is **required** here though optional upstream: it is what selects DRAGEN-metrics mode, so omitting it would silently launch a full BAM_QC/VCF_QC recompute.
  - The run tag is prefixed `qc-`. `RUN_TAG` drives the Nextflow `workDir`, launch dir and default outdir, but Airflow run ids are only unique *within* a DAG — and this DAG can run concurrently with `radiant-nextflow-postprocessing`. Without the prefix the two could share a launch dir (corrupting the resume cache) and either `cleanup_work` could delete the other's scratch.
- **`k8s.py` refactor**: extracted `_nextflow_driver_operator` / `_nextflow_cleanup_operator` holding the pod topology shared by both pipelines; `NextflowPostprocessing` and the new `NextflowQualityControl` now both use them. Behaviour-preserving.
- **`NEXTFLOW_QC_OPERATOR_IMAGE`** (falls back to `NEXTFLOW_OPERATOR_IMAGE`) so QC can be pinned to an ad-hoc build without moving post-processing onto an unreleased image.
- **`Dockerfile.nextflow.launcher`** bakes the QC pipeline alongside post-processing, plus `nf-schema@2.3.0` next to `2.1.0` (each pipeline declares its own version). `-r v2.0.0` is load-bearing: the repo's manifest says `defaultBranch = 'master'` while the actual branch is `main`, so a bare `nextflow pull` resolves nothing. The plugin sanity check now verifies each plugin individually — the previous single `grep` passed when only one of two `nf-schema` versions was present.
- **The driver runs the pipeline from the shared filesystem**, not from the image. See notes below.

## ☑️ TO-DOs

- [x] `nextflow-qc-cfg` / `nextflow-qc-params` ConfigMaps in `qlin-qa-infra`
- [x] `quay` ECR pull-through cache rule + node IAM (all pipeline containers are `biocontainers/*`, which resolve against quay.io)
- [x] `somalier_sites` reference data uploaded
- [ ] Replace the hand-built `poc-nextflow:qc-2.0.0` image with a tagged `nextflow-launcher` release, then drop `NEXTFLOW_QC_OPERATOR_IMAGE`
- [ ] Full green run on the 1000genomes DRAGEN dataset

## 🧪 Tests

- `tests/unit/dags/test_nextflow_quality_control.py` — DAG shape, task graph, cleanup trigger rule, param-creep guard, required/optional params, retries, `max_active_runs`, and that the run tag is namespaced away from the post-processing DAG.
- `tests/unit/dags/operators/k8s/test_nextflow_quality_control_k8s_operator.py` — pod topology, QC-specific ConfigMaps, image override and fallback, Jinja-safety of the launch script, and that the pipeline is staged to the shared filesystem.
- The pre-existing `test_nextflow_postprocessing*` tests are unchanged and still pass — that is the check on the operator refactor.

```
make test-static && make test-unit   # 707 passed
```

Verified on qlin-eks beyond unit tests: the image builds amd64 with both pipeline assets at the right revisions and all three plugins; `nextflow -C <cfg> config` parses the QC config inside the real launcher image; and the `multiqc_report.py` fix was confirmed from inside the actual `biocontainers/multiqc` worker container.

## 🔗 Related Issues

<!-- Begin JIRA Issues -->
SJRA-1856
<!-- End JIRA Issues -->

## 👀 Notes for Reviewers

- **Why the pipeline is copied to the shared filesystem.** This pipeline ships nf-core module resource scripts (`modules/local/multiqc_python/resources/usr/bin/multiqc_report.py`). Nextflow puts them on a task's PATH by exporting the **projectDir** path into the task wrapper — but the task runs in the module's own container (`biocontainers/multiqc`), which mounts only `/workspace` and has no `/opt/nextflow`. Run from the image path, `MULTIQC_PYTHON` dies with `multiqc_report.py: command not found` (exit 127). Post-processing never hit this because it has no module resource scripts. The copy is keyed by the asset's git commit so a rebuilt image cannot silently reuse a stale one, and `mv -T` makes a concurrent driver on the same revision harmless. Consequence: the first run after a revision bump re-executes rather than resumes, since projectDir is part of every task hash.
- **A separate ConfigMap pair is required, not preferred.** The post-processing `nextflow.config` references `params.save_genotyped` and `params.tools`, and a param referenced from a `-c` config but absent from the `-params-file` kills the run at config parse. The two pipelines cannot share one config.
- **Upstream bug worth knowing.** `conf/modules/somalier.config` declares `withName: 'SOMALIER_*'`, but `withName` takes a regex, not a glob — `SOMALIER_*` means "SOMALIER followed by zero or more underscores" and matches neither `SOMALIER_EXTRACT` nor `SOMALIER_RELATE`. Their intended 0.3.0 override is dead code and the nf-core default 0.2.19 runs instead. `nextflow-qc-cfg` pins 0.2.19 explicitly so the version cannot silently jump the day upstream fixes the typo.
- No ECS branch: the driver needs the FSx PVC and the `nextflow` namespace, so this is K8s-only like the other Nextflow DAGs.
